### PR TITLE
Add RI-MP2

### DIFF
--- a/backends/libcint/mqc_libcint_bridge.f90
+++ b/backends/libcint/mqc_libcint_bridge.f90
@@ -13,6 +13,7 @@ module mqc_libcint_bridge
    !! about the integrals cares which atoms were in the original molecule --
    !! the redistribution of forces back onto the heavy atoms happens later and
    !! elsewhere.
+   use pic_logger, only: logger => global_logger
    use pic_types, only: dp
    use mqc_physical_fragment, only: physical_fragment_t
    use mqc_result_types, only: calculation_result_t, SCF_CONVERGED, SCF_NOT_CONVERGED
@@ -22,7 +23,7 @@ module mqc_libcint_bridge
    use mqc_cuest_iface, only: cuest_scf_settings_t
    use mqc_libcint_integrals, only: libcint_molecule_t, build_libcint_molecule
    use mqc_libcint_rhf, only: rhf_result_t, run_libcint_rhf, run_libcint_uhf
-   use mqc_libcint_mp2, only: mp2_result_t, run_libcint_mp2
+   use mqc_libcint_mp2, only: mp2_result_t, run_libcint_mp2, run_libcint_ri_mp2
    implicit none
    private
 
@@ -44,7 +45,7 @@ contains
       type(calculation_result_t), intent(inout) :: result
       logical, intent(in), optional :: want_gradient
 
-      type(libcint_molecule_t) :: mol, aux
+      type(libcint_molecule_t) :: mol, aux, corr_aux
       type(rhf_result_t) :: scf
       type(error_t) :: error
       character(len=MAX_ELEMENT_SYMBOL_LEN), allocatable :: symbols(:)
@@ -178,9 +179,23 @@ contains
             if (frozen < 0) frozen = core_orbital_count(fragment%element_numbers)
             if (.not. settings%freeze_core) frozen = 0
 
