### PR TITLE
exercise the Python interface in CI, and document it

### DIFF
--- a/.github/workflows/local_conda_env.yml
+++ b/.github/workflows/local_conda_env.yml
@@ -36,6 +36,14 @@ jobs:
             tblite: false
             legacy_mpi: false
             libcint: true
+          # The Python interface needs both backends in one library: the
+          # examples cover standalone and fragmented, xTB and Hartree-Fock, and
+          # three of those four paths can break without the others noticing.
+          - name: "python interface"
+            tblite: true
+            legacy_mpi: false
+            libcint: true
+            python: true
     steps:
       - uses: actions/checkout@v4
       - uses: conda-incubator/setup-miniconda@v3
@@ -71,6 +79,19 @@ jobs:
       # checked against PySCF rather than against numbers this program printed
       # earlier. Separate from the xTB validation below because that one needs
       # tblite and this one needs libcint, and neither job has both.
+      # Builds the shared library and runs the examples, which assert rather
+      # than print. Nothing else here loads libmqc.so through ctypes, so a
+      # renamed C entry point or a changed signature is a segfault at call
+      # time and compiles perfectly until then.
+      - name: Run Python interface examples
+        if: matrix.python
+        shell: bash -el {0}
+        run: |
+          conda activate mqc
+          cmake --build build --target mqc_shared
+          MQC_LIBRARY=$PWD/build/libmqc.so PYTHONPATH=$PWD/python \
+            python3 python/examples/backends.py
+
       - name: Run CPU validation tests (libcint)
         if: matrix.libcint
         shell: bash -el {0}

--- a/mqc_docs/source/index.rst
+++ b/mqc_docs/source/index.rst
@@ -22,6 +22,7 @@ The API docs for the code itself can be found here: https://jorgeg94.github.io/m
    getting_started
    capabilities
    input_files
+   python_interface
    json_output
    validation
    vibrational_analysis

--- a/mqc_docs/source/python_interface.rst
+++ b/mqc_docs/source/python_interface.rst
@@ -1,0 +1,113 @@
+================
+Python interface
+================
+
+Metalquicha can be driven from Python. The Fortran program still does the
+calculation and still owns MPI; Python sets up the molecule, decides which
+fragments to compute, and reads the answers back.
+
+The division is deliberate. Python runs on rank 0 and nowhere else -- it never
+sees the other ranks and never needs to. When it asks for a calculation, the
+Fortran side distributes the work across the whole job and returns when the
+work is done. So a script that looks single-threaded runs on as many nodes as
+it was launched with, and ``mpirun -np 64 python script.py`` is a valid way to
+start one.
+
+Building it
+===========
+
+The interface loads ``libmqc.so``, which is a separate target from the
+executable:
+
+.. code-block:: bash
+
+   cmake -B build -DMQC_ENABLE_TBLITE=ON -DMQC_ENABLE_LIBCINT=ON
+   cmake --build build --target mqc_shared
+
+Then point Python at it. The package looks for the library next to an in-tree
+``build/`` directory, so this is usually enough:
+
+.. code-block:: bash
+
+   export PYTHONPATH=$PWD/python
+   python3 -c "import mqc; print(mqc.__all__)"
+
+and if the library is elsewhere, ``MQC_LIBRARY`` overrides the search:
+
+.. code-block:: bash
+
+   export MQC_LIBRARY=/path/to/libmqc.so
+
+Which backends are available depends on how the library was built. ``gfn2`` and
+``gfn1`` need ``MQC_ENABLE_TBLITE``; ``hf`` on the CPU needs
+``MQC_ENABLE_LIBCINT``. A method the build does not have fails when it is run,
+not when it is named.
+
+A first calculation
+===================
+
+.. code-block:: python
+
+   import mqc
+
+   with mqc.session():
+       water = mqc.System(
+           symbols=["O", "H", "H"],
+           coords=[[0.0, 0.0, 0.1008],
+                   [0.0, 0.7725, -0.4678],
+                   [0.0, -0.7725, -0.4678]],
+       )
+       water.set_monomers([[0, 1, 2]])
+       result = mqc.MBE(water, level=0, method="gfn2").run(write_to_file=False)
+       print(result.energy)
+
+Everything happens inside ``mqc.session()``. It starts MPI on entry and stops
+it on exit, and outside it there is nothing to talk to.
+
+Note ``set_monomers`` even though nothing is being fragmented. A partition is
+required whether or not the expansion uses one, and ``level=0`` means the whole
+system is computed at once. For a molecule made of separate pieces,
+``auto_monomers()`` finds them; it refuses a single covalently bonded molecule,
+because where to cut such a thing is a chemical decision and not one to guess.
+
+Fragmenting
+===========
+
+.. code-block:: python
+
+   cluster = mqc.System.from_xyz("water20.xyz")
+   cluster.auto_monomers()
+   result = mqc.MBE(cluster, level=2, method="gfn2").run(label="w20")
+
+With exactly two monomers an ``MBE(2)`` is not an approximation -- the
+two-body term cancels the monomer terms and what is left is the supermolecular
+energy. That identity is worth knowing because it is the cheapest available
+test of the fragmentation machinery, and it is what
+``python/examples/backends.py`` checks.
+
+Examples
+========
+
+``python/examples/`` holds runnable scripts, not fragments:
+
+``backends.py``
+   Standalone and fragmented, xTB and Hartree-Fock -- the four paths through
+   the program that the interface can reach. Each case asserts against a
+   reference and the script exits non-zero if any is wrong, so it runs in CI
+   rather than sitting there going quietly stale. The Hartree-Fock references
+   are PySCF; the fragmented cases check the expansion against the same dimer
+   computed whole.
+
+``energy_screened_mbe.py``
+   A two-pass calculation: the whole expansion at a cheap level, then the terms
+   whose contribution exceeded a threshold recomputed with DFT. The criterion
+   is energetic rather than geometric, which is the point -- a distance cutoff
+   discards a strong interaction that happens to be far away.
+
+What it cannot do
+=================
+
+Gradients are not available from the CPU Hartree-Fock backend; it refuses them
+rather than returning something untested. Density fitting is likewise not
+reachable from the Python side yet -- the auxiliary basis is accepted and
+ignored, and the calculation runs with exact integrals.

