### PR TITLE
make density fitting reachable, and stop losing backend errors

### DIFF
--- a/backends/libcint/mqc_libcint_bridge.f90
+++ b/backends/libcint/mqc_libcint_bridge.f90
@@ -43,7 +43,7 @@ contains
       type(calculation_result_t), intent(inout) :: result
       logical, intent(in), optional :: want_gradient
 
-      type(libcint_molecule_t) :: mol
+      type(libcint_molecule_t) :: mol, aux
       type(rhf_result_t) :: scf
       type(error_t) :: error
       character(len=MAX_ELEMENT_SYMBOL_LEN), allocatable :: symbols(:)
@@ -85,9 +85,31 @@ contains
       diis_size = settings%diis_size
       if (.not. settings%use_diis) diis_size = 0
 
-      call run_libcint_rhf(mol, fragment%nelec, settings%max_iter, settings%energy_tol, &
-                           settings%density_tol, settings%verbose, scf, error, &
-                           diis_vectors=diis_size)
+      ! Density fitting is asked for, not inferred. aux_basis_set carries a
+      ! default, so treating its presence as the request would mean every
+      ! calculation quietly fitted -- and the difference is 5e-5 Hartree, large
+      ! enough to matter and small enough to look like convergence noise.
+      if (settings%density_fitting) then
+         call build_libcint_molecule(fragment%element_numbers, symbols, &
+                                     fragment%coordinates, trim(settings%aux_basis_set), &
+                                     aux, error)
+         if (error%has_error()) then
+            call result%error%set(ERROR_VALIDATION, "auxiliary basis '"// &
+                                  trim(settings%aux_basis_set)//"': "//error%get_message())
+            result%has_error = .true.
+            call mol%destroy()
+            return
+         end if
+
+         call run_libcint_rhf(mol, fragment%nelec, settings%max_iter, settings%energy_tol, &
+                              settings%density_tol, settings%verbose, scf, error, &
+                              aux=aux, diis_vectors=diis_size)
+         call aux%destroy()
+      else
+         call run_libcint_rhf(mol, fragment%nelec, settings%max_iter, settings%energy_tol, &
+                              settings%density_tol, settings%verbose, scf, error, &
+                              diis_vectors=diis_size)
+      end if
       if (error%has_error()) then
          call result%error%set(ERROR_VALIDATION, error%get_message())
          result%has_error = .true.

--- a/mqc_docs/source/python_interface.rst
+++ b/mqc_docs/source/python_interface.rst
@@ -70,6 +70,28 @@ system is computed at once. For a molecule made of separate pieces,
 ``auto_monomers()`` finds them; it refuses a single covalently bonded molecule,
 because where to cut such a thing is a chemical decision and not one to guess.
 
+Density fitting
+===============
+
+Hartree-Fock on the CPU can fit J and K against an auxiliary basis instead of
+computing exact four-index integrals:
+
+.. code-block:: python
+
+   mqc.MBE(water, level=0, method="hf", basis="sto-3g",
+           aux_basis="def2-universal-jkfit", density_fitting=True)
+
+It has to be asked for. Setting ``aux_basis`` alone does not turn it on,
+because that name carries a default -- inferring the request from its presence
+would mean every Hartree-Fock quietly fitted. The difference on water/sto-3g is
+8.6e-5 Hartree: large enough to matter, small enough to be mistaken for
+convergence noise.
+
+cuEST is the other way round. It has no four-index path at all, so it fits
+whether or not the flag is set, and the flag is ignored there.
+
+In a deck the same switch is ``keywords.scf.density_fitting``.
+
 Fragmenting
 ===========
 
@@ -107,7 +129,17 @@ Examples
 What it cannot do
 =================
 
-Gradients are not available from the CPU Hartree-Fock backend; it refuses them
-rather than returning something untested. Density fitting is likewise not
-reachable from the Python side yet -- the auxiliary basis is accepted and
-ignored, and the calculation runs with exact integrals.
+Gradients are not available from the CPU Hartree-Fock backend. libcint has the
+derivative entry points, so this is a gap rather than a wall, but an untested
+gradient is worse than an absent one -- so it raises:
+
+.. code-block:: python
+
+   >>> mqc.MBE(water, level=0, method="hf", driver="gradient").run()
+   MQCError: the CPU backend has no gradients yet; run an energy, or build with cuEST
+
+xTB gradients work normally, and so do cuEST's. Only the CPU Hartree-Fock path
+refuses.
+
+The CPU backend is also closed-shell only: an unrestricted reference is refused
+in the same way rather than approximated.

--- a/python/examples/backends.py
+++ b/python/examples/backends.py
@@ -43,6 +43,12 @@ DIMER = dict(
 #: disagrees, one of the two codes is wrong, which is the point.
 HF_WATER_STO3G = -74.962005687948
 
+#: PySCF density-fitted RHF/sto-3g, def2-universal-jkfit, on WATER. Fitting is
+#: an approximation, so this differs from the exact number by 8.6e-5 -- which
+#: is the point: a wired-up fitting path must reproduce the fitted reference,
+#: not the exact one.
+HF_WATER_STO3G_DF = -74.962092123400
+
 #: PySCF RHF/sto-3g on the whole DIMER. Not a monomer sum -- see
 #: fragmented_hf() for why that is the reference an MBE(2) must reproduce.
 HF_DIMER_STO3G = -149.922856255009
@@ -78,6 +84,44 @@ def standalone_hf():
     system.set_monomers([[0, 1, 2]])
     return mqc.MBE(system, level=0, method="hf", basis="sto-3g").run(
         label="py_standalone_hf", write_to_file=False).energy
+
+
+def standalone_hf_df():
+    """One molecule, density-fitted J and K on the CPU."""
+    system = mqc.System(**WATER)
+    system.set_monomers([[0, 1, 2]])
+    return mqc.MBE(system, level=0, method="hf", basis="sto-3g",
+                   aux_basis="def2-universal-jkfit", density_fitting=True).run(
+        label="py_standalone_hf_df", write_to_file=False).energy
+
+
+def gradient_support():
+    """Gradients work through tblite and are refused by libcint.
+
+    Not a limitation being papered over -- the CPU backend says so and stops,
+    which is the right behaviour for a derivative nobody has tested. What this
+    checks is that it stays a clean refusal rather than becoming a wrong
+    number, and that asking xTB for the same thing still works.
+    """
+    system = mqc.System(**WATER)
+    system.set_monomers([[0, 1, 2]])
+
+    refused = False
+    try:
+        mqc.MBE(system, level=0, method="hf", basis="sto-3g", driver="gradient").run(
+            label="py_grad_hf", write_to_file=False)
+    except mqc.MQCError as exc:
+        refused = "gradient" in str(exc).lower()
+
+    worked = False
+    try:
+        mqc.MBE(system, level=0, method="gfn2", driver="gradient").run(
+            label="py_grad_xtb", write_to_file=False)
+        worked = True
+    except mqc.MQCError:
+        worked = False
+
+    return refused, worked
 
 
 def fragmented_xtb():
@@ -131,6 +175,7 @@ def main(argv):
         cases = [
             ("standalone xtb", standalone_xtb, XTB_WATER, TOL_XTB, "ours"),
             ("standalone hf", standalone_hf, HF_WATER_STO3G, TOL_HF, "PySCF"),
+            ("standalone hf/df", standalone_hf_df, HF_WATER_STO3G_DF, TOL_HF, "PySCF fitted"),
             ("fragmented xtb", fragmented_xtb, None, TOL_CLOSURE, "same dimer, whole"),
             ("fragmented hf", fragmented_hf, HF_DIMER_STO3G, TOL_HF, "PySCF dimer"),
         ]
@@ -148,6 +193,13 @@ def main(argv):
                   f"({source})   diff {delta:.2e}   {'ok' if ok else 'FAIL'}")
             if not ok:
                 failures.append(f"{name}: {energy} vs {expected}, diff {delta:.2e} > {tol:.1e}")
+
+        refused, worked = gradient_support()
+        print(f"  {'gradients':<18} libcint refuses: {refused}   tblite provides: {worked}")
+        if not refused:
+            failures.append("the CPU backend must refuse gradients, not return one")
+        if not worked:
+            failures.append("tblite must still provide gradients")
 
     if failures:
         print("\nFAILED:")

--- a/python/mqc/__init__.py
+++ b/python/mqc/__init__.py
@@ -456,6 +456,8 @@ class MBE:
         level=2,
         method="gfn2",
         basis=None,
+        aux_basis=None,
+        density_fitting=False,
         functional=None,
         driver="Energy",
         cutoffs=None,
@@ -470,6 +472,8 @@ class MBE:
         self.level = int(level)
         self.method = method
         self.basis = basis
+        self.aux_basis = aux_basis
+        self.density_fitting = density_fitting
         self.functional = functional
         self.driver = driver
         self.cutoffs = dict(cutoffs) if cutoffs else None
@@ -495,6 +499,8 @@ class MBE:
         model = {"method": self.method}
         if self.basis:
             model["basis"] = self.basis
+        if self.aux_basis:
+            model["aux_basis"] = self.aux_basis
         if self.functional:
             model["functional"] = self.functional
 
@@ -504,6 +510,12 @@ class MBE:
             # right magnitude, so the run must stop rather than quietly fold it
             # into the total; this says "I know, keep going, tell me at the end".
             scf["allow_crap_scf"] = True
+        if self.density_fitting:
+            # Asked for, never inferred from aux_basis being set: that name
+            # carries a default, so inferring would mean every Hartree-Fock
+            # quietly fitted. The difference is around 5e-5 Hartree -- big
+            # enough to matter, small enough to pass for convergence noise.
+            scf["density_fitting"] = True
 
         fragmentation = {"method": "MBE", "level": self.level}
         if self.cutoffs:

--- a/src/interface/mqc_capi_run.f90
+++ b/src/interface/mqc_capi_run.f90
@@ -132,6 +132,18 @@ contains
          return
       end if
 
+      ! A failure inside a fragment lands on the result, not on the session
+      ! error: the driver keeps going so it can report every bad term at the
+      ! end rather than the first. Checking only `error` therefore returned
+      ! MQC_OK with whatever total had accumulated -- for a gradient the CPU
+      ! backend refuses, that was a clean 0.0 handed back as a success, which
+      ! is the worst shape a failure can take.
+      if (result%has_error) then
+         last_message = result%error%get_message()
+         status = MQC_ERROR
+         return
+      end if
+
       energy = real(result%energy%total(), c_double)
       status = MQC_OK
    end function mqc_run

--- a/src/io/mqc_config_adapter.f90
+++ b/src/io/mqc_config_adapter.f90
@@ -161,6 +161,7 @@ contains
       end if
       driver_config%method_config%scf%allow_crap_scf = mqc_config%allow_crap_scf
       driver_config%method_config%scf%unrestricted = mqc_config%scf_unrestricted
+      driver_config%method_config%scf%density_fitting = mqc_config%scf_density_fitting
       if (allocated(mqc_config%scf_guess)) then
          driver_config%method_config%scf%guess = mqc_config%scf_guess
       end if

--- a/src/io/mqc_config_types.f90
+++ b/src/io/mqc_config_types.f90
@@ -84,6 +84,8 @@ module mqc_config_types
          !! Initial guess name from %scf
       logical :: scf_unrestricted = .false.
       logical :: allow_crap_scf = .false.
+      logical :: scf_density_fitting = .false.
+         !! Fit J and K against the auxiliary basis, on the CPU backend
          !! Let a non-converged SCF into the expansion instead of stopping.
          !! Off by default: the energy of an SCF that ran out of iterations is
          !! of the right magnitude and nothing downstream can tell, so silence

--- a/src/io/mqc_json_config_reader.f90
+++ b/src/io/mqc_json_config_reader.f90
@@ -187,6 +187,8 @@ contains
       call optional_logical(json, "keywords.scf.unrestricted", config%scf_unrestricted)
       call optional_string(json, "keywords.scf.guess", config%scf_guess)
       call optional_logical(json, "keywords.scf.allow_crap_scf", config%allow_crap_scf)
+      call optional_logical(json, "keywords.scf.density_fitting", &
+                            config%scf_density_fitting)
 
       ! Both spellings of the displacement key are accepted, as the JSON
       ! generator used to allow.

--- a/src/io/mqc_json_schema.f90
+++ b/src/io/mqc_json_schema.f90
@@ -185,6 +185,7 @@ contains
       call allow(keys, "unrestricted")
       call allow(keys, "guess")
       call allow(keys, "allow_crap_scf")
+      call allow(keys, "density_fitting")
    end function scf_keys
 
    function hessian_keys() result(keys)

--- a/src/methods/mqc_cuest_iface.f90
+++ b/src/methods/mqc_cuest_iface.f90
@@ -21,6 +21,8 @@ module mqc_cuest_iface
       character(len=32) :: basis_set = "sto-3g"
          !! Orbital basis set name
       character(len=32) :: aux_basis_set = "def2-universal-jkfit"
+      logical :: density_fitting = .false.
+         !! Read by the CPU backend only; cuEST always fits.
          !! Auxiliary (JKFIT) basis. Required: cuEST fits J and K always.
       character(len=32) :: functional = ""
          !! Exchange-correlation functional; empty means Hartree-Fock

--- a/src/methods/mqc_method_config.f90
+++ b/src/methods/mqc_method_config.f90
@@ -39,6 +39,14 @@ module mqc_method_config
          !! Auxiliary (JKFIT) basis for the density-fitted J and K.
          !! Required, not optional, for the cuEST backend: cuEST exposes no
          !! conventional four-index ERI path, so J/K are always fitted.
+      logical :: density_fitting = .false.
+         !! Fit J and K against `aux_basis_set` on the CPU backend.
+         !!
+         !! Off by default, and only the CPU backend reads it: cuEST has no
+         !! four-index path, so it fits whether or not this is set. libcint has
+         !! both, so which one runs has to be asked for rather than inferred
+         !! from an auxiliary basis being present -- that name carries a
+         !! default, so inferring would mean every calculation silently fitted.
    end type scf_config_t
 
    !============================================================================

--- a/src/methods/mqc_method_factory.F90
+++ b/src/methods/mqc_method_factory.F90
@@ -142,6 +142,7 @@ contains
 
       ! SCF settings from shared config%scf
       m%options%aux_basis_set = config%scf%aux_basis_set
+      m%options%density_fitting = config%scf%density_fitting
       m%options%unrestricted = config%scf%unrestricted
       m%options%guess = config%scf%guess
       m%options%max_iter = config%scf%max_iter

--- a/src/methods/mqc_method_hf.F90
+++ b/src/methods/mqc_method_hf.F90
@@ -30,6 +30,8 @@ module mqc_method_hf
          !! Orbital basis set name
       character(len=32) :: aux_basis_set = "def2-universal-jkfit"
          !! Auxiliary (JKFIT) basis for the density-fitted J and K
+      logical :: density_fitting = .false.
+         !! Fit J and K rather than computing exact integrals (CPU backend)
       logical :: spherical = .true.
          !! Use spherical (true) or Cartesian (false) basis
       logical :: verbose = .false.
@@ -86,6 +88,7 @@ contains
 
       settings%basis_set = this%options%basis_set
       settings%aux_basis_set = this%options%aux_basis_set
+      settings%density_fitting = this%options%density_fitting
       settings%functional = ""        ! empty selects pure Hartree-Fock
       settings%spherical = this%options%spherical
       settings%verbose = this%options%verbose


### PR DESCRIPTION
Two things, found together because the second only shows up once the first works.

Density fitting was unreachable from a deck or from Python. run_libcint_rhf has taken an optional `aux` argument since the density-fitting branch, and mqc_libcint_bridge never passed it, so only check_df ever exercised the path. A deck asking for an auxiliary basis got exact integrals and no indication that it had. Wired through as keywords.scf.density_fitting, and as density_fitting=True in the Python MBE.

Asked for, not inferred. aux_basis_set carries a default, so treating its presence as the request would mean every Hartree-Fock quietly fitted -- and the difference is 8.6e-5 Hartree on water/sto-3g, large enough to matter and small enough to pass for convergence noise. cuEST is the opposite and ignores the flag: it has no four-index path, so it fits either way.

Checked against PySCF's fitted answer rather than its exact one, which is the distinction that says the wiring works:

  exact    -74.962005712   vs PySCF exact   -74.962005688
  fitted   -74.962092147   vs PySCF fitted  -74.962092123

Before this, both decks returned the first number.

The second thing is worse. Asking the CPU backend for a gradient returned energy 0.0 through the C API with status MQC_OK -- no exception in Python, no indication of failure, a zero handed back as an answer. mqc_run checked the session error, but a failure inside a fragment lands on the result: the driver keeps going so it can report every bad term at the end rather than the first, and nothing was looking at result%has_error. It now raises with the message the backend actually produced.

python/examples/backends.py grows a fitted case and a gradient case. The gradient one asserts both halves of what was asked for -- libcint refuses, tblite still provides -- because "it fails" and "it fails cleanly" are different properties and only the second is worth having.

45/45, both CPU validation decks pass, docs updated.