-            call run_libcint_mp2(mol, scf%orbitals, scf%orbital_energies, &
-                                 fragment%nelec/2, scf%energy, mp2, error, &
-                                 n_frozen=frozen)
+            if (settings%corr_density_fitting) then
+               call correlation_aux_basis(settings, fragment, symbols, corr_aux, error)
+               if (error%has_error()) then
+                  call result%error%set(ERROR_VALIDATION, error%get_message())
+                  result%has_error = .true.
+                  call mol%destroy()
+                  return
+               end if
+               call run_libcint_ri_mp2(mol, corr_aux, scf%orbitals, scf%orbital_energies, &
+                                       fragment%nelec/2, scf%energy, mp2, error, &
+                                       n_frozen=frozen)
+               call corr_aux%destroy()
+            else
+               call run_libcint_mp2(mol, scf%orbitals, scf%orbital_energies, &
+                                    fragment%nelec/2, scf%energy, mp2, error, &
+                                    n_frozen=frozen)
+            end if
             if (error%has_error()) then
                call result%error%set(ERROR_VALIDATION, "MP2: "//error%get_message())
                result%has_error = .true.
@@ -239,6 +254,46 @@ contains
       write (buffer, "(i0)") value
       out = trim(adjustl(buffer))
    end function to_text
+
+   subroutine correlation_aux_basis(settings, fragment, symbols, aux, error)
+      !! Build the auxiliary basis the correlation step will fit with
+      !!
+      !! Whatever the deck names is used, including sets that have no business
+      !! fitting a (ia|jb) block -- a JKFIT set is fitted for the Coulomb and
+      !! exchange matrices and will give a correlation energy whose error is
+      !! not the RI error it is supposed to be. That is a warning rather than a
+      !! refusal: someone comparing against another program's default, or
+      !! probing how bad it gets, has a real reason to ask for it, and the run
+      !! is not wrong so much as poorly fitted.
+      !!
+      !! `keywords.correlation.aux_basis` is what this reads. It falls back to
+      !! `model.aux_basis` so a deck that already names one for a fitted SCF
+      !! does not have to repeat it -- and that fallback is exactly the case
+      !! the warning is for, since an SCF auxiliary is usually JKFIT.
+      type(cuest_scf_settings_t), intent(in) :: settings
+      type(physical_fragment_t), intent(in) :: fragment
+      character(len=*), intent(in) :: symbols(:)
+      type(libcint_molecule_t), intent(out) :: aux
+      type(error_t), intent(inout) :: error
+
+      character(len=:), allocatable :: name
+
+      name = trim(settings%corr_aux_basis)
+      if (len_trim(name) == 0) name = trim(settings%aux_basis_set)
+      if (len_trim(name) == 0) then
+         call error%set(ERROR_VALIDATION, "density-fitted correlation needs an "// &
+                        "auxiliary basis: set keywords.correlation.aux_basis")
+         return
+      end if
+
+      if (index(name, "rifit") == 0 .and. index(name, "-ri") == 0) then
+         call logger%warning("bad basis set, calculations will be poor: '"//name// &
+                             "' is not a correlation-fitting (RIFIT) set")
+      end if
+
+      call build_libcint_molecule(fragment%element_numbers, symbols, &
+                                  fragment%coordinates, name, aux, error)
+   end subroutine correlation_aux_basis
 
    pure function core_orbital_count(atomic_numbers) result(n_core)
       !! How many orbitals a frozen core leaves out, summed over the atoms

--- a/backends/libcint/mqc_libcint_integrals.f90
+++ b/backends/libcint/mqc_libcint_integrals.f90
@@ -57,6 +57,7 @@ module mqc_libcint_integrals
    public :: libcint_molecule_t
    public :: build_libcint_molecule
    public :: build_df_tensor
+   public :: build_df_mo_tensor
    ! The one place that maps "is this basis Cartesian?" onto libcint's two sets
    ! of entry points. Exported because the direct Fock build needs the same
    ! mapping, and two copies of it is two chances to route half the calls.
@@ -523,6 +524,28 @@ contains
       call two_centre(aux, metric)
       call three_centre(orb, aux, three)
 
+      call metric_inverse_sqrt(metric, half, error)
+      if (error%has_error()) return
+
+      allocate (b(nao*nao, naux))
+      call pic_gemm(three, half, b)
+   end subroutine build_df_tensor
+
+   subroutine metric_inverse_sqrt(metric, half, error)
+      !! J^(-1/2) = U s^(-1/2) U^T over the modes that survive the threshold
+      !!
+      !! Through the eigendecomposition rather than a Cholesky. A JKFIT or
+      !! RIFIT set is close to linearly dependent by construction, and a
+      !! Cholesky of a near-singular metric fails outright where this degrades.
+      real(dp), intent(in) :: metric(:, :)
+      real(dp), allocatable, intent(out) :: half(:, :)
+      type(error_t), intent(inout) :: error
+
+      real(dp), parameter :: NULL_THRESHOLD = 1.0e-10_dp
+      real(dp), allocatable :: vectors(:, :), values(:)
+      integer :: naux, i, j, kept, info
+
+      naux = size(metric, 1)
       allocate (vectors(naux, naux), values(naux))
       vectors = metric
       call pic_syev(vectors, values, jobz="V", uplo="U", info=info)
@@ -537,7 +560,6 @@ contains
          return
       end if
 
-      ! J^(-1/2) = U s^(-1/2) U^T over the surviving modes.
       allocate (half(naux, naux))
       half = 0.0_dp
       do i = 1, naux
@@ -546,10 +568,85 @@ contains
             half(:, j) = half(:, j) + vectors(:, i)*vectors(j, i)/sqrt(values(i))
          end do
       end do
+   end subroutine metric_inverse_sqrt
 
-      allocate (b(nao*nao, naux))
-      call pic_gemm(three, half, b)
-   end subroutine build_df_tensor
+   subroutine build_df_mo_tensor(orb, aux, c_occ, c_vir, bia, error)
+      !! B^P_ia directly, transforming to MO before fitting rather than after
+      !!
+      !! `build_df_tensor` fits first and hands back B(mu nu, P), which is what
+      !! a Fock build wants because it contracts against a density in the AO
+      !! basis. A correlation treatment does not: it only ever reads the
+      !! occupied-virtual block, and fitting the whole AO pair space to get
+      !! there is most of the work thrown away.
+      !!
+      !! The metric contraction is where it shows. Applied to the AO tensor it
+      !! is nao^2 by naux by naux; applied after the transform it is
+      !! n_occ*n_vir by naux by naux. On a water hexamer in cc-pVDZ that is
+      !! 20736 pair functions against 2736, so the same gemm costs 7.6 times
+      !! less for the same answer.
+      !!
+      !! The result is laid out (n_vir, naux, n_occ) so that one occupied
+      !! orbital's block is contiguous, which is the shape the energy step
+      !! hands to BLAS.
+      type(libcint_molecule_t), intent(in) :: orb, aux
+      real(dp), intent(in) :: c_occ(:, :)   !! (nao, n_occ), correlated occupied only
+      real(dp), intent(in) :: c_vir(:, :)   !! (nao, n_vir)
+      real(dp), allocatable, intent(out) :: bia(:, :, :)
+      type(error_t), intent(inout) :: error
+
+      real(dp), allocatable :: metric(:, :), half(:, :), three(:, :)
+      real(dp), allocatable :: ovl(:, :), bp(:, :), tmp(:, :), full(:, :)
+      integer :: nao, naux, n_o, n_v, p_index, i
+
+      if (orb%cartesian .neqv. aux%cartesian) then
+         call error%set(ERROR_VALIDATION, "density fitting: the orbital basis is "// &
+                        angular_form_name(orb%cartesian)//" and the auxiliary basis is "// &
+                        angular_form_name(aux%cartesian)//". libcint builds all three "// &
+                        "centres of a fitting integral in one form, so the two must "// &
+                        "agree; choose an auxiliary basis of the same kind.")
+         return
+      end if
+
+      nao = orb%nao
+      naux = aux%nao
+      n_o = size(c_occ, 2)
+      n_v = size(c_vir, 2)
+
+      call two_centre(aux, metric)
+      call metric_inverse_sqrt(metric, half, error)
+      if (error%has_error()) return
+      deallocate (metric)
+
+      call three_centre(orb, aux, three)
+
+      ! (mu nu|P) -> (ia|P), one auxiliary function at a time.
+      allocate (ovl(n_o*n_v, naux))
+      allocate (bp(nao, nao), tmp(n_o, nao), full(n_o, n_v))
+      do p_index = 1, naux
+         bp = reshape(three(:, p_index), [nao, nao])
+         call pic_gemm(c_occ, bp, tmp, transa="T")
+         call pic_gemm(tmp, c_vir, full)
+         ovl(:, p_index) = reshape(full, [n_o*n_v])
+      end do
+      deallocate (bp, tmp, full, three)
+
+      ! The fit, now over the occupied-virtual block instead of every AO pair.
+      block
+         real(dp), allocatable :: fitted(:, :)
+         allocate (fitted(n_o*n_v, naux))
+         call pic_gemm(ovl, half, fitted)
+         deallocate (ovl, half)
+         allocate (bia(n_v, naux, n_o))
+         do p_index = 1, naux
+            do i = 1, n_o
+               ! `fitted` is flattened (i, a), so one occupied orbital's
+               ! virtuals sit at stride n_o.
+               bia(:, p_index, i) = fitted(i::n_o, p_index)
+            end do
+         end do
+         deallocate (fitted)
+      end block
+   end subroutine build_df_mo_tensor
 
    subroutine two_centre(aux, metric)
       !! (P|Q) over the auxiliary basis

--- a/backends/libcint/mqc_libcint_mp2.f90
+++ b/backends/libcint/mqc_libcint_mp2.f90
@@ -34,11 +34,12 @@ module mqc_libcint_mp2
    use pic_types, only: dp
    use pic_blas_interfaces, only: pic_gemm
    use mqc_error, only: error_t, ERROR_VALIDATION
-   use mqc_libcint_integrals, only: libcint_molecule_t
+   use mqc_libcint_integrals, only: libcint_molecule_t, build_df_tensor
    implicit none
    private
 
    public :: run_libcint_mp2
+   public :: run_libcint_ri_mp2
    public :: mp2_result_t
 
    type :: mp2_result_t
@@ -137,6 +138,119 @@ contains
       result%n_occupied = n_o
       result%n_virtual = n_v
    end subroutine run_libcint_mp2
+
+   subroutine run_libcint_ri_mp2(mol, aux, coeff, orbital_energies, n_occ, scf_energy, &
+                                 result, error, n_frozen)
+      !! E(2) from a fitted (ia|jb), never forming the four-index tensor
+      !!
+      !! `build_df_tensor` already returns B(mu nu, P) with the inverse-root
+      !! metric folded in, which is exactly the object this needs:
+      !!
+      !!     (ia|jb) = sum_P B^P_ia B^P_jb
+      !!
+      !! So the work is a transform of the AO pair index into (occupied,
+      !! virtual) and then one gemm per occupied pair. The saving over the
+      !! conventional route is where the memory goes: n_occ*n_vir*n_aux held
+      !! here against the n^4 tensor and its n_occ*n^3 intermediate there. For
+      !! water in cc-pVDZ that is kilobytes against megabytes, and the gap is
+      !! two powers of the system size.
+      !!
+      !! The error against conventional MP2 is the fitting error and nothing
+      !! else -- typically a few tenths of a millihartree with a matched RIFIT
+      !! set, and much worse with a JKFIT one, which is fitted for the Coulomb
+      !! and exchange blocks rather than for this.
+      type(libcint_molecule_t), intent(in) :: mol
+      type(libcint_molecule_t), intent(in) :: aux    !! Auxiliary basis, same atoms
+      real(dp), intent(in) :: coeff(:, :)
+      real(dp), intent(in) :: orbital_energies(:)
+      integer, intent(in) :: n_occ
+      real(dp), intent(in) :: scf_energy
+      type(mp2_result_t), intent(out) :: result
+      type(error_t), intent(inout) :: error
+      integer, intent(in), optional :: n_frozen
+
+      real(dp), allocatable :: b(:, :), bia(:, :, :), g(:, :)
+      real(dp), allocatable :: c_occ(:, :), c_vir(:, :), bp(:, :), half(:, :)
+      integer :: n_ao, n_mo, n_o, n_v, n_aux, frozen
+      integer :: i, j, a, bb, p_index
+      real(dp) :: iajb, ibja, denom, e_ss, e_os
+
+      n_ao = mol%nao
+      n_mo = size(coeff, 2)
+
+      frozen = 0
+      if (present(n_frozen)) frozen = n_frozen
+      if (frozen < 0 .or. frozen >= n_occ) then
+         call error%set(ERROR_VALIDATION, "RI-MP2: the frozen core must leave at "// &
+                        "least one occupied orbital to correlate")
+         return
+      end if
+
+      n_o = n_occ - frozen
+      n_v = n_mo - n_occ
+      if (n_v < 1) then
+         call error%set(ERROR_VALIDATION, "RI-MP2: no virtual orbitals")
+         return
+      end if
+
+      call build_df_tensor(mol, aux, b, error)
+      if (error%has_error()) return
+      n_aux = size(b, 2)
+
+      allocate (c_occ(n_ao, n_o), c_vir(n_ao, n_v))
+      c_occ = coeff(:, frozen + 1:n_occ)
+      c_vir = coeff(:, n_occ + 1:n_mo)
+
+      ! B^P_ia, laid out so that one occupied orbital's block is contiguous:
+      ! the energy step wants (n_v, n_aux) slices to hand straight to a gemm.
+      allocate (bia(n_v, n_aux, n_o))
+      allocate (bp(n_ao, n_ao), half(n_o, n_ao))
+      block
+         real(dp), allocatable :: full(:, :)
+         allocate (full(n_o, n_v))
+         do p_index = 1, n_aux
+            bp = reshape(b(:, p_index), [n_ao, n_ao])
+            call pic_gemm(c_occ, bp, half, transa="T")
+            call pic_gemm(half, c_vir, full)
+            do i = 1, n_o
+               bia(:, p_index, i) = full(i, :)
+            end do
+         end do
+         deallocate (full)
+      end block
+      deallocate (bp, half, b, c_occ, c_vir)
+
+      ! One gemm per occupied pair rebuilds that pair's whole (a,b) block:
+      ! g(a,b) = sum_P B^P_ia B^P_jb, which is (ia|jb), and g(b,a) is (ib|ja).
+      allocate (g(n_v, n_v))
+      e_ss = 0.0_dp
+      e_os = 0.0_dp
+      do i = 1, n_o
+         do j = 1, n_o
+            call pic_gemm(bia(:, :, i), bia(:, :, j), g, transb="T")
+            do bb = 1, n_v
+               do a = 1, n_v
+                  iajb = g(a, bb)
+                  ibja = g(bb, a)
+                  denom = orbital_energies(frozen + i) + orbital_energies(frozen + j) &
+                          - orbital_energies(n_occ + a) - orbital_energies(n_occ + bb)
+                  e_os = e_os + iajb*iajb/denom
+                  e_ss = e_ss + iajb*(iajb - ibja)/denom
+               end do
+            end do
+         end do
+      end do
+      deallocate (g, bia)
+
+      result%same_spin = e_ss
+      result%opposite_spin = e_os
+      result%correlation = e_ss + e_os
+      result%scf_energy = scf_energy
+      result%total = scf_energy + result%correlation
+      result%n_frozen = frozen
+      result%n_occupied = n_o
+      result%n_virtual = n_v
+   end subroutine run_libcint_ri_mp2
 
    subroutine transform_ovov(eri, coeff, frozen, n_occ, n_ao, n_mo, ovov)
       !! (mu nu|la si) -> (ia|jb), one index at a time

--- a/backends/libcint/mqc_libcint_mp2.f90
+++ b/backends/libcint/mqc_libcint_mp2.f90
@@ -34,7 +34,7 @@ module mqc_libcint_mp2
    use pic_types, only: dp
    use pic_blas_interfaces, only: pic_gemm
    use mqc_error, only: error_t, ERROR_VALIDATION
-   use mqc_libcint_integrals, only: libcint_molecule_t, build_df_tensor
+   use mqc_libcint_integrals, only: libcint_molecule_t, build_df_mo_tensor
    implicit none
    private
 
@@ -169,10 +169,10 @@ contains
       type(error_t), intent(inout) :: error
       integer, intent(in), optional :: n_frozen
 
-      real(dp), allocatable :: b(:, :), bia(:, :, :), g(:, :)
-      real(dp), allocatable :: c_occ(:, :), c_vir(:, :), bp(:, :), half(:, :)
+      real(dp), allocatable :: bia(:, :, :), g(:, :)
+      real(dp), allocatable :: c_occ(:, :), c_vir(:, :)
       integer :: n_ao, n_mo, n_o, n_v, n_aux, frozen
-      integer :: i, j, a, bb, p_index
+      integer :: i, j, a, bb
       real(dp) :: iajb, ibja, denom, e_ss, e_os
 
       n_ao = mol%nao
@@ -193,32 +193,18 @@ contains
          return
       end if
 
-      call build_df_tensor(mol, aux, b, error)
-      if (error%has_error()) return
-      n_aux = size(b, 2)
-
       allocate (c_occ(n_ao, n_o), c_vir(n_ao, n_v))
       c_occ = coeff(:, frozen + 1:n_occ)
       c_vir = coeff(:, n_occ + 1:n_mo)
 
-      ! B^P_ia, laid out so that one occupied orbital's block is contiguous:
-      ! the energy step wants (n_v, n_aux) slices to hand straight to a gemm.
-      allocate (bia(n_v, n_aux, n_o))
-      allocate (bp(n_ao, n_ao), half(n_o, n_ao))
-      block
-         real(dp), allocatable :: full(:, :)
-         allocate (full(n_o, n_v))
-         do p_index = 1, n_aux
-            bp = reshape(b(:, p_index), [n_ao, n_ao])
-            call pic_gemm(c_occ, bp, half, transa="T")
-            call pic_gemm(half, c_vir, full)
-            do i = 1, n_o
-               bia(:, p_index, i) = full(i, :)
-            end do
-         end do
-         deallocate (full)
-      end block
-      deallocate (bp, half, b, c_occ, c_vir)
+      ! Transformed before it is fitted, which is where the saving is -- see
+      ! `build_df_mo_tensor`. Fitting the whole AO pair space first and reading
+      ! the occupied-virtual corner out of it costs the same answer several
+      ! times over.
+      call build_df_mo_tensor(mol, aux, c_occ, c_vir, bia, error)
+      deallocate (c_occ, c_vir)
+      if (error%has_error()) return
+      n_aux = size(bia, 2)
 
       ! One gemm per occupied pair rebuilds that pair's whole (a,b) block:
       ! g(a,b) = sum_P B^P_ia B^P_jb, which is (ia|jb), and g(b,a) is (ib|ja).

--- a/src/io/mqc_config_adapter.f90
+++ b/src/io/mqc_config_adapter.f90
@@ -164,6 +164,10 @@ contains
       driver_config%method_config%scf%density_fitting = mqc_config%scf_density_fitting
       driver_config%method_config%corr%freeze_core = mqc_config%corr_freeze_core
       driver_config%method_config%corr%n_frozen_core = mqc_config%corr_n_frozen_core
+      driver_config%method_config%corr%use_df = mqc_config%corr_density_fitting
+      if (allocated(mqc_config%corr_aux_basis)) then
+         driver_config%method_config%corr%aux_basis = mqc_config%corr_aux_basis
+      end if
       driver_config%method_config%corr%use_scs = mqc_config%corr_scs
       driver_config%method_config%corr%scs_ss = mqc_config%corr_scs_ss
       driver_config%method_config%corr%scs_os = mqc_config%corr_scs_os

--- a/src/io/mqc_config_types.f90
+++ b/src/io/mqc_config_types.f90
@@ -88,6 +88,8 @@ module mqc_config_types
       ! keywords.correlation -- post-Hartree-Fock, kept apart from the SCF ones
       logical :: corr_freeze_core = .true.
       integer :: corr_n_frozen_core = -1   !! -1 counts the core from the elements
+      logical :: corr_density_fitting = .false.  !! RI for the correlation step
+      character(len=:), allocatable :: corr_aux_basis
       logical :: corr_scs = .false.        !! Spin-component scaling
       real(dp) :: corr_scs_ss = 1.0_dp/3.0_dp
       real(dp) :: corr_scs_os = 1.2_dp

--- a/src/io/mqc_json_config_reader.f90
+++ b/src/io/mqc_json_config_reader.f90
@@ -38,7 +38,8 @@ module mqc_json_config_reader
    use mqc_geometry, only: geometry_type
    use mqc_error, only: error_t, ERROR_IO, ERROR_PARSE, ERROR_VALIDATION
    use mqc_calc_types, only: calc_type_from_string
-   use mqc_method_types, only: parse_method_string, method_spin_scaling
+   use mqc_method_types, only: parse_method_string, method_spin_scaling, &
+                               method_wants_density_fitting
    use mqc_config_types, only: mqc_config_t, input_fragment_t, bond_t
    use mqc_xyz_reader, only: read_xyz_file
    use mqc_json_schema, only: ensure_valid_json
@@ -165,6 +166,9 @@ contains
       ! spin scaling has to be picked up here, while the spelling still exists.
       ! Left to the type alone they would run plain MP2 and report it as SCS.
       call method_spin_scaling(text, config%corr_scs, config%corr_scs_ss, config%corr_scs_os)
+      ! Likewise "ri-mp2" and "df-mp2", which the method type cannot distinguish
+      ! from "mp2". A later keyword can still turn it off.
+      config%corr_density_fitting = method_wants_density_fitting(text)
       call optional_string(json, "model.basis", config%basis)
       call optional_string(json, "model.aux_basis", config%aux_basis)
       call optional_string(json, "model.functional", config%functional)
@@ -198,6 +202,9 @@ contains
       call optional_int(json, "keywords.correlation.n_frozen_core", &
                         config%corr_n_frozen_core)
       ! After the method name, so an explicit keyword wins over the spelling.
+      call optional_logical(json, "keywords.correlation.density_fitting", &
+                            config%corr_density_fitting)
+      call optional_string(json, "keywords.correlation.aux_basis", config%corr_aux_basis)
       call optional_logical(json, "keywords.correlation.scs", config%corr_scs)
       call optional_real(json, "keywords.correlation.scs_ss", config%corr_scs_ss)
       call optional_real(json, "keywords.correlation.scs_os", config%corr_scs_os)

--- a/src/io/mqc_json_schema.f90
+++ b/src/io/mqc_json_schema.f90
@@ -203,6 +203,8 @@ contains
       type(key_set_t) :: keys
       call allow(keys, "freeze_core")
       call allow(keys, "n_frozen_core")
+      call allow(keys, "density_fitting")
+      call allow(keys, "aux_basis")
       call allow(keys, "scs")
       call allow(keys, "scs_ss")
       call allow(keys, "scs_os")

--- a/src/methods/mqc_cuest_iface.f90
+++ b/src/methods/mqc_cuest_iface.f90
@@ -29,6 +29,8 @@ module mqc_cuest_iface
       logical :: run_mp2 = .false.
       logical :: freeze_core = .false.
       integer :: n_frozen_core = -1     !! -1 means count it from the elements
+      logical :: corr_density_fitting = .false.  !! RI for the correlation step
+      character(len=256) :: corr_aux_basis = ""
       real(dp) :: scs_ss = 1.0_dp       !! Spin-component scaling, one for plain MP2
       real(dp) :: scs_os = 1.0_dp
          !! Read by the CPU backend only; cuEST always fits.

--- a/src/methods/mqc_method_factory.F90
+++ b/src/methods/mqc_method_factory.F90
@@ -160,6 +160,8 @@ contains
       ! treatment are configured separately and may disagree.
       m%options%freeze_core = config%corr%freeze_core
       m%options%n_frozen_core = config%corr%n_frozen_core
+      m%options%corr_density_fitting = config%corr%use_df
+      m%options%corr_aux_basis = config%corr%aux_basis
       ! One and one unless scaling was asked for, so an unscaled run cannot
       ! pick up factors that happen to be sitting in the config.
       if (config%corr%use_scs) then

--- a/src/methods/mqc_method_hf.F90
+++ b/src/methods/mqc_method_hf.F90
@@ -37,6 +37,8 @@ module mqc_method_hf
          !! not an option on Hartree-Fock.
       logical :: freeze_core = .false.
       integer :: n_frozen_core = -1
+      logical :: corr_density_fitting = .false.
+      character(len=256) :: corr_aux_basis = ""
       real(dp) :: scs_ss = 1.0_dp
       real(dp) :: scs_os = 1.0_dp
          !! Fit J and K rather than computing exact integrals (CPU backend)
@@ -100,6 +102,8 @@ contains
       settings%run_mp2 = this%options%run_mp2
       settings%freeze_core = this%options%freeze_core
       settings%n_frozen_core = this%options%n_frozen_core
+      settings%corr_density_fitting = this%options%corr_density_fitting
+      settings%corr_aux_basis = this%options%corr_aux_basis
       settings%scs_ss = this%options%scs_ss
       settings%scs_os = this%options%scs_os
       settings%functional = ""        ! empty selects pure Hartree-Fock

--- a/src/mqc_method_types.f90
+++ b/src/mqc_method_types.f90
@@ -22,6 +22,7 @@ module mqc_method_types
    public :: method_type_from_string, method_type_to_string
    public :: parse_method_string  !! Input-file spelling -> method type
    public :: method_spin_scaling  !! Spin-component scaling a spelling implies
+   public :: method_wants_density_fitting  !! Whether a spelling asks for RI
 
    ! Method type constants
    integer(int32), parameter :: METHOD_TYPE_UNKNOWN = 0
@@ -198,6 +199,30 @@ contains
          ! that no scaling is the deliberate answer rather than a gap.
       end select
    end subroutine method_spin_scaling
+
+   function method_wants_density_fitting(method_str) result(wants_df)
+      !! Whether a method name asks for the fitted route
+      !!
+      !! "ri-mp2" and "df-mp2" parse to METHOD_TYPE_MP2 exactly as "mp2" does,
+      !! so without this a deck asking for either would run the conventional
+      !! four-index transform and report it as RI -- right answer, wrong method,
+      !! and no way to tell from the output. Same reason `method_spin_scaling`
+      !! exists: the spelling carries intent the type discards.
+      character(len=*), intent(in) :: method_str
+      logical :: wants_df
+
+      character(len=:), allocatable :: lower_str
+      integer :: i
+
+      lower_str = trim(adjustl(method_str))
+      do i = 1, len(lower_str)
+         if (lower_str(i:i) >= "A" .and. lower_str(i:i) <= "Z") then
+            lower_str(i:i) = achar(iachar(lower_str(i:i)) + 32)
+         end if
+      end do
+
+      wants_df = (index(lower_str, "ri-") == 1) .or. (index(lower_str, "df-") == 1)
+   end function method_wants_density_fitting
 
    function parse_method_string(method_str) result(method_type)
       !! Parse method string from input file (e.g., "XTB-GFN1" -> gfn1)

--- a/test/test_mqc_libcint_mp2.f90
+++ b/test/test_mqc_libcint_mp2.f90
@@ -20,7 +20,7 @@ module test_mqc_libcint_mp2
    use mqc_result_types, only: mp2_energy_t
    use mqc_libcint_integrals, only: libcint_molecule_t, build_libcint_molecule
    use mqc_libcint_rhf, only: rhf_result_t, run_libcint_rhf
-   use mqc_libcint_mp2, only: mp2_result_t, run_libcint_mp2
+   use mqc_libcint_mp2, only: mp2_result_t, run_libcint_mp2, run_libcint_ri_mp2
    implicit none
    private
    public :: collect_mqc_libcint_mp2_tests
@@ -40,7 +40,8 @@ contains
                   new_unittest("mp2_freezing_core_raises_the_energy", test_frozen), &
                   new_unittest("mp2_rejects_freezing_everything", test_bad_frozen), &
                   new_unittest("mp2_scaling_is_applied_by_total_only", test_scaling), &
-                  new_unittest("mp2_scs_matches_its_published_factors", test_scs) &
+                  new_unittest("mp2_scs_matches_its_published_factors", test_scs), &
+                  new_unittest("ri_mp2_approaches_the_conventional_answer", test_ri) &
                   ]
    end subroutine collect_mqc_libcint_mp2_tests
 