--- a/python/examples/backends.py
+++ b/python/examples/backends.py
@@ -1,0 +1,162 @@
+"""Every backend the Python interface can reach, on the same two molecules.
+
+    python backends.py            run them all
+    python backends.py xtb        run the ones whose name contains "xtb"
+
+Four cases, because they are four different paths through the program and
+three of them can break without the others noticing:
+
+    standalone xTB      one molecule, tblite
+    standalone HF       one molecule, libcint on the CPU
+    fragmented xTB      MBE(2), tblite per fragment
+    fragmented HF       MBE(2), libcint per fragment
+
+The reference energies for the Hartree-Fock cases come from PySCF on the same
+geometry and basis. The xTB ones come from this program, which is weaker --
+they are there to catch a change, not to prove the physics -- and they are
+marked as such below.
+
+Run as a test rather than a demonstration: each case asserts, and the script
+exits non-zero if any of them is wrong. An example nobody executes stops being
+true without anyone finding out, which is the whole reason this is in CI.
+"""
+
+import sys
+
+import mqc
+
+#: Water, and two waters far enough apart to be separate monomers.
+WATER = dict(
+    symbols=["O", "H", "H"],
+    coords=[[0.0, 0.0, 0.10077199], [0.0, 0.77250895, -0.46780200],
+            [0.0, -0.77250895, -0.46780200]],
+)
+DIMER = dict(
+    symbols=["O", "H", "H", "O", "H", "H"],
+    coords=[[0.0, 0.0, 0.10077199], [0.0, 0.77250895, -0.46780200],
+            [0.0, -0.77250895, -0.46780200],
+            [4.0, 0.0, 0.10077199], [4.0, 0.77250895, -0.46780200],
+            [4.0, -0.77250895, -0.46780200]],
+)
+
+#: PySCF RHF/sto-3g on the WATER geometry above. An external reference: if this
+#: disagrees, one of the two codes is wrong, which is the point.
+HF_WATER_STO3G = -74.962005687948
+
+#: PySCF RHF/sto-3g on the whole DIMER. Not a monomer sum -- see
+#: fragmented_hf() for why that is the reference an MBE(2) must reproduce.
+HF_DIMER_STO3G = -149.922856255009
+
+#: This program's own answer for one water. It checks that nothing changed, not
+#: that anything is right: tblite has no second implementation here to check
+#: against, and a tighter tolerance would be false precision.
+XTB_WATER = -5.070544
+
+TOL_HF = 1.0e-6      # against PySCF
+TOL_XTB = 1.0e-4     # against ourselves; loose on purpose
+TOL_CLOSURE = 1.0e-8 # MBE(2) against the supermolecule; exact, so tight
+
+
+def standalone_xtb():
+    """One molecule through tblite.
+
+    The whole molecule is declared as one monomer. The validator wants a
+    partition whether or not the expansion will use one, and auto_monomers()
+    refuses a single covalently connected molecule -- rightly, since where to
+    cut it is a chemical choice and not something to guess. At level 0 nothing
+    is cut, so saying "all of it, once" is the honest way to ask.
+    """
+    system = mqc.System(**WATER)
+    system.set_monomers([[0, 1, 2]])
+    return mqc.MBE(system, level=0, method="gfn2").run(
+        label="py_standalone_xtb", write_to_file=False).energy
+
+
+def standalone_hf():
+    """One molecule through libcint on the CPU."""
+    system = mqc.System(**WATER)
+    system.set_monomers([[0, 1, 2]])
+    return mqc.MBE(system, level=0, method="hf", basis="sto-3g").run(
+        label="py_standalone_hf", write_to_file=False).energy
+
+
+def fragmented_xtb():
+    """MBE(2) over two monomers against the same dimer computed whole.
+
+    With exactly two monomers the expansion closes:
+
+        E = E_1 + E_2 + (E_12 - E_1 - E_2) = E_12
+
+    so MBE(2) is not an approximation here, it is the supermolecular energy by
+    a longer route. That makes this a real test of the fragmentation machinery
+    -- the partition, the n-body deltas, the assembly -- rather than a recorded
+    constant, and it needs no external reference because both sides come from
+    the same method. Anything but agreement to rounding is a bug in the
+    expansion.
+    """
+    system = mqc.System(**DIMER)
+    system.auto_monomers()
+    fragmented = mqc.MBE(system, level=2, method="gfn2").run(
+        label="py_frag_xtb", write_to_file=False).energy
+
+    whole = mqc.System(**DIMER)
+    whole.set_monomers([[0, 1, 2, 3, 4, 5]])
+    supermolecule = mqc.MBE(whole, level=0, method="gfn2").run(
+        label="py_whole_xtb", write_to_file=False).energy
+    return fragmented, supermolecule
+
+
+def fragmented_hf():
+    """MBE(2) over two monomers, libcint per fragment, against PySCF.
+
+    Same closure as fragmented_xtb: two monomers means the expansion reproduces
+    the dimer exactly. So the reference is PySCF on the whole six-atom dimer --
+    external, and it checks the fragmentation and the CPU SCF together.
+
+    A monomer sum would be the wrong reference and is what this originally
+    used: it omits the interaction, which here is 1.2 millihartree, and the
+    test failed until the reference was corrected rather than the code.
+    """
+    system = mqc.System(**DIMER)
+    system.auto_monomers()
+    return mqc.MBE(system, level=2, method="hf", basis="sto-3g").run(
+        label="py_frag_hf", write_to_file=False).energy
+
+
+def main(argv):
+    pattern = argv[1] if len(argv) > 1 else ""
+    failures = []
+
+    with mqc.session():
+        cases = [
+            ("standalone xtb", standalone_xtb, XTB_WATER, TOL_XTB, "ours"),
+            ("standalone hf", standalone_hf, HF_WATER_STO3G, TOL_HF, "PySCF"),
+            ("fragmented xtb", fragmented_xtb, None, TOL_CLOSURE, "same dimer, whole"),
+            ("fragmented hf", fragmented_hf, HF_DIMER_STO3G, TOL_HF, "PySCF dimer"),
+        ]
+        for name, fn, expected, tol, source in cases:
+            if pattern and pattern not in name:
+                continue
+            energy = fn()
+            if expected is None:
+                # The case returned (fragmented, supermolecule): its reference
+                # is the second, computed in this same run.
+                energy, expected = energy
+            delta = abs(energy - expected)
+            ok = delta <= tol
+            print(f"  {name:<18} {energy:>18.9f}   ref {expected:>18.9f} "
+                  f"({source})   diff {delta:.2e}   {'ok' if ok else 'FAIL'}")
+            if not ok:
+                failures.append(f"{name}: {energy} vs {expected}, diff {delta:.2e} > {tol:.1e}")
+
+    if failures:
+        print("\nFAILED:")
+        for f in failures:
+            print("  " + f)
+        return 1
+    print("\nall backends agree with their references")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
Nothing here has ever loaded libmqc.so. No workflow builds mqc_shared, no test imports the package, and the three files under python/ have been unverified since they landed. That is the wrong layer to leave uncovered: a renamed C entry point or a changed signature compiles perfectly and segfaults at call time, and ctypes will not warn about either.

