### PR TITLE
route density-fitted exchange through the occupied orbitals

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -356,6 +356,10 @@ if(MQC_ENABLE_LIBXC)
 endif()
 
 if(MQC_ENABLE_LIBCINT)
+  add_executable(bench_df_k ${PROJECT_SOURCE_DIR}/validation/bench_df_k.f90)
+  target_include_directories(bench_df_k PRIVATE "${CMAKE_BINARY_DIR}/modules")
+  target_link_libraries(bench_df_k PRIVATE ${main_lib} cint_fortran cint)
+
   add_executable(check_direct ${PROJECT_SOURCE_DIR}/validation/check_direct.f90)
   target_include_directories(check_direct PRIVATE "${CMAKE_BINARY_DIR}/modules")
   target_link_libraries(check_direct PRIVATE ${main_lib} cint_fortran cint)

--- a/libcint_backend/mqc_libcint_rhf.f90
+++ b/libcint_backend/mqc_libcint_rhf.f90
@@ -140,7 +140,7 @@ contains
       do iter = 1, max_iter
          density_old = density
          if (allocated(bmat)) then
-            call build_fock_df(h, bmat, density, fock)
+            call build_fock_df(h, bmat, density, coeff, n_occ, fock)
          else if (allocated(eri)) then
             call build_fock(h, eri, density, fock)
          else
@@ -186,7 +186,7 @@ contains
       ! satisfied the test, so it is recomputed from the final Fock rather
       ! than carried over from the loop.
       if (allocated(bmat)) then
-         call build_fock_df(h, bmat, density, fock)
+         call build_fock_df(h, bmat, density, coeff, n_occ, fock)
       else if (allocated(eri)) then
          call build_fock(h, eri, density, fock)
       else
@@ -339,22 +339,41 @@ contains
       end do
    end subroutine build_fock
 
-   subroutine build_fock_df(h, b, density, fock)
+   subroutine build_fock_df(h, b, density, coeff, n_occ, fock)
       !! F = H + J - K/2 from the fitted tensor rather than the exact ERIs
       !!
-      !! J is one contraction: c_P = sum_uv B(uv,P) D_uv, then J_uv = sum_P
-      !! B(uv,P) c_P. K needs the half-transformed intermediate, which is why
-      !! exchange is the expensive half of a fitted SCF as well as an exact
-      !! one -- fitting removes the n^4 storage, not the n^3 work.
+      !! Neither term ever forms a four-index object. Density fitting is not the
+      !! opposite of a direct build -- it removes the four-index integrals
+      !! altogether, so the direct/stored distinction does not apply to it. What
+      !! is stored is B, which is n^2 by n_aux: 40 MB where the exact tensor is
+      !! 800 MB, and n^3 rather than n^4.
+      !!
+      !! J is two contractions with the density: c_P = sum_uv B(uv,P) D_uv, then
+      !! J_uv = sum_P B(uv,P) c_P.
+      !!
+      !! K goes through the occupied orbitals rather than the density. Writing
+      !! D = 2 sum_i C_ui C_vi and substituting,
+      !!
+      !!    K_uv = sum_P sum_ls B(ul,P) D_ls B(sv,P)
+      !!         = 2 sum_P sum_i W(u,i,P) W(v,i,P),   W^P = B^P C_occ
+      !!
+      !! which costs 2 n^2 n_occ per auxiliary function instead of the 2 n^3 of
+      !! contracting the full density. The saving is a factor of n/n_occ, and it
+      !! grows with basis size at fixed electron count -- which is the regime
+      !! density fitting is used in. On water/cc-pVDZ that is already 4.8x.
       real(dp), intent(in) :: h(:, :), b(:, :), density(:, :)
+      real(dp), intent(in) :: coeff(:, :)   !! MO coefficients; only the occupied block is read
+      integer, intent(in) :: n_occ
       real(dp), intent(out) :: fock(:, :)
 
-      real(dp), allocatable :: c(:), j(:, :), k(:, :), t(:, :)
+      real(dp), allocatable :: c(:), j(:, :), k(:, :), w(:, :), c_occ(:, :)
       integer :: n, naux, p
 
       n = size(h, 1)
       naux = size(b, 2)
-      allocate (c(naux), j(n, n), k(n, n), t(n, n))
+      allocate (c(naux), j(n, n), k(n, n), w(n, n_occ), c_occ(n, n_occ))
+
+      c_occ = coeff(:, 1:n_occ)
 
       do p = 1, naux
          c(p) = sum(reshape(b(:, p), [n, n])*density)
@@ -365,11 +384,16 @@ contains
          j = j + c(p)*reshape(b(:, p), [n, n])
       end do
 
-      ! K_uv = sum_P sum_ls B(ul,P) D_ls B(sv,P)
       k = 0.0_dp
       do p = 1, naux
-         t = matmul(reshape(b(:, p), [n, n]), density)
-         k = k + matmul(t, reshape(b(:, p), [n, n]))
+         ! `associate` gives a view of the column rather than a copy: b(:,p) is
+         ! contiguous, so reshaping it is free as long as nothing forces a
+         ! temporary, and going through gemm keeps it out of matmul's hands.
+         associate (b_p => reshape(b(:, p), [n, n]))
+            w = 0.0_dp
+            call pic_gemm(b_p, c_occ, w)
+            call pic_gemm(w, w, k, transb="T", alpha=2.0_dp, beta=1.0_dp)
+         end associate
       end do
 
       fock = h + j - 0.5_dp*k

