### PR TITLE
let the release architecture flags be overridden

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -40,25 +40,25 @@ endif()
 
 # Architecture tuning, overridable.
 #
-# `-march=native` tunes for the machine doing the *build*, which on a cluster
-# is rarely the machine doing the running. Two ways that bites:
+# `-march=native` tunes for the machine doing the *build*, which on a cluster is
+# rarely the machine doing the running. Two ways that bites:
 #
-#   * A build node newer than the compute nodes produces a binary that dies
-#     with SIGILL on an instruction the compute node has never heard of.
-#   * A compiler newer than the assembler produces instructions the assembler
-#     has never heard of. On Gadi, `-march=native` on a Sapphire Rapids node
-#     enables AVX512-FP16, GCC then uses `vmovw` for ordinary 16-bit moves --
-#     in tblite's zip writer, whose headers are full of 2-byte fields -- and
-#     binutils older than 2.38 rejects it. The fix there is a newer binutils
-#     if the module exists, and this variable if it does not.
+# * A build node newer than the compute nodes produces a binary that dies with
+#   SIGILL on an instruction the compute node has never heard of.
+# * A compiler newer than the assembler produces instructions the assembler has
+#   never heard of. On Gadi, `-march=native` on a Sapphire Rapids node enables
+#   AVX512-FP16, GCC then uses `vmovw` for ordinary 16-bit moves -- in tblite's
+#   zip writer, whose headers are full of 2-byte fields -- and binutils older
+#   than 2.38 rejects it. The fix there is a newer binutils if the module
+#   exists, and this variable if it does not.
 #
-# Kept as the default because it is what this project has always done and it
-# is right for a workstation. Override for anything shared:
+# Kept as the default because it is what this project has always done and it is
+# right for a workstation. Override for anything shared:
 #
-#   -DMQC_ARCH_FLAGS=                       portable, no tuning
-#   -DMQC_ARCH_FLAGS=-march=x86-64-v3       AVX2, runs on anything since 2015
-#   -DMQC_ARCH_FLAGS="-march=native -mno-avx512fp16"   native minus the bit
-#                                                      the assembler lacks
+# -DMQC_ARCH_FLAGS=                       portable, no tuning
+# -DMQC_ARCH_FLAGS=-march=x86-64-v3       AVX2, runs on anything since 2015
+# -DMQC_ARCH_FLAGS="-march=native -mno-avx512fp16"   native minus the bit the
+# assembler lacks
 set(MQC_ARCH_FLAGS
     "DEFAULT"
     CACHE STRING "Architecture flags for Release builds; empty for portable")

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -38,6 +38,31 @@ endif()
 # coverage builds (GCC only typically)
 # =============================================================================
 
+# Architecture tuning, overridable.
+#
+# `-march=native` tunes for the machine doing the *build*, which on a cluster
+# is rarely the machine doing the running. Two ways that bites:
+#
+#   * A build node newer than the compute nodes produces a binary that dies
+#     with SIGILL on an instruction the compute node has never heard of.
+#   * A compiler newer than the assembler produces instructions the assembler
+#     has never heard of. On Gadi, `-march=native` on a Sapphire Rapids node
+#     enables AVX512-FP16, GCC then uses `vmovw` for ordinary 16-bit moves --
+#     in tblite's zip writer, whose headers are full of 2-byte fields -- and
+#     binutils older than 2.38 rejects it. The fix there is a newer binutils
+#     if the module exists, and this variable if it does not.
+#
+# Kept as the default because it is what this project has always done and it
+# is right for a workstation. Override for anything shared:
+#
+#   -DMQC_ARCH_FLAGS=                       portable, no tuning
+#   -DMQC_ARCH_FLAGS=-march=x86-64-v3       AVX2, runs on anything since 2015
+#   -DMQC_ARCH_FLAGS="-march=native -mno-avx512fp16"   native minus the bit
+#                                                      the assembler lacks
+set(MQC_ARCH_FLAGS
+    "DEFAULT"
+    CACHE STRING "Architecture flags for Release builds; empty for portable")
+
 if(CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
   set(FLAGS_STANDARD "-ffree-line-length-none -fbacktrace")
   set(FLAGS_DEBUG "-ffpe-trap=invalid,zero,overflow -fcheck=all")
@@ -91,6 +116,13 @@ set(CMAKE_Fortran_FLAGS
 set(CMAKE_Fortran_FLAGS_DEBUG
     "${CMAKE_Fortran_FLAGS_DEBUG} ${FLAGS_DEBUG}"
     PARENT_SCOPE)
+# An explicit MQC_ARCH_FLAGS replaces the per-compiler default, including when
+# it is set to the empty string -- which is how a portable build is asked for.
+if(NOT MQC_ARCH_FLAGS STREQUAL "DEFAULT")
+  set(FLAGS_RELEASE "${MQC_ARCH_FLAGS}")
+  message(STATUS "Architecture flags overridden: '${MQC_ARCH_FLAGS}'")
+endif()
+
 set(CMAKE_Fortran_FLAGS_RELEASE
     "${CMAKE_Fortran_FLAGS_RELEASE} ${FLAGS_RELEASE}"
     PARENT_SCOPE)


### PR DESCRIPTION
-march=native has been the gfortran Release default since the flags were
written, with no way to change it short of editing cmake/CMakeLists.txt. On
Gadi that is now a build failure:

  Assembler messages: no such instruction: `vmovw %eax,%xmm0'

Nothing in the repository changed to cause it, which is what makes it
confusing to chase. -march=native is not a fixed target: gcc expands it
against whichever CPU is running the compiler, and emits whatever that CPU
advertises. A node new enough to report AVX512-FP16 gets vmovw, which needs
binutils 2.38 or later to assemble. Pair a recent compiler module with the
system assembler and gcc generates an instruction its own toolchain rejects.

Split configure and build across node types -- which Gadi forces, since the
compute nodes have no outbound network and FetchContent has to run on a login
node -- and the flag is resolved on a different machine than the one it was
configured on. The two failure directions are not symmetric: building on the
newer node fails to assemble, building on the older one produces a binary that
can SIGILL on the nodes it was meant for. Neither is visible from the deck.

So the default is kept and an override is added:

  cmake -B build                                        -O3 -march=native
  cmake -B build -DMQC_ARCH_FLAGS=                      -O3
  cmake -B build -DMQC_ARCH_FLAGS=-march=x86-64-v3      -O3 -march=x86-64-v3

The empty string is a meaningful value here -- it is how a portable build is
asked for -- so it cannot double as "unset". Hence the DEFAULT sentinel rather
than testing whether the variable is empty.

Both branches of that conditional were checked by configuring and reading
CMakeFiles/metalquicha.dir/flags.make rather than the cache, since the cache
records what was requested and not what the compiler is handed. Omitted gives
-O3 -march=native, byte for byte what it gave before; empty drops the arch
flag and keeps -O3. A two-word value survives intact, FLAGS_RELEASE being
concatenated into a flag string rather than a list.

This does not change any existing build. It only makes the one that is
currently broken expressible.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