python/examples/backends.py covers the four paths the interface can reach -- standalone and fragmented, xTB and Hartree-Fock -- and asserts rather than prints, so it can run in CI. An example nobody executes stops being true without anyone finding out, which is how the two in this file were written wrong to begin with.

  standalone xtb    -5.070544354   diff 3.5e-07  vs ours
  standalone hf    -74.962005712   diff 2.4e-08  vs PySCF
  fragmented xtb   -10.139833055   diff 0.0e+00  vs the same dimer, whole
  fragmented hf   -149.922856304   diff 4.9e-08  vs PySCF on the dimer

The fragmented cases are worth explaining. Both first compared against a monomer sum, which is not what an MBE(2) returns, and both failed. With exactly two monomers the expansion closes -- E_1 + E_2 + (E_12 - E_1 - E_2) = E_12 -- so the correct reference is the supermolecule, and the interaction energy the monomer sum omits was the 1.2 millihartree they were failing by. Corrected, the xTB case reproduces the whole dimer bit for bit and the Hartree-Fock one matches PySCF to 4.9e-8.

That identity makes these real tests of the partition, the n-body deltas and the assembly rather than recorded constants. The xTB case needs no external reference at all, since both sides come from the same method.

Two things the interface does that are worth writing down, because both cost time to discover: an unfragmented run still needs a partition declared, and auto_monomers() refuses a single covalently bonded molecule -- correctly, since where to cut one is a chemical choice. The documentation says so.

Also recorded there: the CPU backend has no gradients and ignores the auxiliary basis, so a deck asking for density fitting gets exact integrals instead.