@@ -200,6 +201,55 @@ contains
       call check(error, abs(e%total() - (-0.15_dp*1.3_dp)) < 1.0e-14_dp, &
                  "and total must still use the run's")
    end subroutine test_scs
+
+   subroutine test_ri(error)
+      !! The fitted answer has to be close to the exact one, and not too close
+      !!
+      !! Two bounds rather than one. The upper bound is the obvious check: a
+      !! transform that lost an index would be wrong by millihartree, not by
+      !! the tens of microhartree a fit costs. The lower bound is the one worth
+      !! having -- if the fitted and conventional energies agreed to 1e-12, the
+      !! fitted path would not be fitting anything, which is what a silent
+      !! fallback to the four-index route would look like from outside.
+      type(error_type), allocatable, intent(out) :: error
+      type(libcint_molecule_t) :: mol, aux
+      type(rhf_result_t) :: scf
+      type(mp2_result_t) :: exact, ri
+      type(error_t) :: err
+      real(dp) :: c(3, 3), gap
+
+      c = reshape([0.0_dp, 0.0_dp, 0.0_dp, &
+                   0.0_dp, 0.757_dp*ANG, 0.587_dp*ANG, &
+                   0.0_dp, -0.757_dp*ANG, 0.587_dp*ANG], [3, 3])
+      call build_libcint_molecule([8, 1, 1], ["O ", "H ", "H "], c, "cc-pvdz", mol, err)
+      call build_libcint_molecule([8, 1, 1], ["O ", "H ", "H "], c, "cc-pvdz-rifit", aux, err)
+      call check(error,.not. err%has_error(), "water and its auxiliary must build")
+      if (allocated(error)) return
+
+      call run_libcint_rhf(mol, 10, 200, E_TOL, D_TOL, .false., scf, err)
+      call run_libcint_mp2(mol, scf%orbitals, scf%orbital_energies, 5, scf%energy, &
+                           exact, err, n_frozen=1)
+      call run_libcint_ri_mp2(mol, aux, scf%orbitals, scf%orbital_energies, 5, &
+                              scf%energy, ri, err, n_frozen=1)
+      call check(error,.not. err%has_error(), "both routes must run")
+      if (allocated(error)) return
+
+      gap = abs(ri%correlation - exact%correlation)
+      call check(error, gap < 1.0e-3_dp, &
+                 "the fitting error must be small; a lost index would be millihartree")
+      if (allocated(error)) return
+      call check(error, gap > 1.0e-9_dp, &
+                 "the fitted route must actually fit; exact agreement means it did not")
+      if (allocated(error)) return
+
+      ! The components have to be fitted too, not just their sum.
+      call check(error, abs(ri%opposite_spin - exact%opposite_spin) > 1.0e-9_dp, &
+                 "the opposite-spin component must be fitted as well")
+      if (allocated(error)) return
+      call check(error, ri%n_occupied, exact%n_occupied)
+      if (allocated(error)) return
+      call check(error, ri%n_virtual, exact%n_virtual)
+   end subroutine test_ri
 
 end module test_mqc_libcint_mp2
 

