### PR TITLE
density-fit J and K, the way cuEST always does

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -305,6 +305,10 @@ if(MQC_ENABLE_LIBCINT)
                              PRIVATE "${CMAKE_BINARY_DIR}/modules")
   target_link_libraries(check_libcint PRIVATE ${main_lib} cint_fortran cint)
 
+  add_executable(check_df ${PROJECT_SOURCE_DIR}/validation/check_df.f90)
+  target_include_directories(check_df PRIVATE "${CMAKE_BINARY_DIR}/modules")
+  target_link_libraries(check_df PRIVATE ${main_lib} cint_fortran cint)
+
   add_executable(check_rhf ${PROJECT_SOURCE_DIR}/validation/check_rhf.f90)
   target_include_directories(check_rhf PRIVATE "${CMAKE_BINARY_DIR}/modules")
   target_link_libraries(check_rhf PRIVATE ${main_lib} cint_fortran cint)

--- a/libcint_backend/mqc_libcint_integrals.f90
+++ b/libcint_backend/mqc_libcint_integrals.f90
@@ -27,11 +27,14 @@ module mqc_libcint_integrals
    !! calculation is small by construction -- and the wrong one for anything
    !! else. Direct or density-fitted assembly is a different backend.
    use pic_types, only: dp
+   use pic_blas_interfaces, only: pic_gemm
    use mqc_error, only: error_t, ERROR_VALIDATION
    use mqc_cgto, only: molecular_basis_type
    use mqc_basis_utils, only: find_basis_file
    use mqc_json_basis_reader, only: build_molecular_basis_json
+   use pic_lapack_interfaces, only: pic_syev
    use libcint_fortran, only: libcint_1e_ovlp_sph, libcint_1e_kin_sph, &
+                              libcint_3c2e_sph, libcint_2c2e_sph, &
                               libcint_1e_nuc_sph, libcint_2e_sph, &
                               libcint_cgto_sph, libcint_tot_cgto_sph, &
                               libcint_gto_norm, &
@@ -45,6 +48,7 @@ module mqc_libcint_integrals
 
    public :: libcint_molecule_t
    public :: build_libcint_molecule
+   public :: build_df_tensor
 
    type :: libcint_molecule_t
       !! One molecule, packed the way libcint wants it
@@ -280,6 +284,170 @@ contains
       end do
       deallocate (buf)
    end subroutine one_electron
