### PR TITLE
read effective core potentials from the BSE basis files

### DIFF
--- a/src/basis/CMakeLists.txt
+++ b/src/basis/CMakeLists.txt
@@ -1,6 +1,8 @@
 target_sources(
-  ${main_lib} PRIVATE mqc_basis_utils.F90 mqc_cgto.f90
-                      mqc_json_basis_reader.f90 mqc_basis_normalization.f90)
+  ${main_lib}
+  PRIVATE mqc_basis_utils.F90 mqc_cgto.f90 mqc_ecp.f90
+          mqc_json_basis_reader.f90 mqc_json_ecp_reader.f90
+          mqc_basis_normalization.f90)
 
 # Where find_basis_file falls back to when neither $MQC_BASIS_PATH nor
 # ./basis_sets has the file -- the tree this build was configured from, which is

--- a/src/basis/mqc_ecp.f90
+++ b/src/basis/mqc_ecp.f90
@@ -1,0 +1,186 @@
+!! Effective core potential data structures
+module mqc_ecp
+   !! Holds an effective core potential in the semi-local form every code and
+   !! every tabulation uses:
+   !!
+   !!     U(r) = U_L(r) + sum_{l=0}^{L-1} [ U_l(r) - U_L(r) ] P_l
+   !!
+   !! `U_L` is the **local** channel, the one with the highest angular
+   !! momentum; the lower `U_l` act only on their own angular momentum through
+   !! the projector `P_l`. Each channel is a sum of primitives
+   !!
+   !!     U_l(r) = sum_k d_k r^(n_k - 2) exp(-z_k r^2)
+   !!
+   !! so a channel is three parallel arrays: radial powers, coefficients and
+   !! exponents. The `-2` in the exponent is a convention difference between
+   !! tabulations; the powers here are stored exactly as the source file gives
+   !! them, and it is the consumer's business to know which convention its
+   !! library wants.
+   !!
+   !! The number an ECP is really defined by is `core_electrons` -- how many
+   !! electrons it stands in for. Everything downstream has to agree on it: the
+   !! atom contributes `Z - core_electrons` electrons to the SCF, screens the
+   !! nucleus to the same effective charge, and repels other nuclei with it.
+   !! Those three are separate pieces of code and none of them will complain if
+   !! one is missed.
+   use pic_types, only: dp
+   implicit none
+   private
+
+   public :: ecp_shell_type      !! One angular-momentum channel
+   public :: atomic_ecp_type     !! The whole potential for one atom
+   public :: molecular_ecp_type  !! One entry per atom in a molecule
+
+   type :: ecp_shell_type
+      !! One channel of a semi-local ECP
+      integer :: ang_mom = -1
+         !! The l this channel projects onto; the local channel carries the
+         !! highest l in the potential and is not projected at all
+      integer :: nprim = 0
+      integer, allocatable :: radial_powers(:)  !! r exponents, as tabulated
+      real(dp), allocatable :: exponents(:)     !! Gaussian exponents
+      real(dp), allocatable :: coefficients(:)
+   contains
+      procedure :: allocate_arrays => ecp_shell_allocate
+      procedure :: destroy => ecp_shell_destroy
+   end type ecp_shell_type
+
+   type :: atomic_ecp_type
+      !! The effective core potential for one atom
+      character(len=:), allocatable :: element
+      integer :: core_electrons = 0
+         !! Electrons this potential replaces. Zero, with `has_ecp` false, for
+         !! a light atom carrying no ECP.
+      logical :: has_ecp = .false.
+      type(ecp_shell_type) :: local
+         !! U_L, the highest angular momentum channel
+      type(ecp_shell_type), allocatable :: projected(:)
+         !! U_0 .. U_(L-1), each acting through its own projector
+      integer :: n_projected = 0
+   contains
+      procedure :: allocate_projected => atomic_ecp_allocate
+      procedure :: destroy => atomic_ecp_destroy
+   end type atomic_ecp_type
+
+   type :: molecular_ecp_type
+      !! One entry per atom, parallel to `molecular_basis_type%elements`
+      !!
+      !! Indexed by atom rather than by element so an entry lines up with the
+      !! atom index everything else uses -- coordinates, nuclear charges, and
+      !! the active-atom list an ECP integral plan is built from. Atoms without
+      !! an ECP get an entry with `has_ecp` false rather than being skipped, so
+      !! the indexing never has to be translated.
+      type(atomic_ecp_type), allocatable :: atoms(:)
+      integer :: natoms = 0
+      integer :: n_ecp_atoms = 0
+         !! How many of them actually carry a potential
+   contains
+      procedure :: allocate_atoms => molecular_ecp_allocate
+      procedure :: destroy => molecular_ecp_destroy
+      procedure :: core_electrons => molecular_ecp_core_electrons
+      procedure :: any_ecp => molecular_ecp_any
+   end type molecular_ecp_type
+
+contains
+
+   subroutine ecp_shell_allocate(this, nprim)
+      !! Size one channel for `nprim` primitives
+      class(ecp_shell_type), intent(inout) :: this
+      integer, intent(in) :: nprim
+
+      call this%destroy()
+      this%nprim = nprim
+      allocate (this%radial_powers(nprim))
+      allocate (this%exponents(nprim))
+      allocate (this%coefficients(nprim))
+      this%radial_powers = 0
+      this%exponents = 0.0_dp
+      this%coefficients = 0.0_dp
+   end subroutine ecp_shell_allocate
+
+   subroutine ecp_shell_destroy(this)
+      class(ecp_shell_type), intent(inout) :: this
+
+      if (allocated(this%radial_powers)) deallocate (this%radial_powers)
+      if (allocated(this%exponents)) deallocate (this%exponents)
+      if (allocated(this%coefficients)) deallocate (this%coefficients)
+      this%nprim = 0
+      this%ang_mom = -1
+   end subroutine ecp_shell_destroy
+
+   subroutine atomic_ecp_allocate(this, n_projected)
+      !! Size the projected channels
+      class(atomic_ecp_type), intent(inout) :: this
+      integer, intent(in) :: n_projected
+
+      if (allocated(this%projected)) deallocate (this%projected)
+      this%n_projected = n_projected
+      if (n_projected > 0) allocate (this%projected(n_projected))
+   end subroutine atomic_ecp_allocate
+
+   subroutine atomic_ecp_destroy(this)
+      class(atomic_ecp_type), intent(inout) :: this
+      integer :: i
+
+      if (allocated(this%element)) deallocate (this%element)
+      call this%local%destroy()
+      if (allocated(this%projected)) then
+         do i = 1, size(this%projected)
+            call this%projected(i)%destroy()
+         end do
+         deallocate (this%projected)
+      end if
+      this%n_projected = 0
+      this%core_electrons = 0
+      this%has_ecp = .false.
+   end subroutine atomic_ecp_destroy
+
+   subroutine molecular_ecp_allocate(this, natoms)
+      !! One entry per atom, all of them empty until filled
+      class(molecular_ecp_type), intent(inout) :: this
+      integer, intent(in) :: natoms
+
+      call this%destroy()
+      this%natoms = natoms
+      if (natoms > 0) allocate (this%atoms(natoms))
+   end subroutine molecular_ecp_allocate
+
+   subroutine molecular_ecp_destroy(this)
+      class(molecular_ecp_type), intent(inout) :: this
+      integer :: i
+
+      if (allocated(this%atoms)) then
+         do i = 1, size(this%atoms)
+            call this%atoms(i)%destroy()
+         end do
+         deallocate (this%atoms)
+      end if
+      this%natoms = 0
+      this%n_ecp_atoms = 0
+   end subroutine molecular_ecp_destroy
+
+   pure function molecular_ecp_core_electrons(this) result(total)
+      !! Electrons replaced across the whole molecule
+      !!
+      !! This is what the SCF's electron count has to drop by, and it is a sum
+      !! over ATOMS -- two rubidiums replace 56 electrons, not 28.
+      class(molecular_ecp_type), intent(in) :: this
+      integer :: total
+      integer :: iatom
+
+      total = 0
+      if (.not. allocated(this%atoms)) return
+      do iatom = 1, this%natoms
+         if (this%atoms(iatom)%has_ecp) total = total + this%atoms(iatom)%core_electrons
+      end do
+   end function molecular_ecp_core_electrons
+
+   pure function molecular_ecp_any(this) result(any_present)
+      !! Whether any atom carries a potential at all
+      class(molecular_ecp_type), intent(in) :: this
+      logical :: any_present
+
+      any_present = (this%n_ecp_atoms > 0)
+   end function molecular_ecp_any
+
+end module mqc_ecp