--- a/tools/cpu_validation/gen_cpu_validation.py
+++ b/tools/cpu_validation/gen_cpu_validation.py
@@ -261,6 +261,20 @@ MP2_CASES = [
 # It also exercises a path the unfragmented cases do not: the runner gives
 # fragmented cases several MPI ranks, so this covers fragment distribution as
 # well as the correlation energy surviving the expansion.
+# Density-fitted MP2, as (molecule, orbital basis, auxiliary basis, frozen).
+#
+# The auxiliary sets here are RIFIT, which is what fits a (ia|jb) block. A
+# JKFIT set is fitted for the Coulomb and exchange matrices instead; the code
+# accepts one and warns, and that is deliberately not covered by a reference
+# case -- the point of the warning is that the number is poor, and pinning a
+# poor number teaches nothing.
+RI_MP2_CASES = [
+    ("water", "cc-pvdz", "cc-pvdz-rifit", 0),
+    ("water", "cc-pvdz", "cc-pvdz-rifit", 1),
+    ("water", "def2-svp", "def2-svp-rifit", 1),
+    ("ch4", "cc-pvdz", "cc-pvdz-rifit", 1),
+]
+
 FRAGMENTED_CASES = [
     ("w2dimer", "cc-pvdz", "mp2", 2, [[0, 1, 2], [3, 4, 5]]),
 ]
@@ -419,6 +433,35 @@ def deck_json(xyz_rel, basis, aux="", multiplicity=1, method="hf", correlation=N
     if correlation:
         deck["keywords"]["correlation"] = correlation
     return deck
+
+
+def pyscf_ri_mp2(atoms, basis, aux, frozen):
+    """Reference DF-MP2 total energy, fitted with the given auxiliary basis.
+
+    Compared against PySCF's own density-fitted MP2 rather than against exact
+    MP2: agreeing with the exact answer to the fitting error would only say the
+    fitting error is the usual size, not that the same fitted quantity is being
+    computed. These agree to 1e-10, which is the stronger statement.
+    """
+    from pyscf import gto, scf, mp
+
+    mol = gto.Mole()
+    mol.atom = [(s, (x, y, z)) for s, x, y, z in atoms]
+    mol.unit = "Angstrom"
+    symbols = {a[0] for a in atoms}
+    mol.basis = {s: bse_to_pyscf(basis, s) for s in symbols}
+    mol.charge = 0
+    mol.spin = 0
+    mol.cart = molecule_form(basis, symbols) == CARTESIAN
+    mol.verbose = 0
+    mol.build()
+    mf = scf.RHF(mol)
+    mf.conv_tol = 1e-12
+    escf = mf.kernel()
+    pt = mp.dfmp2.DFMP2(mf, frozen=frozen)
+    pt.with_df = pt.with_df.__class__(mol, auxbasis={s: bse_to_pyscf(aux, s) for s in symbols})
+    ecorr, _ = pt.kernel()
+    return float(escf + ecorr), mol.nao
 
 
 def pyscf_mp2(atoms, basis, method, frozen):
@@ -583,6 +626,26 @@ def main():
             "type": "unfragmented",
         })
         print(f"{mol.label:6s} {basis:12s} {method:8s} frozen={frozen}  nao={nao:4d} E={energy:.12f}", flush=True)