+
+   subroutine build_df_tensor(orb, aux, b, error)
+      !! B(mu nu, P) = sum_Q (mu nu | Q) [(P|Q)^(-1/2)]_QP
+      !!
+      !! The fitted J and K are contractions of this one tensor, which is why
+      !! it is formed once and kept rather than recomputed per iteration. It
+      !! is (nao^2, naux) -- large, but n^2 rather than the n^4 of the exact
+      !! integrals, and that is the whole point of fitting.
+      !!
+      !! The metric is inverted through its eigendecomposition rather than a
+      !! Cholesky, and modes below a threshold are dropped. A JKFIT auxiliary
+      !! basis is close to linearly dependent by construction, and a Cholesky
+      !! of a near-singular metric fails outright where this degrades.
+      type(libcint_molecule_t), intent(in) :: orb   !! Orbital basis
+      type(libcint_molecule_t), intent(in) :: aux   !! Auxiliary basis, same atoms
+      real(dp), allocatable, intent(out) :: b(:, :)
+      type(error_t), intent(inout) :: error
+
+      real(dp), parameter :: NULL_THRESHOLD = 1.0e-10_dp
+      real(dp), allocatable :: metric(:, :), vectors(:, :), values(:), half(:, :)
+      real(dp), allocatable :: three(:, :)
+      integer :: naux, nao, i, j, kept, info
+
+      nao = orb%nao
+      naux = aux%nao
+
+      call two_centre(aux, metric)
+      call three_centre(orb, aux, three)
+
+      allocate (vectors(naux, naux), values(naux))
+      vectors = metric
+      call pic_syev(vectors, values, jobz="V", uplo="U", info=info)
+      if (info /= 0) then
+         call error%set(ERROR_VALIDATION, "density fitting: the metric would not diagonalise")
+         return
+      end if
+
+      kept = count(values > NULL_THRESHOLD)
+      if (kept == 0) then
+         call error%set(ERROR_VALIDATION, "density fitting: the auxiliary metric is singular")
+         return
+      end if
+
+      ! J^(-1/2) = U s^(-1/2) U^T over the surviving modes.
+      allocate (half(naux, naux))
+      half = 0.0_dp
+      do i = 1, naux
+         if (values(i) <= NULL_THRESHOLD) cycle
+         do j = 1, naux
+            half(:, j) = half(:, j) + vectors(:, i)*vectors(j, i)/sqrt(values(i))
+         end do
+      end do
+
+      allocate (b(nao*nao, naux))
+      call pic_gemm(three, half, b)
+   end subroutine build_df_tensor
+
+   subroutine two_centre(aux, metric)
+      !! (P|Q) over the auxiliary basis
+      type(libcint_molecule_t), intent(in) :: aux
+      real(dp), allocatable, intent(out) :: metric(:, :)
+
+      real(dp), allocatable :: buf(:)
+      integer :: shls(2)
+      integer :: ish, jsh, di, dj, i, j, io, jo, ret
+
+      allocate (metric(aux%nao, aux%nao))
+      metric = 0.0_dp
+      allocate (buf(max_block(aux)**2))
+
+      do ish = 1, aux%nbas
+         di = libcint_cgto_sph(ish - 1, aux%bas)
+         io = aux%shell_offset(ish)
+         do jsh = 1, aux%nbas
+            dj = libcint_cgto_sph(jsh - 1, aux%bas)
+            jo = aux%shell_offset(jsh)
+            shls = [ish - 1, jsh - 1]
+            ret = libcint_2c2e_sph(buf, shls, aux%atm, aux%natm, aux%bas, aux%nbas, aux%env)
+            if (ret == 0) cycle
+            do j = 1, dj
+               do i = 1, di
+                  metric(io + i, jo + j) = buf(i + (j - 1)*di)
+               end do
+            end do
+         end do
+      end do
+   end subroutine two_centre
+
+   subroutine three_centre(orb, aux, three)
+      !! (mu nu | P), flattened to (nao*nao, naux)
+      !!
+      !! The orbital and auxiliary shells are concatenated into one bas array,
+      !! because libcint addresses all four centres of a 3c2e call by index
+      !! into a single table. The fourth index names a dummy s shell with a
+      !! zero exponent, which is how libcint spells "only three centres".
+      type(libcint_molecule_t), intent(in) :: orb, aux
+      real(dp), allocatable, intent(out) :: three(:, :)
+
+      integer, allocatable :: bas(:, :)
+      real(dp), allocatable :: env(:), buf(:)
+      integer :: nbas_orb, nbas_aux, dummy, n_env_orb
+      integer :: shls(4)
+      integer :: ish, jsh, ksh, di, dj, dk, i, j, k, io, jo, ko, ret, idx
+
+      nbas_orb = orb%nbas
+      nbas_aux = aux%nbas
+
+      ! Orbital shells, then auxiliary shells, then one dummy. The auxiliary
+      ! env offsets are shifted by the orbital env length because both live in
+      ! one array now.
+      n_env_orb = size(orb%env)
+      allocate (bas(LIBCINT_BAS_SLOTS, nbas_orb + nbas_aux + 1))
+      allocate (env(n_env_orb + size(aux%env) + 1))
+      bas = 0
+      env = 0.0_dp
+      env(1:n_env_orb) = orb%env
+      env(n_env_orb + 1:n_env_orb + size(aux%env)) = aux%env
+
+      bas(:, 1:nbas_orb) = orb%bas
+      bas(:, nbas_orb + 1:nbas_orb + nbas_aux) = aux%bas
+      do ish = 1, nbas_aux
+         bas(LIBCINT_PTR_EXP, nbas_orb + ish) = aux%bas(LIBCINT_PTR_EXP, ish) + n_env_orb
+         bas(LIBCINT_PTR_COEFF, nbas_orb + ish) = aux%bas(LIBCINT_PTR_COEFF, ish) + n_env_orb
+      end do
+
+      ! The dummy: one s shell, one primitive, exponent and coefficient zero.
+      dummy = nbas_orb + nbas_aux + 1
+      bas(LIBCINT_ATOM_OF, dummy) = 0
+      bas(LIBCINT_ANG_OF, dummy) = 0
+      bas(LIBCINT_NPRIM_OF, dummy) = 1
+      bas(LIBCINT_NCTR_OF, dummy) = 1
+      bas(LIBCINT_PTR_EXP, dummy) = size(env) - 1
+      bas(LIBCINT_PTR_COEFF, dummy) = size(env) - 1
+      env(size(env)) = 0.0_dp
+
+      allocate (three(orb%nao*orb%nao, aux%nao))
+      three = 0.0_dp
+      allocate (buf(max_block(orb)**2*max_block(aux)))
+
+      do ish = 1, nbas_orb
+         di = libcint_cgto_sph(ish - 1, bas)
+         io = orb%shell_offset(ish)
+         do jsh = 1, nbas_orb
+            dj = libcint_cgto_sph(jsh - 1, bas)
+            jo = orb%shell_offset(jsh)
+            do ksh = 1, nbas_aux
+               dk = libcint_cgto_sph(nbas_orb + ksh - 1, bas)
+               ko = aux%shell_offset(ksh)
+               shls = [ish - 1, jsh - 1, nbas_orb + ksh - 1, dummy - 1]
+               ret = libcint_3c2e_sph(buf, shls, orb%atm, orb%natm, bas, &
+                                      nbas_orb + nbas_aux + 1, env)
+               if (ret == 0) cycle
+               do k = 1, dk
+                  do j = 1, dj
+                     do i = 1, di
+                        idx = i + (j - 1)*di + (k - 1)*di*dj
+                        three((jo + j - 1)*orb%nao + io + i, ko + k) = buf(idx)
+                     end do
+                  end do
+               end do
+            end do
+         end do
+      end do
+   end subroutine three_centre
 
    subroutine molecule_eris(this, eri)
       !! Every two-electron integral, in core, as (ij|kl)

