### PR TITLE
ignore CMake build trees under any name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,21 @@ output_*_fragments.csv
 # Out-of-source build directories
 build*/
 
+# CMake build trees under any name.
+#
+# The rules above match on the directory being called build-something. That is
+# most of them and not all of them: a scratch tree called `tip` or `v1` is
+# invisible to a name-based rule, and `git add -A` in a repository containing
+# one stages tens of thousands of files from _deps/ -- including whole cloned
+# dependencies, which git records as embedded repositories rather than
+# refusing. So match on what a build tree contains instead of what it is
+# called. None of these are ever authored by hand.
+**/CMakeCache.txt
+**/CMakeFiles/
+**/_deps/
+**/cmake_install.cmake
+**/CTestTestfile.cmake
+
 # profiling / scratch
 *.nsys-rep
 *.sqlite


### PR DESCRIPTION
The existing rules match a directory called build-something. That covers most build trees and not all of them: a scratch tree called `tip` or `v1` is invisible to a name-based rule.

That is not theoretical. Running `git add -A` in a worktree holding eight such trees staged 27035 paths, including six cloned dependencies that git records as embedded repositories rather than refusing. It was caught before anything was pushed, but only because the warnings were read.

So match on what a build tree contains rather than what it is called -- CMakeCache.txt, CMakeFiles/, _deps/, cmake_install.cmake, CTestTestfile.cmake. None of those are ever written by hand, and none are tracked on any branch today, checked before adding the rules.

This does not make `git add -A` safe. It makes one common way of getting it wrong harmless. `git add -u` stages modifications to tracked files only and cannot pick up an untracked directory at all, which is the habit worth having.