### PR TITLE
pin the serial GMBE path to one thread, like every other one

### DIFF
--- a/src/fragmentation/gmbe/mqc_gmbe_fragment_distribution_scheme.f90
+++ b/src/fragmentation/gmbe/mqc_gmbe_fragment_distribution_scheme.f90
@@ -4,6 +4,7 @@ module mqc_gmbe_fragment_distribution_scheme
    !! Handles both serial and MPI-parallelized distribution of monomers and intersection fragments
    use pic_types, only: int32, int64, dp
    use pic_timer, only: timer_type
+   use omp_lib, only: omp_set_num_threads, omp_get_max_threads
    use mqc_calc_types, only: CALC_TYPE_GRADIENT
    use pic_mpi_lib, only: comm_t, send, recv, isend, irecv, &
                           wait, iprobe, MPI_Status, request_t, MPI_ANY_SOURCE, MPI_ANY_TAG, abort_comm
@@ -67,6 +68,7 @@ contains
       type(calculation_result_t), allocatable :: results(:)
       type(error_t) :: error
       integer :: n_atoms, max_atoms, iatom, current_log_level, hess_dim
+      integer :: outer_threads  !! Thread count to put back when the terms are done
       integer(int64) :: term_idx
       integer, allocatable :: atom_list(:)
       real(dp) :: total_energy, term_energy
@@ -111,6 +113,16 @@ contains
          allocate (term_dipole_derivs(3, hess_dim))
          total_dipole_derivs = 0.0_dp
       end if
+
+      ! One thread per term, as every MBE path already does. The methods
+      ! underneath are not safe to run threaded -- tblite's generalized
+      ! eigensolve fails on more than one thread, reproducibly, and it fails
+      ! by corrupting a result rather than by stopping. This was the last
+      ! route to fragment work that did not pin: the distributed GMBE workers
+      ! pin, the MBE processors pin, and this one did not, so serial GMBE was
+      ! the only way to reach a method with threads live.
+      outer_threads = omp_get_max_threads()
+      call omp_set_num_threads(1)
 
       do term_idx = 1_int64, n_pie_terms
          coeff = pie_coefficients(term_idx)
@@ -196,6 +208,12 @@ contains
          deallocate (atom_list)
          call phys_frag%destroy()
       end do
+
+      ! Saved and restored rather than set to omp_get_max_threads(), which is
+      ! what the MBE processor does and which cannot work: after
+      ! omp_set_num_threads(1), omp_get_max_threads() reports 1, so that
+      ! "restore" hands back the value it just clamped.
+      call omp_set_num_threads(outer_threads)
 
       call logger%info(" ")
       call logger%info("GMBE PIE calculation completed successfully")

--- a/src/fragmentation/mbe/mqc_serial_fragment_processor.f90
+++ b/src/fragmentation/mbe/mqc_serial_fragment_processor.f90
@@ -28,6 +28,7 @@ contains
       type(timer_type) :: coord_timer
       integer(int32) :: calc_type_local
       type(error_t) :: error
+      integer :: outer_threads
 
       calc_type_local = calc_type
 
@@ -36,6 +37,9 @@ contains
 
       allocate (results(total_fragments))
 
+      ! One thread per fragment: the methods underneath are not safe to run
+      ! threaded, and they fail by corrupting a result rather than by stopping.
+      outer_threads = omp_get_max_threads()
       call omp_set_num_threads(1)
       call coord_timer%start()
       do frag_idx = 1_int64, total_fragments
@@ -95,7 +99,10 @@ contains
       end do
       call coord_timer%stop()
       call logger%info("Time to evaluate all fragments "//to_char(coord_timer%get_elapsed_time())//" s")
-      call omp_set_num_threads(omp_get_max_threads())
+      ! Not omp_get_max_threads(): after omp_set_num_threads(1) that reports 1,
+      ! so the obvious spelling hands back the value it just clamped and the
+      ! rest of the process silently stays single-threaded.
+      call omp_set_num_threads(outer_threads)
 
       call logger%info("All fragments processed")
 


### PR DESCRIPTION
Serial GMBE was the last route to fragment work that ran threaded. The MBE
processors pin, the distributed GMBE workers pin, gmbe_run_serial did not --
so it was the only way to reach a method with threads live, and the methods
underneath are not safe that way.

It was not theoretical. overlapping_gly3 on this box:

  threaded, error ignored  Final GMBE energy:  15.140244820540
  pinned                   Final GMBE energy: -47.019271891995

The first is what the released code printed. A positive total energy for a
glycine trimer, 62 Hartree out, reported as a result with nothing anywhere
suggesting a problem. With yesterday's convergence check in place the same
run stops instead, naming the term: "PIE term 1 calculation failed: SCF not
converged in 300 cycles". Pinned, it converges and the answer is right.

The restore is written as save-and-put-back rather than
omp_set_num_threads(omp_get_max_threads()), which is what the MBE processor
had and which cannot work: after omp_set_num_threads(1), omp_get_max_threads()
reports 1, so that spelling hands back the value it just clamped and leaves
the process single-threaded for good. Fixed there too. Harmless in practice --
it clamped the safe direction -- but it meant the pin was permanent rather
than scoped, which is not what it looks like.

decane checked alongside gly3; both GMBE cases and prism unchanged at np 4.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