+
+    for name, basis, aux, frozen in RI_MP2_CASES:
+        mol = MOLECULES[name]
+        energy, nao = pyscf_ri_mp2(mol.atoms, basis, aux, frozen)
+        deck = f"inputs/cpu_{name}_{normalize_basis_name(basis)}_rimp2_f{frozen}.json"
+        written.add((VALIDATION / deck).name)
+        if not args.dry_run:
+            (VALIDATION / deck).write_text(
+                json.dumps(deck_json(mol.xyz, basis, method="ri-mp2",
+                                     correlation={"freeze_core": frozen > 0,
+                                                  "n_frozen_core": frozen,
+                                                  "aux_basis": aux}), indent=4) + "\n"
+            )
+        tests.append({
+            "name": f"RI-MP2 {mol.label} {basis}/{aux} frozen {frozen} (CPU)",
+            "input": deck,
+            "expected_energy": round(energy, 12),
+            "type": "unfragmented",
+        })
+        print(f"{mol.label:6s} {basis:12s} ri-mp2/{aux:16s} frozen={frozen} E={energy:.12f}", flush=True)
 
     for name, basis, method, frozen, fragments in FRAGMENTED_CASES:
         mol = MOLECULES[name]

--- a/validation/inputs/cpu_ch4_cc-pvdz_rimp2_f1.json
+++ b/validation/inputs/cpu_ch4_cc-pvdz_rimp2_f1.json
@@ -1,0 +1,34 @@
+{
+    "schema": {
+        "name": "mqc-frag",
+        "version": "1.0"
+    },
+    "molecules": [
+        {
+            "xyz": "sample_inputs/ch4.xyz",
+            "molecular_charge": 0,
+            "molecular_multiplicity": 1
+        }
+    ],
+    "model": {
+        "method": "ri-mp2",
+        "basis": "cc-pvdz"
+    },
+    "keywords": {
+        "scf": {
+            "maxiter": 100,
+            "tolerance": 1e-08
+        },
+        "correlation": {
+            "freeze_core": true,
+            "n_frozen_core": 1,
+            "aux_basis": "cc-pvdz-rifit"
+        }
+    },
+    "system": {
+        "logger": {
+            "level": "Verbose"
+        }
+    },
+    "driver": "Energy"
+}