--- a/libcint_backend/mqc_libcint_rhf.f90
+++ b/libcint_backend/mqc_libcint_rhf.f90
@@ -16,7 +16,7 @@ module mqc_libcint_rhf
    use pic_lapack_interfaces, only: pic_syev
    use mqc_error, only: error_t, ERROR_VALIDATION
    use mqc_diis, only: diis_state_t
-   use mqc_libcint_integrals, only: libcint_molecule_t
+   use mqc_libcint_integrals, only: libcint_molecule_t, build_df_tensor
    implicit none
    private
 
@@ -39,7 +39,7 @@ module mqc_libcint_rhf
 contains
 
    subroutine run_libcint_rhf(mol, nelec, max_iter, energy_tol, density_tol, &
-                              verbose, result, error, diis_vectors)
+                              verbose, result, error, aux, diis_vectors)
       !! Drive a closed-shell SCF to convergence
       type(libcint_molecule_t), intent(in) :: mol
       integer, intent(in) :: nelec
@@ -48,6 +48,11 @@ contains
       logical, intent(in) :: verbose
       type(rhf_result_t), intent(out) :: result
       type(error_t), intent(inout) :: error
+      type(libcint_molecule_t), intent(in), optional :: aux
+         !! Auxiliary basis. Present means density-fitted J and K, which is
+         !! what cuEST always does -- so a comparison against the GPU path
+         !! needs this, and a comparison against an exact-ERI code needs it
+         !! absent. Both are worth being able to ask for.
       integer, intent(in), optional :: diis_vectors
          !! Subspace size. Zero turns DIIS off, which is worth being able to
          !! do: the two paths should agree with and without it, and if they
@@ -55,7 +60,7 @@ contains
 
       integer :: diis_size
 
-      real(dp), allocatable :: s(:, :), h(:, :), eri(:, :, :, :)
+      real(dp), allocatable :: s(:, :), h(:, :), eri(:, :, :, :), bmat(:, :)
       real(dp), allocatable :: x(:, :), fock(:, :), density(:, :), density_old(:, :)
       real(dp), allocatable :: coeff(:, :), eigenvalues(:)
       real(dp), allocatable :: err(:, :), fock_flat(:)
@@ -82,7 +87,12 @@ contains
 
       call mol%overlap(s)
       call mol%core_hamiltonian(h)
-      call mol%eris(eri)
+      if (present(aux)) then
+         call build_df_tensor(mol, aux, bmat, error)
+         if (error%has_error()) return
+      else
+         call mol%eris(eri)
+      end if
 
       call build_orthogonalizer(s, x, n_mo, error)
       if (error%has_error()) return
@@ -112,7 +122,11 @@ contains
 
       do iter = 1, max_iter
          density_old = density
-         call build_fock(h, eri, density, fock)
+         if (allocated(bmat)) then
+            call build_fock_df(h, bmat, density, fock)
+         else
+            call build_fock(h, eri, density, fock)
+         end if
 
          ! The energy belongs to the Fock built from this density, so it is
          ! taken before extrapolation. A DIIS-mixed Fock is a convergence
@@ -151,7 +165,11 @@ contains
       ! The energy that goes out is the one belonging to the density that
       ! satisfied the test, so it is recomputed from the final Fock rather
       ! than carried over from the loop.