--- a/src/basis/mqc_json_ecp_reader.f90
+++ b/src/basis/mqc_json_ecp_reader.f90
@@ -1,0 +1,343 @@
+!! Reader for Basis Set Exchange JSON effective core potentials
+module mqc_json_ecp_reader
+   !! Parses the `ecp_potentials` blocks the
+   !! [Basis Set Exchange](https://www.basissetexchange.org) ships alongside
+   !! orbital basis sets, producing the `mqc_ecp` types.
+   !!
+   !! The BSE layout for one element is
+   !!
+   !!     "ecp_electrons": 28,
+   !!     "ecp_potentials": [
+   !!       { "angular_momentum": [3], "r_exponents": [2],
+   !!         "gaussian_exponents": ["3.8431140"],
+   !!         "coefficients": [["-12.3169000"]] },
+   !!       { "angular_momentum": [0], ... }
+   !!     ]
+   !!
+   !! **The local channel is the one with the highest angular momentum**, not
+   !! the one listed first. For every def2 element those happen to coincide --
+   !! the order is 3, 0, 1, 2 -- but the physics is defined by the angular
+   !! momentum, so that is what this selects on. A tabulation that listed its
+   !! channels in ascending order would otherwise silently produce a potential
+   !! with the local and projected parts exchanged, which is a wrong answer
+   !! rather than an error.
+   !!
+   !! Exponents and coefficients are stored as strings to preserve every digit,
+   !! exactly as in the orbital basis files, and are read back with
+   !! list-directed input.
+   !!
+   !! Not every element in a file has an ECP, and not every basis set has an
+   !! ECP file at all. Both are ordinary: a missing element yields an entry
+   !! with `has_ecp` false rather than an error, so a molecule of light atoms
+   !! and heavy ones needs no special casing.
+   use pic_types, only: dp
+   use mqc_ecp, only: ecp_shell_type, atomic_ecp_type, molecular_ecp_type
+   use mqc_elements, only: element_symbol_to_number
+   use mqc_error, only: error_t, ERROR_IO, ERROR_PARSE
+   use json_module, only: json_file
+   implicit none
+   private
+
+   public :: read_json_ecp_element    !! Parse one element's ECP from a BSE file
+   public :: build_molecular_ecp_json  !! Build a per-atom ECP set for a molecule
+
+contains
+
+   pure function integer_to_key(value) result(key)
+      !! An integer as the string BSE keys its elements by
+      integer, intent(in) :: value
+      character(len=:), allocatable :: key
+      character(len=12) :: buffer
+
+      write (buffer, "(I0)") value
+      key = trim(buffer)
+   end function integer_to_key
+
+   subroutine read_json_ecp_element(json_path, element_symbol, atom_ecp, error)
+      !! Parse the ECP for one element, if the file defines one
+      !!
+      !! An element the file does not carry is not an error: `atom_ecp` comes
+      !! back with `has_ecp` false.
+      character(len=*), intent(in) :: json_path
+      character(len=*), intent(in) :: element_symbol
+      type(atomic_ecp_type), intent(out) :: atom_ecp
+      type(error_t), intent(out) :: error
+
+      type(json_file) :: json
+      character(len=:), allocatable :: element_key, base_path
+      integer :: atomic_number, n_potentials, ipot, local_index, iproj
+      integer, allocatable :: channel_l(:)
+      logical :: found, file_exists
+
+      atom_ecp%element = trim(adjustl(element_symbol))
+
+      inquire (file=json_path, exist=file_exists)
+      if (.not. file_exists) then
+         call error%set(ERROR_IO, "JSON ECP file not found: "//trim(json_path))
+         return
+      end if
+
+      atomic_number = element_symbol_to_number(trim(adjustl(element_symbol)))
+      if (atomic_number <= 0) then
+         call error%set(ERROR_PARSE, "Unrecognized element symbol: "//trim(element_symbol))
+         return
+      end if
+      element_key = integer_to_key(atomic_number)
+
+      call json%initialize()
+      call json%load(filename=json_path)
+      if (json%failed()) then
+         call error%set(ERROR_PARSE, "Could not parse JSON ECP file: "//trim(json_path))
+         call json%destroy()
+         return
+      end if
+
+      base_path = "elements."//element_key
+      call json%info(base_path//".ecp_potentials", found=found, n_children=n_potentials)
+      if (.not. found .or. n_potentials <= 0) then
+         ! A light element in a file that only covers the heavy ones.
+         call json%destroy()
+         return
+      end if
+
+      call json%get(base_path//".ecp_electrons", atom_ecp%core_electrons, found)
+      if (.not. found) then
+         call error%set(ERROR_PARSE, "Element "//trim(element_symbol)// &
+                        " has ecp_potentials but no ecp_electrons in "//trim(json_path))
+         call json%destroy()
+         return
+      end if
+
+      ! ---- which channel is local? -----------------------------------------
+      allocate (channel_l(n_potentials))
+      do ipot = 1, n_potentials
+         call channel_angular_momentum(json, base_path, ipot, channel_l(ipot), found)
+         if (.not. found) then
+            call error%set(ERROR_PARSE, "ECP channel without angular_momentum for "// &
+                           trim(element_symbol)//" in "//trim(json_path))
+            deallocate (channel_l)
+            call json%destroy()
+            return
+         end if
+      end do
+      local_index = maxloc(channel_l, dim=1)
+
+      call atom_ecp%allocate_projected(n_potentials - 1)
+      call read_channel(json, base_path, local_index, channel_l(local_index), &
+                        atom_ecp%local, json_path, error)
+      if (error%has_error()) then
+         deallocate (channel_l)
+         call json%destroy()
+         return
+      end if
+
+      iproj = 0
+      do ipot = 1, n_potentials
+         if (ipot == local_index) cycle
+         iproj = iproj + 1
+         call read_channel(json, base_path, ipot, channel_l(ipot), &
+                           atom_ecp%projected(iproj), json_path, error)
+         if (error%has_error()) then
+            deallocate (channel_l)
+            call json%destroy()
+            return
+         end if
+      end do
+
+      deallocate (channel_l)
+      atom_ecp%has_ecp = .true.
+      call json%destroy()
+   end subroutine read_json_ecp_element
+
+   subroutine channel_angular_momentum(json, base_path, ipot, ang_mom, found)
+      !! The single angular momentum one ECP channel carries
+      type(json_file), intent(inout) :: json
+      character(len=*), intent(in) :: base_path
+      integer, intent(in) :: ipot
+      integer, intent(out) :: ang_mom
+      logical, intent(out) :: found
+
+      integer, allocatable :: momenta(:)
+
+      ang_mom = -1
+      call json%get(base_path//".ecp_potentials("//integer_to_key(ipot)// &
+                    ").angular_momentum", momenta, found)
+      if (.not. found .or. .not. allocated(momenta)) then
+         found = .false.
+         return
+      end if
+      ! Unlike an orbital shell, an ECP channel carries exactly one l.
+      if (size(momenta) < 1) then
+         found = .false.
+         return
+      end if
+      ang_mom = momenta(1)
+   end subroutine channel_angular_momentum
+
+   subroutine read_channel(json, base_path, ipot, ang_mom, shell, json_path, error)
+      !! Read one channel's primitives
+      type(json_file), intent(inout) :: json
+      character(len=*), intent(in) :: base_path
+      integer, intent(in) :: ipot, ang_mom
+      type(ecp_shell_type), intent(inout) :: shell
+      character(len=*), intent(in) :: json_path
+      type(error_t), intent(out) :: error
+
+      character(len=:), allocatable :: path, value_text
+      integer, allocatable :: powers(:)
+      integer :: nprim, iprim, read_status
+      real(dp) :: value
+      logical :: found
+
+      path = base_path//".ecp_potentials("//integer_to_key(ipot)//")"
+
+      call json%get(path//".r_exponents", powers, found)
+      if (.not. found .or. .not. allocated(powers)) then
+         call error%set(ERROR_PARSE, "ECP channel without r_exponents in "//trim(json_path))
+         return
+      end if
+      nprim = size(powers)
+
+      call json%info(path//".gaussian_exponents", found=found, n_children=iprim)
+      if (.not. found .or. iprim /= nprim) then
+         call error%set(ERROR_PARSE, "ECP channel with mismatched exponent count in "// &
+                        trim(json_path))
+         return
+      end if
+
+      call shell%allocate_arrays(nprim)
+      shell%ang_mom = ang_mom
+      shell%radial_powers = powers
+
+      do iprim = 1, nprim
+         call json%get(path//".gaussian_exponents("//integer_to_key(iprim)//")", &
+                       value_text, found)
+         if (.not. found) then
+            call error%set(ERROR_PARSE, "Missing ECP exponent in "//trim(json_path))
+            return
+         end if
+         read (value_text, *, iostat=read_status) value
+         if (read_status /= 0) then
+            call error%set(ERROR_PARSE, "Malformed ECP exponent '"//trim(value_text)// &
+                           "' in "//trim(json_path))
+            return
+         end if
+         shell%exponents(iprim) = value
+
+         ! Coefficients are nested one level deeper: a channel has a single
+         ! coefficient set, stored as a list of lists to match the orbital
+         ! shells, which can have several.
+         call json%get(path//".coefficients(1)("//integer_to_key(iprim)//")", &
+                       value_text, found)
+         if (.not. found) then
+            call error%set(ERROR_PARSE, "Missing ECP coefficient in "//trim(json_path))
+            return
+         end if
+         read (value_text, *, iostat=read_status) value
+         if (read_status /= 0) then
+            call error%set(ERROR_PARSE, "Malformed ECP coefficient '"//trim(value_text)// &
+                           "' in "//trim(json_path))
+            return
+         end if
+         shell%coefficients(iprim) = value
+      end do
+   end subroutine read_channel
+
+   subroutine build_molecular_ecp_json(json_path, element_symbols, mol_ecp, error)
+      !! Build a per-atom ECP set for a list of atoms
+      !!
+      !! Each distinct element is read once and copied to every atom of that
+      !! element, as the orbital basis reader does -- parsing the same file per
+      !! atom would dominate the setup for anything but a tiny molecule.
+      character(len=*), intent(in) :: json_path
+      character(len=*), intent(in) :: element_symbols(:)
+      type(molecular_ecp_type), intent(out) :: mol_ecp
+      type(error_t), intent(out) :: error
+
+      type(atomic_ecp_type), allocatable :: unique_ecps(:)
+      integer, allocatable :: unique_z(:)
+      integer :: n_atoms, n_unique, iatom, iunique, match, z
+      logical :: is_new
+
+      n_atoms = size(element_symbols)
+      call mol_ecp%allocate_atoms(n_atoms)
+      if (n_atoms == 0) return
+
+      allocate (unique_z(n_atoms), unique_ecps(n_atoms))
+
+      n_unique = 0
+      do iatom = 1, n_atoms
+         z = element_symbol_to_number(trim(adjustl(element_symbols(iatom))))
+         is_new = .true.
+         do iunique = 1, n_unique
+            if (unique_z(iunique) == z) then
+               is_new = .false.
+               exit
+            end if
+         end do
+         if (is_new) then
+            n_unique = n_unique + 1
+            unique_z(n_unique) = z
+            call read_json_ecp_element(json_path, element_symbols(iatom), &
+                                       unique_ecps(n_unique), error)
+            if (error%has_error()) then
+               call error%add_context("mqc_json_ecp_reader:build_molecular_ecp_json")
+               deallocate (unique_ecps, unique_z)
+               return
+            end if
+         end if
+      end do
+
+      mol_ecp%n_ecp_atoms = 0
+      do iatom = 1, n_atoms
+         z = element_symbol_to_number(trim(adjustl(element_symbols(iatom))))
+         match = 1
+         do iunique = 1, n_unique
+            if (unique_z(iunique) == z) then
+               match = iunique
+               exit
+            end if
+         end do
+         call copy_atomic_ecp(unique_ecps(match), mol_ecp%atoms(iatom))
+         if (mol_ecp%atoms(iatom)%has_ecp) mol_ecp%n_ecp_atoms = mol_ecp%n_ecp_atoms + 1
+      end do
+
+      do iunique = 1, n_unique
+         call unique_ecps(iunique)%destroy()
+      end do
+      deallocate (unique_ecps, unique_z)
+   end subroutine build_molecular_ecp_json
+
+   subroutine copy_atomic_ecp(source, dest)
+      !! Deep copy of one atom's ECP
+      type(atomic_ecp_type), intent(in) :: source
+      type(atomic_ecp_type), intent(out) :: dest
+
+      integer :: i
+
+      if (allocated(source%element)) dest%element = source%element
+      dest%core_electrons = source%core_electrons
+      dest%has_ecp = source%has_ecp
+      if (.not. source%has_ecp) return
+
+      call copy_ecp_shell(source%local, dest%local)
+      call dest%allocate_projected(source%n_projected)
+      do i = 1, source%n_projected
+         call copy_ecp_shell(source%projected(i), dest%projected(i))
+      end do
+   end subroutine copy_atomic_ecp
+
+   subroutine copy_ecp_shell(source, dest)
+      !! Deep copy of one channel
+      type(ecp_shell_type), intent(in) :: source
+      type(ecp_shell_type), intent(out) :: dest
+
+      dest%ang_mom = source%ang_mom
+      if (source%nprim <= 0) return
+      call dest%allocate_arrays(source%nprim)
+      dest%radial_powers = source%radial_powers
+      dest%exponents = source%exponents
+      dest%coefficients = source%coefficients
+   end subroutine copy_ecp_shell
+
+end module mqc_json_ecp_reader

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -42,6 +42,7 @@ addtest(mqc_config_roundtrip)
 addtest(mqc_json_config)
 addtest(mqc_json_reader)
 addtest(mqc_json_schema)
+addtest(mqc_ecp_reader)
 
 # Parses basis_sets/*.json, which mqc_extract_basis_sets() unpacks from the BSE
 # bundle. Only the CMake build does that, so the test compiles to a skip stub

--- a/test/test_mqc_ecp_reader.f90
+++ b/test/test_mqc_ecp_reader.f90
@@ -45,7 +45,7 @@ contains
       type(error_t) :: read_error
 
       call read_json_ecp_element(ECP_FILE, "Rb", ecp, read_error)
-      call check(error, .not. read_error%has_error(), read_error%get_message())
+      call check(error,.not. read_error%has_error(), read_error%get_message())
       if (allocated(error)) return
 
       call check(error, ecp%has_ecp, "Rb should carry an ECP")
@@ -100,7 +100,7 @@ contains
       symbols = ["Rb", "Ag", "Au", "Rn"]
       do isym = 1, size(symbols)
          call read_json_ecp_element(ECP_FILE, trim(symbols(isym)), ecp, read_error)
-         call check(error, .not. read_error%has_error(), read_error%get_message())
+         call check(error,.not. read_error%has_error(), read_error%get_message())
          if (allocated(error)) return
          call check(error, ecp%has_ecp, trim(symbols(isym))//" should carry an ECP")
          if (allocated(error)) return
@@ -121,7 +121,7 @@ contains
       type(error_t) :: read_error
 
       call read_json_ecp_element(ECP_FILE, "Au", ecp, read_error)
-      call check(error, .not. read_error%has_error(), read_error%get_message())
+      call check(error,.not. read_error%has_error(), read_error%get_message())
       if (allocated(error)) return
       call check(error, ecp%core_electrons, 60, "Au ECP replaces 60 electrons")
       if (allocated(error)) return
@@ -139,11 +139,11 @@ contains
       type(error_t) :: read_error
 
       call read_json_ecp_element(ECP_FILE, "O", ecp, read_error)
-      call check(error, .not. read_error%has_error(), &
+      call check(error,.not. read_error%has_error(), &
                  "an element without an ECP should not be an error: "// &
                  read_error%get_message())
       if (allocated(error)) return
-      call check(error, .not. ecp%has_ecp, "oxygen should carry no ECP")
+      call check(error,.not. ecp%has_ecp, "oxygen should carry no ECP")
       if (allocated(error)) return
       call check(error, ecp%core_electrons, 0, "an absent ECP replaces no electrons")
 
@@ -160,7 +160,7 @@ contains
       ! Au-O-Au-H: heavy, light, heavy again, light.
       symbols = ["Au", "O ", "Au", "H "]
       call build_molecular_ecp_json(ECP_FILE, symbols, mol_ecp, read_error)
-      call check(error, .not. read_error%has_error(), read_error%get_message())
+      call check(error,.not. read_error%has_error(), read_error%get_message())
       if (allocated(error)) return
 
       call check(error, mol_ecp%natoms, 4, "one entry per atom")
@@ -172,11 +172,11 @@ contains
       ! downstream indexes coordinates and charges the same way.
       call check(error, mol_ecp%atoms(1)%has_ecp, "atom 1 (Au) should carry an ECP")
       if (allocated(error)) return
-      call check(error, .not. mol_ecp%atoms(2)%has_ecp, "atom 2 (O) should not")
+      call check(error,.not. mol_ecp%atoms(2)%has_ecp, "atom 2 (O) should not")
       if (allocated(error)) return
       call check(error, mol_ecp%atoms(3)%has_ecp, "atom 3 (Au) should carry an ECP")
       if (allocated(error)) return
-      call check(error, .not. mol_ecp%atoms(4)%has_ecp, "atom 4 (H) should not")
+      call check(error,.not. mol_ecp%atoms(4)%has_ecp, "atom 4 (H) should not")
       if (allocated(error)) return
 
       ! The repeated element must be a real copy, not a shared or empty one.
@@ -202,7 +202,7 @@ contains
 
       symbols = ["Au", "Au", "O "]
       call build_molecular_ecp_json(ECP_FILE, symbols, mol_ecp, read_error)
-      call check(error, .not. read_error%has_error(), read_error%get_message())
+      call check(error,.not. read_error%has_error(), read_error%get_message())
       if (allocated(error)) return
 
       call check(error, mol_ecp%core_electrons(), 120, &

--- a/test/test_mqc_ecp_reader.f90
+++ b/test/test_mqc_ecp_reader.f90
@@ -1,0 +1,277 @@
+module test_mqc_ecp_reader
+   !! Tests the BSE JSON effective-core-potential reader.
+   !!
+   !! The values below are read off `basis_sets/def2-ecp.json` by hand. They
+   !! are worth stating explicitly rather than derived, because the two things
+   !! most likely to go wrong here are silent: picking the wrong channel as the
+   !! local one, and losing digits from the coefficients. Neither fails, both
+   !! give a wrong potential.
+   !!
+   !! Rubidium is the lightest element def2-ECP covers, and gold is a case
+   !! where the core is large enough that getting `ecp_electrons` wrong would
+   !! be unmistakable in the electron count.
+   use testdrive, only: new_unittest, unittest_type, error_type, check
+   use mqc_ecp, only: atomic_ecp_type, molecular_ecp_type
+   use mqc_json_ecp_reader, only: read_json_ecp_element, build_molecular_ecp_json
+   use mqc_error, only: error_t
+   use pic_types, only: dp
+   implicit none
+   private
+   public :: collect_mqc_ecp_reader_tests
+
+   character(len=*), parameter :: ECP_FILE = "../basis_sets/def2-ecp.json"
+      !! Tests run with their source directory as the working directory
+
+contains
+
+   subroutine collect_mqc_ecp_reader_tests(testsuite)
+      type(unittest_type), allocatable, intent(out) :: testsuite(:)
+
+      testsuite = [ &
+                  new_unittest("rubidium_channels", test_rubidium), &
+                  new_unittest("local_channel_is_highest_l", test_local_is_highest), &
+                  new_unittest("gold_core_electrons", test_gold), &
+                  new_unittest("light_element_has_no_ecp", test_light_element), &
+                  new_unittest("molecular_set_is_per_atom", test_molecular), &
+                  new_unittest("core_electrons_sum_over_atoms", test_core_sum), &
+                  new_unittest("missing_file_is_an_error", test_missing_file) &
+                  ]
+   end subroutine collect_mqc_ecp_reader_tests
+
+   subroutine test_rubidium(error)
+      !! Channel count, angular momenta and the first primitive of each
+      type(error_type), allocatable, intent(out) :: error
+      type(atomic_ecp_type) :: ecp
+      type(error_t) :: read_error
+
+      call read_json_ecp_element(ECP_FILE, "Rb", ecp, read_error)
+      call check(error, .not. read_error%has_error(), read_error%get_message())
+      if (allocated(error)) return
+
+      call check(error, ecp%has_ecp, "Rb should carry an ECP")
+      if (allocated(error)) return
+      call check(error, ecp%core_electrons, 28, "Rb ECP replaces 28 electrons")
+      if (allocated(error)) return
+
+      ! def2-ECP gives Rb four channels: l = 3 local, plus 0, 1, 2 projected.
+      call check(error, ecp%n_projected, 3, "Rb should have three projected channels")
+      if (allocated(error)) return
+      call check(error, ecp%local%ang_mom, 3, "Rb local channel is l = 3")
+      if (allocated(error)) return
+
+      ! The single l=3 primitive, read straight out of the file.
+      call check(error, ecp%local%nprim, 1, "Rb local channel has one primitive")
+      if (allocated(error)) return
+      call check(error, ecp%local%radial_powers(1), 2, "Rb local r exponent is 2")
+      if (allocated(error)) return
+      call check(error, close_enough(ecp%local%exponents(1), 3.8431140_dp), &
+                 "Rb local exponent should be 3.8431140")
+      if (allocated(error)) return
+      call check(error, close_enough(ecp%local%coefficients(1), -12.3169000_dp), &
+                 "Rb local coefficient should be -12.3169000")
+      if (allocated(error)) return
+
+      ! The l=0 channel has three primitives; check the widest-magnitude one so
+      ! a truncated read shows up.
+      call check(error, projected_of(ecp, 0) > 0, "Rb should have an l = 0 channel")
+      if (allocated(error)) return
+      call check(error, ecp%projected(projected_of(ecp, 0))%nprim, 3, &
+                 "Rb l = 0 channel has three primitives")
+      if (allocated(error)) return
+      call check(error, close_enough(ecp%projected(projected_of(ecp, 0))%coefficients(1), &
+                                     89.5001980_dp), &
+                 "Rb l = 0 leading coefficient should be 89.5001980")
+
+      call ecp%destroy()
+   end subroutine test_rubidium
+
+   subroutine test_local_is_highest(error)
+      !! The local channel must carry a higher l than any projected one
+      !!
+      !! This is the assumption the whole semi-local form rests on. Selecting
+      !! the wrong channel produces a potential that is wrong everywhere and
+      !! complains nowhere.
+      type(error_type), allocatable, intent(out) :: error
+      type(atomic_ecp_type) :: ecp
+      type(error_t) :: read_error
+      character(len=2) :: symbols(4)
+      integer :: isym, iproj
+
+      symbols = ["Rb", "Ag", "Au", "Rn"]
+      do isym = 1, size(symbols)
+         call read_json_ecp_element(ECP_FILE, trim(symbols(isym)), ecp, read_error)
+         call check(error, .not. read_error%has_error(), read_error%get_message())
+         if (allocated(error)) return
+         call check(error, ecp%has_ecp, trim(symbols(isym))//" should carry an ECP")
+         if (allocated(error)) return
+
+         do iproj = 1, ecp%n_projected
+            call check(error, ecp%projected(iproj)%ang_mom < ecp%local%ang_mom, &
+                       trim(symbols(isym))//": a projected channel has l >= the local one")
+            if (allocated(error)) return
+         end do
+         call ecp%destroy()
+      end do
+   end subroutine test_local_is_highest
+
+   subroutine test_gold(error)
+      !! A large core, where an error in the count would be obvious
+      type(error_type), allocatable, intent(out) :: error
+      type(atomic_ecp_type) :: ecp
+      type(error_t) :: read_error
+
+      call read_json_ecp_element(ECP_FILE, "Au", ecp, read_error)
+      call check(error, .not. read_error%has_error(), read_error%get_message())
+      if (allocated(error)) return
+      call check(error, ecp%core_electrons, 60, "Au ECP replaces 60 electrons")
+      if (allocated(error)) return
+      ! Z = 79 less a 60-electron core leaves 19 valence electrons.
+      call check(error, 79 - ecp%core_electrons, 19, &
+                 "Au should be left with 19 valence electrons")
+
+      call ecp%destroy()
+   end subroutine test_gold
+
+   subroutine test_light_element(error)
+      !! An element the file does not cover is not an error
+      type(error_type), allocatable, intent(out) :: error
+      type(atomic_ecp_type) :: ecp
+      type(error_t) :: read_error
+
+      call read_json_ecp_element(ECP_FILE, "O", ecp, read_error)
+      call check(error, .not. read_error%has_error(), &
+                 "an element without an ECP should not be an error: "// &
+                 read_error%get_message())
+      if (allocated(error)) return
+      call check(error, .not. ecp%has_ecp, "oxygen should carry no ECP")
+      if (allocated(error)) return
+      call check(error, ecp%core_electrons, 0, "an absent ECP replaces no electrons")
+
+      call ecp%destroy()
+   end subroutine test_light_element
+
+   subroutine test_molecular(error)
+      !! One entry per atom, in atom order, mixing ECP and non-ECP elements
+      type(error_type), allocatable, intent(out) :: error
+      type(molecular_ecp_type) :: mol_ecp
+      type(error_t) :: read_error
+      character(len=2) :: symbols(4)
+
+      ! Au-O-Au-H: heavy, light, heavy again, light.
+      symbols = ["Au", "O ", "Au", "H "]
+      call build_molecular_ecp_json(ECP_FILE, symbols, mol_ecp, read_error)
+      call check(error, .not. read_error%has_error(), read_error%get_message())
+      if (allocated(error)) return
+
+      call check(error, mol_ecp%natoms, 4, "one entry per atom")
+      if (allocated(error)) return
+      call check(error, mol_ecp%n_ecp_atoms, 2, "two of the four atoms carry an ECP")
+      if (allocated(error)) return
+
+      ! Entries must line up with atom order, not element order -- everything
+      ! downstream indexes coordinates and charges the same way.
+      call check(error, mol_ecp%atoms(1)%has_ecp, "atom 1 (Au) should carry an ECP")
+      if (allocated(error)) return
+      call check(error, .not. mol_ecp%atoms(2)%has_ecp, "atom 2 (O) should not")
+      if (allocated(error)) return
+      call check(error, mol_ecp%atoms(3)%has_ecp, "atom 3 (Au) should carry an ECP")
+      if (allocated(error)) return
+      call check(error, .not. mol_ecp%atoms(4)%has_ecp, "atom 4 (H) should not")
+      if (allocated(error)) return
+
+      ! The repeated element must be a real copy, not a shared or empty one.
+      call check(error, mol_ecp%atoms(3)%local%nprim, mol_ecp%atoms(1)%local%nprim, &
+                 "the second gold should have the same channels as the first")
+      if (allocated(error)) return
+      call check(error, close_enough(mol_ecp%atoms(3)%local%exponents(1), &
+                                     mol_ecp%atoms(1)%local%exponents(1)), &
+                 "the second gold's exponents should match the first's")
+
+      call mol_ecp%destroy()
+   end subroutine test_molecular
+
+   subroutine test_core_sum(error)
+      !! Core electrons sum over atoms, not over elements
+      !!
+      !! Two golds replace 120 electrons, not 60. Summing per element would
+      !! leave the SCF with 60 electrons too many and still converge.
+      type(error_type), allocatable, intent(out) :: error
+      type(molecular_ecp_type) :: mol_ecp
+      type(error_t) :: read_error
+      character(len=2) :: symbols(3)
+
+      symbols = ["Au", "Au", "O "]
+      call build_molecular_ecp_json(ECP_FILE, symbols, mol_ecp, read_error)
+      call check(error, .not. read_error%has_error(), read_error%get_message())
+      if (allocated(error)) return
+
+      call check(error, mol_ecp%core_electrons(), 120, &
+                 "two gold ECPs should replace 120 electrons between them")
+      if (allocated(error)) return
+      call check(error, mol_ecp%any_ecp(), "the molecule should report carrying ECPs")
+
+      call mol_ecp%destroy()
+   end subroutine test_core_sum
+
+   subroutine test_missing_file(error)
+      type(error_type), allocatable, intent(out) :: error
+      type(atomic_ecp_type) :: ecp
+      type(error_t) :: read_error
+
+      call read_json_ecp_element("../basis_sets/no-such-ecp.json", "Au", ecp, read_error)
+      call check(error, read_error%has_error(), &
+                 "a missing ECP file should be an error")
+   end subroutine test_missing_file
+
+   ! ---- helpers -------------------------------------------------------------
+
+   pure function projected_of(ecp, ang_mom) result(index)
+      !! Which projected channel carries a given l, or 0
+      type(atomic_ecp_type), intent(in) :: ecp
+      integer, intent(in) :: ang_mom
+      integer :: index
+      integer :: i
+
+      index = 0
+      do i = 1, ecp%n_projected
+         if (ecp%projected(i)%ang_mom == ang_mom) then
+            index = i
+            return
+         end if
+      end do
+   end function projected_of
+
+   pure function close_enough(a, b) result(same)
+      real(dp), intent(in) :: a, b
+      logical :: same
+      same = abs(a - b) <= 1.0e-10_dp*max(1.0_dp, abs(b))
+   end function close_enough
+
+end module test_mqc_ecp_reader
+
+program tester
+   use, intrinsic :: iso_fortran_env, only: error_unit
+   use testdrive, only: run_testsuite, new_testsuite, testsuite_type
+   use test_mqc_ecp_reader, only: collect_mqc_ecp_reader_tests
+   implicit none
+   integer :: stat, is
+   type(testsuite_type), allocatable :: testsuites(:)
+   character(len=*), parameter :: fmt = '("#", *(1x, a))'
+
+   stat = 0
+
+   testsuites = [ &
+                new_testsuite("mqc_ecp_reader", collect_mqc_ecp_reader_tests) &
+                ]
+
+   do is = 1, size(testsuites)
+      write (*, fmt) "Testing:", testsuites(is)%name
+      call run_testsuite(testsuites(is)%collect, error_unit, stat)
+   end do
+
+   if (stat > 0) then
+      write (error_unit, "(i0, 1x, a)") stat, "test(s) failed!"
+      error stop
+   end if
+
+end program tester


### PR DESCRIPTION
The data has been sitting in basis_sets/ the whole time -- def2-ecp.json
covers Z = 37..86 with ecp_electrons and ecp_potentials -- and the basis
reader's header has said "for when that gets wired up" since it was written.
This is the reading half.

mqc_ecp holds the semi-local form: a local channel plus one projector per
lower angular momentum, each a set of (radial power, exponent, coefficient)
primitives. mqc_json_ecp_reader parses it, following the orbital reader's
idioms -- values kept as strings in the file to preserve digits, each element
read once and copied per atom.

**The local channel is selected by highest angular momentum, not by position
in the file.** For every def2 element those coincide, since the order is
3, 0, 1, 2. Selecting on position would work today and produce a potential
with the local and projected parts exchanged the first time a tabulation
listed its channels ascending -- wrong everywhere, complaining nowhere.

molecular_ecp_type is indexed per atom rather than per element, matching
molecular_basis_type, so an entry lines up with the atom index that
coordinates, nuclear charges and cuEST's active-atom list all use. Atoms
without an ECP get an entry with has_ecp false rather than being skipped, so
a molecule mixing heavy and light atoms needs no special casing. core_
electrons() sums over atoms for the same reason: two golds replace 120
electrons, not 60, and summing per element would leave the SCF sixty
electrons heavy and still converge.

Tests read real def2-ECP values for Rb and Au and assert them literally,
including that no projected channel has l >= the local one.

Nothing consumes this yet.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