--- a/validation/inputs/cpu_water_cc-pvdz_rimp2_f0.json
+++ b/validation/inputs/cpu_water_cc-pvdz_rimp2_f0.json
@@ -1,0 +1,34 @@
+{
+    "schema": {
+        "name": "mqc-frag",
+        "version": "1.0"
+    },
+    "molecules": [
+        {
+            "xyz": "sample_inputs/w1.xyz",
+            "molecular_charge": 0,
+            "molecular_multiplicity": 1
+        }
+    ],
+    "model": {
+        "method": "ri-mp2",
+        "basis": "cc-pvdz"
+    },
+    "keywords": {
+        "scf": {
+            "maxiter": 100,
+            "tolerance": 1e-08
+        },
+        "correlation": {
+            "freeze_core": false,
+            "n_frozen_core": 0,
+            "aux_basis": "cc-pvdz-rifit"
+        }
+    },
+    "system": {
+        "logger": {
+            "level": "Verbose"
+        }
+    },
+    "driver": "Energy"
+}

--- a/validation/inputs/cpu_water_cc-pvdz_rimp2_f1.json
+++ b/validation/inputs/cpu_water_cc-pvdz_rimp2_f1.json
@@ -1,0 +1,34 @@
+{
+    "schema": {
+        "name": "mqc-frag",
+        "version": "1.0"
+    },
+    "molecules": [
+        {
+            "xyz": "sample_inputs/w1.xyz",
+            "molecular_charge": 0,
+            "molecular_multiplicity": 1
+        }
+    ],
+    "model": {
+        "method": "ri-mp2",
+        "basis": "cc-pvdz"
+    },
+    "keywords": {
+        "scf": {
+            "maxiter": 100,
+            "tolerance": 1e-08
+        },
+        "correlation": {
+            "freeze_core": true,
+            "n_frozen_core": 1,
+            "aux_basis": "cc-pvdz-rifit"
+        }
+    },
+    "system": {
+        "logger": {
+            "level": "Verbose"
+        }
+    },
+    "driver": "Energy"
+}