-      call build_fock(h, eri, density, fock)
+      if (allocated(bmat)) then
+         call build_fock_df(h, bmat, density, fock)
+      else
+         call build_fock(h, eri, density, fock)
+      end if
       result%electronic = electronic_energy(h, fock, density)
       result%nuclear_repulsion = mol%nuclear_repulsion()
       result%energy = result%electronic + result%nuclear_repulsion
@@ -297,6 +315,42 @@ contains
          end do
       end do
    end subroutine build_fock
+
+   subroutine build_fock_df(h, b, density, fock)
+      !! F = H + J - K/2 from the fitted tensor rather than the exact ERIs
+      !!
+      !! J is one contraction: c_P = sum_uv B(uv,P) D_uv, then J_uv = sum_P
+      !! B(uv,P) c_P. K needs the half-transformed intermediate, which is why
+      !! exchange is the expensive half of a fitted SCF as well as an exact
+      !! one -- fitting removes the n^4 storage, not the n^3 work.
+      real(dp), intent(in) :: h(:, :), b(:, :), density(:, :)
+      real(dp), intent(out) :: fock(:, :)
+
+      real(dp), allocatable :: c(:), j(:, :), k(:, :), t(:, :)
+      integer :: n, naux, p
+
+      n = size(h, 1)
+      naux = size(b, 2)
+      allocate (c(naux), j(n, n), k(n, n), t(n, n))
+
+      do p = 1, naux
+         c(p) = sum(reshape(b(:, p), [n, n])*density)
+      end do
+
+      j = 0.0_dp
+      do p = 1, naux
+         j = j + c(p)*reshape(b(:, p), [n, n])
+      end do
+
+      ! K_uv = sum_P sum_ls B(ul,P) D_ls B(sv,P)
+      k = 0.0_dp
+      do p = 1, naux
+         t = matmul(reshape(b(:, p), [n, n]), density)
+         k = k + matmul(t, reshape(b(:, p), [n, n]))
+      end do
+
+      fock = h + j - 0.5_dp*k
+   end subroutine build_fock_df
 
    pure function electronic_energy(h, fock, density) result(energy)
       !! E = 1/2 sum_uv D_uv (H_uv + F_uv)