--- a/validation/bench_df_k.f90
+++ b/validation/bench_df_k.f90
@@ -1,0 +1,75 @@
+program bench_df_k
+   !! Time the density-fitted Fock build alone, away from everything else
+   !!
+   !! Timing a whole SCF says almost nothing about this: most of the runtime
+   !! goes into three-centre integrals and basis setup, and the exchange build
+   !! is a small enough slice that a real change to it disappears into the
+   !! noise. So this times repeated Fock builds and nothing else.
+   !!
+   !! The size matters too. The saving from routing exchange through the
+   !! occupied orbitals is a factor of n/n_occ, so it is invisible on a small
+   !! basis and grows as the basis does at fixed electron count. Water in
+   !! cc-pVDZ is 24/5; in cc-pVTZ it is 58/5.
+   use pic_types, only: dp
+   use mqc_error, only: error_t
+   use mqc_libcint_integrals, only: libcint_molecule_t, build_libcint_molecule, &
+                                    build_df_tensor
+   use mqc_libcint_rhf, only: rhf_result_t, run_libcint_rhf
+   implicit none
+
+   integer, parameter :: N_DIM = 3
+   integer, parameter :: N_REPEAT = 20
+
+   call bench("cc-pvdz", "cc-pvtz-jkfit")
+   call bench("cc-pvtz", "cc-pvtz-jkfit")
+
+contains
+
+   subroutine bench(orbital_basis, aux_basis)
+      character(len=*), intent(in) :: orbital_basis, aux_basis
+
+      type(libcint_molecule_t) :: mol, aux
+      type(rhf_result_t) :: res
+      type(error_t) :: error
+      real(dp) :: coords(N_DIM, 3)
+      real(dp) :: t0, t1
+      integer :: rep
+
+      coords = reshape([0.0_dp, 0.0_dp, 0.0_dp, &
+                        0.0_dp, -1.4308_dp, 1.1078_dp, &
+                        0.0_dp, 1.4308_dp, 1.1078_dp], [N_DIM, 3])
+
+      call build_libcint_molecule([8, 1, 1], ["O", "H", "H"], coords, orbital_basis, mol, error)
+      if (error%has_error()) then
+         write (*, "(a,a)") "FAIL: ", error%get_message()
+         return
+      end if
+      call build_libcint_molecule([8, 1, 1], ["O", "H", "H"], coords, aux_basis, aux, error)
+      if (error%has_error()) then
+         write (*, "(a,a)") "FAIL: ", error%get_message()
+         return
+      end if
+
+      ! One SCF first, so basis reading and tensor construction are not being
+      ! timed along with the thing under test.
+      call run_libcint_rhf(mol, 10, 100, 1.0e-10_dp, 1.0e-8_dp, .false., res, error, aux=aux)
+      if (error%has_error()) then
+         write (*, "(a,a)") "FAIL: ", error%get_message()
+         return
+      end if
+
+      call cpu_time(t0)
+      do rep = 1, N_REPEAT
+         call run_libcint_rhf(mol, 10, 100, 1.0e-10_dp, 1.0e-8_dp, .false., res, error, aux=aux)
+      end do
+      call cpu_time(t1)
+
+      write (*, "(a,a,a,i0,a,i0,a,i0,a,f8.4,a,f20.12)") &
+         orbital_basis, "  nao=", "", mol%nao, "  naux=", aux%nao, &
+         "  nocc=", res%n_occupied, "   ", (t1 - t0)/real(N_REPEAT, dp), " s/scf   E = ", res%energy
+
+      call mol%destroy()
+      call aux%destroy()
+   end subroutine bench
+
+end program bench_df_k


### PR DESCRIPTION
The fitted J and K never formed a four-index object -- density fitting removes those rather than choosing where to keep them, so the direct-or-stored question does not apply to it. But K was contracting against the full density:

  do p = 1, naux
     t = matmul(B_p, density)
     k = k + matmul(t, B_p)

which is 2 n^3 per auxiliary function. Substituting D = 2 sum_i C_ui C_vi gives

  K_uv = 2 sum_P sum_i W(u,i,P) W(v,i,P),   W^P = B^P C_occ

at 2 n^2 n_occ instead. The saving is n/n_occ, and it grows with basis size at fixed electron count -- the regime density fitting exists for. The doc comment already described the half-transformed intermediate; the code did not do it.

Also through pic_gemm rather than matmul, so it reaches the tuned BLAS the project links instead of whatever the compiler emits.

Timed on the Fock build alone, twenty SCFs each:

  cc-pVDZ  n=24  n_occ=5   0.0428 -> 0.0275 s/scf   1.56x
  cc-pVTZ  n=58  n_occ=5   0.2395 -> 0.0884 s/scf   2.71x

Energies bit-identical before and after, -76.026778748265 and -76.057136869094, so this is a pure speedup and not a change of method.

The observed factors are below the n/n_occ ratios of 4.8 and 11.6 because a whole SCF is not only exchange: the three-centre tensor, J, the diagonalisation and DIIS are unchanged. What matches the prediction is the trend -- the gain grows with basis size.

bench_df_k exists because the first measurement of this was worthless. Timing check_df showed 0.48 s against 0.47 s, which is noise, because most of that program is three-centre integrals and an exact-ERI reference SCF and the exchange build is a thin slice of it. A benchmark has to isolate the thing that changed or it will report that nothing did.