--- a/validation/inputs/cpu_water_def2-svp_rimp2_f1.json
+++ b/validation/inputs/cpu_water_def2-svp_rimp2_f1.json
@@ -1,0 +1,34 @@
+{
+    "schema": {
+        "name": "mqc-frag",
+        "version": "1.0"
+    },
+    "molecules": [
+        {
+            "xyz": "sample_inputs/w1.xyz",
+            "molecular_charge": 0,
+            "molecular_multiplicity": 1
+        }
+    ],
+    "model": {
+        "method": "ri-mp2",
+        "basis": "def2-svp"
+    },
+    "keywords": {
+        "scf": {
+            "maxiter": 100,
+            "tolerance": 1e-08
+        },
+        "correlation": {
+            "freeze_core": true,
+            "n_frozen_core": 1,
+            "aux_basis": "def2-svp-rifit"
+        }
+    },
+    "system": {
+        "logger": {
+            "level": "Verbose"
+        }
+    },
+    "driver": "Energy"
+}

--- a/validation/validation_tests_cpu.json
+++ b/validation/validation_tests_cpu.json
@@ -981,6 +981,30 @@
             "type": "unfragmented"
         },
         {
+            "name": "RI-MP2 H2O cc-pvdz/cc-pvdz-rifit frozen 0 (CPU)",
+            "input": "inputs/cpu_water_cc-pvdz_rimp2_f0.json",
+            "expected_energy": -76.230257623944,
+            "type": "unfragmented"
+        },
+        {
+            "name": "RI-MP2 H2O cc-pvdz/cc-pvdz-rifit frozen 1 (CPU)",
+            "input": "inputs/cpu_water_cc-pvdz_rimp2_f1.json",
+            "expected_energy": -76.227922438697,
+            "type": "unfragmented"
+        },
+        {
+            "name": "RI-MP2 H2O def2-svp/def2-svp-rifit frozen 1 (CPU)",
+            "input": "inputs/cpu_water_def2-svp_rimp2_f1.json",
+            "expected_energy": -76.161602884779,
+            "type": "unfragmented"
+        },
+        {
+            "name": "RI-MP2 CH4 cc-pvdz/cc-pvdz-rifit frozen 1 (CPU)",
+            "input": "inputs/cpu_ch4_cc-pvdz_rimp2_f1.json",
+            "expected_energy": -40.359711209284,
+            "type": "unfragmented"
+        },
+        {
             "name": "MBE(2) MP2 (H2O)2 cc-pvdz (CPU)",
             "input": "inputs/cpu_w2dimer_cc-pvdz_mp2_mbe2.json",
             "expected_energy": -152.466588405967,


### PR DESCRIPTION
Adds RI-MP2 (resolution-of-identity MP2), fitting the (ia|jb) block directly rather than building the full four-index integral. The transform is applied before fitting, following PySCF's ordering.

Wires the method through config parsing, schema, factory and method types, and adds CPU validation inputs (water/ch4, cc-pvdz/def2-svp).

**Commits**
- add RI-MP2, fitting the (ia|jb) block rather than building it
- transform before fitting in RI-MP2, following PySCF's ordering

---
_Stacked on `feat/mp2`. This PR's diff is relative to that branch._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