--- a/python/mqc/__init__.py
+++ b/python/mqc/__init__.py
@@ -542,6 +542,13 @@ class MBE:
         Generated on demand and cached, so screening is read-modify-write on
         one list rather than a new one each time.
         """
+        if self._terms is None and self.level < 2:
+            # `fraglist_generate` starts at pairs, so a monomers-only
+            # expansion has no n-mers for it to make and it refuses. That is
+            # right for the generator and wrong as an answer: MBE(1) is a
+            # legitimate calculation -- it is the first term of every other
+            # one -- and its term list is just the monomers.
+            self._terms = [(i,) for i in range(1, self.system.n_monomers + 1)]
         if self._terms is None:
             handle = _ffi.fraglist_new()
             try:

--- a/validation/check_df.f90
+++ b/validation/check_df.f90
@@ -1,0 +1,83 @@
+!! Manual check that density fitting reproduces PySCF's
+!!
+!!     cmake -B build -DMQC_ENABLE_LIBCINT=ON && ./build/check_df
+!!
+!! Density fitting is the approximation cuEST always makes -- it has no
+!! conventional four-index path -- so a CPU reference that computes exact
+!! ERIs can only ever agree with the GPU to the fitting error, which is
+!! around 1e-6 and swamps any bug worth finding. Fitting on this side too is
+!! what turns "roughly agrees" into "any disagreement is a bug".
+!!
+!! Two things are asserted, and the second is the sharper one. The fitted
+!! energy matches PySCF's density_fit on the same auxiliary basis, and so
+!! does the fitting *error* -- the gap between fitted and exact. A fitted
+!! energy could come out right with a wrong metric if the errors happened to
+!! cancel; the error itself agreeing to four digits could not.
+program check_df
+   use pic_types, only: dp
+   use mqc_libcint_integrals, only: libcint_molecule_t, build_libcint_molecule
+   use mqc_libcint_rhf, only: rhf_result_t, run_libcint_rhf
+   use mqc_error, only: error_t
+   implicit none
+   type(libcint_molecule_t) :: mol, aux
+   type(rhf_result_t) :: exact, fitted
+   type(error_t) :: error
+   real(dp) :: coords(3, 3)
+   integer :: z(3)
+   character(len=8) :: names(3)
+   integer :: failures
+   z = [8, 1, 1]
+   names = ["O", "H", "H"]
+   coords(:, 1) = [0.0_dp, 0.0_dp, -0.1364652_dp]
+   coords(:, 2) = [0.0_dp, 1.4304924_dp, 1.0826636_dp]
+   coords(:, 3) = [0.0_dp, -1.4304924_dp, 1.0826636_dp]
+
+   call build_libcint_molecule(z, names, coords, "cc-pvdz", mol, error)
+   if (error%has_error()) then
+      print *, "orbital: ", error%get_message()
+      stop
+   end if
+   call build_libcint_molecule(z, names, coords, "cc-pvtz-jkfit", aux, error)
+   if (error%has_error()) then
+      print *, "aux: ", error%get_message()
+      stop
+   end if
+   write (*, "(a,i0,a,i0)") "cc-pVDZ nao=", mol%nao, "   cc-pVTZ-JKFIT naux=", aux%nao
+
+   call run_libcint_rhf(mol, 10, 200, 1.0e-11_dp, 1.0e-9_dp, .false., exact, error)
+   call run_libcint_rhf(mol, 10, 200, 1.0e-11_dp, 1.0e-9_dp, .false., fitted, error, aux=aux)
+   write (*, "(a,f18.10)") "  exact ERI   E = ", exact%energy
+   write (*, "(a,f18.10)") "  density fit E = ", fitted%energy
+   write (*, "(a,es12.4)") "  fitting error = ", fitted%energy - exact%energy
+
+   ! PySCF 2.14, same geometry, same BSE basis data, scf.RHF().density_fit()
+   failures = 0
+   call expect(aux%nao == 139, "cc-pVTZ-JKFIT gives 139 auxiliary functions")
+   call expect(abs(exact%energy - (-76.0220988827_dp)) < 1.0e-9_dp, &
+               "exact ERI energy matches PySCF")
+   call expect(abs(fitted%energy - (-76.0220956698_dp)) < 1.0e-9_dp, &
+               "density-fitted energy matches PySCF")
+   call expect(abs((fitted%energy - exact%energy) - 3.213e-06_dp) < 1.0e-9_dp, &
+               "the fitting error itself matches PySCF, not just the total")
+
+   write (*, "(A)") ""
+   if (failures == 0) then
+      write (*, "(A)") "[df] all ok -- fitted J and K agree with PySCF"
+   else
+      write (*, "(A,I0,A)") "[df] ", failures, " FAILURE(S)"
+      error stop 1
+   end if
+
+contains
+
+   subroutine expect(condition, what)
+      logical, intent(in) :: condition
+      character(len=*), intent(in) :: what
+
+      if (.not. condition) then
+         write (*, "(A)") "  FAILED: "//what
+         failures = failures + 1
+      end if
+   end subroutine expect
+
+end program check_df


### PR DESCRIPTION
    cc-pVDZ / cc-pVTZ-JKFIT, water        naux = 139
      exact ERI    -76.0220988827    pyscf -76.0220988827
      density fit  -76.0220956698    pyscf -76.0220956698
      fitting error  3.213e-06       pyscf  3.213e-06

This is the addition that makes the CPU backend a tight reference rather than
a rough one. mqc_method_hf says it plainly: cuEST has no conventional
four-index path, J and K are always fitted. So an exact-ERI reference could
only ever agree with the GPU to the fitting error, around 1e-6 -- which
swamps any bug worth finding. Fitting on this side too turns "roughly agrees"
into "any disagreement is a bug".

Both checks matter and the second is sharper. The fitted energy matches
PySCF's density_fit, and so does the fitting *error* -- the gap between
fitted and exact. A fitted energy can come out right with a wrong metric if
errors cancel; the error itself agreeing to four digits cannot.

The metric is inverted through its eigendecomposition with near-null modes
dropped, not by Cholesky: a JKFIT auxiliary basis is close to linearly
dependent by construction, and a Cholesky of a near-singular metric fails
outright where this degrades.

The three-centre integrals needed libcint_3c2e_sph and libcint_2c2e_sph,
which the Fortran interface did not carry. Added upstream in
JorgeG94/libcint rather than bound locally -- one interface, maintained where
the library is -- and this builds against that working tree until it is
pushed and the pin can move.

Also: MBE(1) raised from Python instead of returning its terms, because
fraglist_generate starts at pairs and has no n-mers to make. Right for the
generator, wrong as an answer -- a monomers-only expansion is the first term
of every other one. Fragmented HF now runs from Python and gives the CLI's
numbers exactly.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
