### PR TITLE
Optimize the MP2 four-index transform

### DIFF
--- a/backends/libcint/mqc_libcint_integrals.f90
+++ b/backends/libcint/mqc_libcint_integrals.f90
@@ -62,6 +62,7 @@ module mqc_libcint_integrals
    ! of entry points. Exported because the direct Fock build needs the same
    ! mapping, and two copies of it is two chances to route half the calls.
    public :: shell_dim
+   public :: pair_index
    public :: two_electron_block
    public :: two_electron_optimizer
 
@@ -90,6 +91,7 @@ module mqc_libcint_integrals
       procedure :: overlap => molecule_overlap
       procedure :: core_hamiltonian => molecule_core_hamiltonian
       procedure :: eris => molecule_eris
+      procedure :: eris_packed => molecule_eris_packed
       procedure :: nuclear_repulsion => molecule_nuclear_repulsion
       procedure :: destroy => molecule_destroy
    end type libcint_molecule_t
@@ -943,6 +945,123 @@ contains
       deallocate (pair_i, pair_j)
    end subroutine molecule_eris
 
+   subroutine molecule_eris_packed(this, eri)
+      !! Every unique two-electron integral, as (pq|rs) over packed AO pairs
+      !!
+      !! The dense n^4 form that `eris` returns costs more to fill than to
+      !! compute: eight positions written per integral, across eight different
+      !! stride patterns. That is bandwidth rather than arithmetic, and it does
+      !! not improve with more cores -- the threaded dense build gets 4.3x on
+      !! forty of them.
+      !!
+      !! Packing the two AO pairs collapses (mu nu) with (nu mu), so of the
+      !! eightfold symmetry only the bra-ket swap is left to write out: two
+      !! stores per integral instead of eight, into an array a quarter the size.
+      !! A water hexamer in cc-pVDZ goes from 3.4 GB to 872 MB.
+      !!
+      !! `eris` stays. The in-core SCF and `check_direct` read the dense form,
+      !! and a reference implementation is worth more readable than packed.
+      class(libcint_molecule_t), intent(in) :: this
+      real(dp), allocatable, intent(out) :: eri(:, :)
+
+      real(dp), allocatable :: buf(:)
+      integer :: ish, jsh, ksh, lsh, di, dj, dk, dl, lsh_max
+      integer :: shls(4)
+      integer :: i, j, k, l, io, jo, ko, lo, ret, idx
+      integer :: p, q, r, t, pq, rt, n_pair
+      integer :: npair_sh, ipair
+      integer, allocatable :: pair_i(:), pair_j(:)
+      real(dp) :: value
+      type(c_ptr) :: opt
+
+      n_pair = this%nao*(this%nao + 1)/2
+      allocate (eri(n_pair, n_pair))
+      eri = 0.0_dp
+
+      opt = c_null_ptr
+      call two_electron_optimizer(this%cartesian, opt, this%atm, this%natm, this%bas, &
+                                  this%nbas, this%env)
+
+      npair_sh = this%nbas*(this%nbas + 1)/2
+      allocate (pair_i(npair_sh), pair_j(npair_sh))
+      ipair = 0
+      do ish = 1, this%nbas
+         do jsh = 1, ish
+            ipair = ipair + 1
+            pair_i(ipair) = ish
+            pair_j(ipair) = jsh
+         end do
+      end do
+
+      !$omp parallel default(none) &
+      !$omp    shared(this, eri, opt, npair_sh, pair_i, pair_j) &
+      !$omp    private(ipair, ish, jsh, ksh, lsh, lsh_max, di, dj, dk, dl, io, jo, ko, lo, &
+      !$omp            i, j, k, l, p, q, r, t, pq, rt, shls, ret, idx, value, buf)
+      allocate (buf(max_block(this)**4))
+      !$omp do schedule(dynamic)
+      do ipair = 1, npair_sh
+         ish = pair_i(ipair)
+         jsh = pair_j(ipair)
+         di = shell_dim(this%cartesian, ish - 1, this%bas)
+         io = this%shell_offset(ish)
+         dj = shell_dim(this%cartesian, jsh - 1, this%bas)
+         jo = this%shell_offset(jsh)
+         do ksh = 1, ish
+            dk = shell_dim(this%cartesian, ksh - 1, this%bas)
+            ko = this%shell_offset(ksh)
+            lsh_max = ksh
+            if (ksh == ish) lsh_max = jsh
+            do lsh = 1, lsh_max
+               dl = shell_dim(this%cartesian, lsh - 1, this%bas)
+               lo = this%shell_offset(lsh)
+               shls = [ish - 1, jsh - 1, ksh - 1, lsh - 1]
+               ret = two_electron_block(this%cartesian, buf, shls, this%atm, &
+                                        this%natm, this%bas, this%nbas, this%env, opt)
+               if (ret == 0) cycle
+
+               do l = 1, dl
+                  t = lo + l
+                  do k = 1, dk
+                     r = ko + k
+                     rt = pair_index(r, t)
+                     do j = 1, dj
+                        q = jo + j
+                        do i = 1, di
+                           p = io + i
+                           idx = i + (j - 1)*di + (k - 1)*di*dj + (l - 1)*di*dj*dk
+                           value = buf(idx)
+                           pq = pair_index(p, q)
+                           eri(pq, rt) = value
+                           eri(rt, pq) = value
+                        end do
+                     end do
+                  end do
+               end do
+            end do
+         end do
+      end do
+      !$omp end do
+      deallocate (buf)
+      !$omp end parallel
+
+      call libcint_del_optimizer(opt)
+      deallocate (pair_i, pair_j)
+   end subroutine molecule_eris_packed
+
+   pure function pair_index(p, q) result(pq)
+      !! Where the AO pair (p,q) sits once the two orderings are collapsed
+      !!
+      !! Lower triangle, one-based: (1,1) is 1, (2,1) is 2, (2,2) is 3. The
+      !! caller need not order its arguments.
+      integer, intent(in) :: p, q
+      integer :: pq
+
+      if (p >= q) then
+         pq = p*(p - 1)/2 + q
+      else
+         pq = q*(q - 1)/2 + p
+      end if
+   end function pair_index
    pure function molecule_nuclear_repulsion(this) result(energy)
       !! Sum of Z_a Z_b / R_ab over pairs
       class(libcint_molecule_t), intent(in) :: this

--- a/backends/libcint/mqc_libcint_integrals.f90
+++ b/backends/libcint/mqc_libcint_integrals.f90
@@ -834,46 +834,73 @@ contains
    subroutine molecule_eris(this, eri)
       !! Every two-electron integral, in core, as (ij|kl)
       !!
-      !! Stored as a full n^4 array with no permutational symmetry exploited.
-      !! For a reference implementation that is the right trade: the eightfold
-      !! symmetry saves memory and costs an index map, and an index map is
-      !! exactly the sort of thing that would need its own validation.
+      !! Stored as a full n^4 array. The eightfold symmetry decides which
+      !! integrals to *evaluate*, not how they are stored -- the array stays
+      !! dense, so every consumer indexes it directly and needs no index map.
+      !! That keeps what made this readable as a reference while removing the
+      !! eight times too many calls into libcint that filling it naively cost.
+      !!
+      !! Scattering all eight positions is safe here precisely because this
+      !! assigns rather than accumulates: when shells coincide some permutations
+      !! name the same element, and writing the same value twice is harmless. An
+      !! accumulating version would have to know which had collapsed, which is
+      !! the bookkeeping this routine was written to avoid.
       class(libcint_molecule_t), intent(in) :: this
       real(dp), allocatable, intent(out) :: eri(:, :, :, :)
 
       real(dp), allocatable :: buf(:)
-      integer :: ish, jsh, ksh, lsh, di, dj, dk, dl
+      integer :: ish, jsh, ksh, lsh, di, dj, dk, dl, lsh_max
       integer :: shls(4)
       integer :: i, j, k, l, io, jo, ko, lo, ret, idx
+      integer :: p, q, r, t
+      real(dp) :: value
+      type(c_ptr) :: opt
 
       allocate (eri(this%nao, this%nao, this%nao, this%nao))
       eri = 0.0_dp
-      ! Four shells, so the fourth power. Same reasoning as the pair above.
       allocate (buf(max_block(this)**4))
+
+      opt = c_null_ptr
+      call two_electron_optimizer(this%cartesian, opt, this%atm, this%natm, this%bas, &
+                                  this%nbas, this%env)
 
       do ish = 1, this%nbas
          di = shell_dim(this%cartesian, ish - 1, this%bas)
          io = this%shell_offset(ish)
-         do jsh = 1, this%nbas
+         do jsh = 1, ish
             dj = shell_dim(this%cartesian, jsh - 1, this%bas)
             jo = this%shell_offset(jsh)
-            do ksh = 1, this%nbas
+            do ksh = 1, ish
                dk = shell_dim(this%cartesian, ksh - 1, this%bas)
                ko = this%shell_offset(ksh)
-               do lsh = 1, this%nbas
+               lsh_max = ksh
+               if (ksh == ish) lsh_max = jsh
+               do lsh = 1, lsh_max
                   dl = shell_dim(this%cartesian, lsh - 1, this%bas)
                   lo = this%shell_offset(lsh)
                   shls = [ish - 1, jsh - 1, ksh - 1, lsh - 1]
                   ret = two_electron_block(this%cartesian, buf, shls, this%atm, &
-                                           this%natm, this%bas, this%nbas, this%env)
+                                           this%natm, this%bas, this%nbas, this%env, opt)
                   if (ret == 0) cycle
 
                   do l = 1, dl
+                     t = lo + l
                      do k = 1, dk
+                        r = ko + k
                         do j = 1, dj
+                           q = jo + j
                            do i = 1, di
+                              p = io + i
                               idx = i + (j - 1)*di + (k - 1)*di*dj + (l - 1)*di*dj*dk
-                              eri(io + i, jo + j, ko + k, lo + l) = buf(idx)
+                              value = buf(idx)
+                              eri(p, q, r, t) = value
+                              eri(q, p, r, t) = value
+                              eri(p, q, t, r) = value
+                              eri(q, p, t, r) = value
+                              eri(r, t, p, q) = value
+                              eri(t, r, p, q) = value
+                              eri(r, t, q, p) = value
+                              eri(t, r, q, p) = value
                            end do
                         end do
                      end do
@@ -882,6 +909,8 @@ contains
             end do
          end do
       end do
+
+      call libcint_del_optimizer(opt)
       deallocate (buf)
    end subroutine molecule_eris
 

--- a/backends/libcint/mqc_libcint_integrals.f90
+++ b/backends/libcint/mqc_libcint_integrals.f90
@@ -853,24 +853,50 @@ contains
       integer :: shls(4)
       integer :: i, j, k, l, io, jo, ko, lo, ret, idx
       integer :: p, q, r, t
+      integer :: npair, ipair
+      integer, allocatable :: pair_i(:), pair_j(:)
       real(dp) :: value
       type(c_ptr) :: opt
 
       allocate (eri(this%nao, this%nao, this%nao, this%nao))
       eri = 0.0_dp
-      allocate (buf(max_block(this)**4))
 
       opt = c_null_ptr
       call two_electron_optimizer(this%cartesian, opt, this%atm, this%natm, this%bas, &
                                   this%nbas, this%env)
 
+      ! Threaded over bra pairs, exactly as the direct Fock build is, and for
+      ! once with nothing to reduce: a canonical quartet owns the eight
+      ! positions it scatters into and no other canonical quartet names any of
+      ! them, so the threads write disjoint elements of a shared array.
+      npair = this%nbas*(this%nbas + 1)/2
+      allocate (pair_i(npair), pair_j(npair))
+      ipair = 0
       do ish = 1, this%nbas
+         do jsh = 1, ish
+            ipair = ipair + 1
+            pair_i(ipair) = ish
+            pair_j(ipair) = jsh
+         end do
+      end do
+
+      !$omp parallel default(none) &
+      !$omp    shared(this, eri, opt, npair, pair_i, pair_j) &
+      !$omp    private(ipair, ish, jsh, ksh, lsh, lsh_max, di, dj, dk, dl, io, jo, ko, lo, &
+      !$omp            i, j, k, l, p, q, r, t, shls, ret, idx, value, buf)
+      allocate (buf(max_block(this)**4))
+      !$omp do schedule(dynamic)
+      do ipair = 1, npair
+         ish = pair_i(ipair)
+         jsh = pair_j(ipair)
          di = shell_dim(this%cartesian, ish - 1, this%bas)
          io = this%shell_offset(ish)
-         do jsh = 1, ish
-            dj = shell_dim(this%cartesian, jsh - 1, this%bas)
-            jo = this%shell_offset(jsh)
-            do ksh = 1, ish
+         dj = shell_dim(this%cartesian, jsh - 1, this%bas)
+         jo = this%shell_offset(jsh)
+         block
+            integer :: ksh_local
+            do ksh_local = 1, ish
+               ksh = ksh_local
                dk = shell_dim(this%cartesian, ksh - 1, this%bas)
                ko = this%shell_offset(ksh)
                lsh_max = ksh
@@ -907,11 +933,14 @@ contains
                   end do
                end do
             end do
-         end do
+         end block
       end do
+      !$omp end do
+      deallocate (buf)
+      !$omp end parallel
 
       call libcint_del_optimizer(opt)
-      deallocate (buf)
+      deallocate (pair_i, pair_j)
    end subroutine molecule_eris
 
    pure function molecule_nuclear_repulsion(this) result(energy)

--- a/backends/libcint/mqc_libcint_mp2.f90
+++ b/backends/libcint/mqc_libcint_mp2.f90
@@ -34,7 +34,7 @@ module mqc_libcint_mp2
    use pic_types, only: dp
    use pic_blas_interfaces, only: pic_gemm
    use mqc_error, only: error_t, ERROR_VALIDATION
-   use mqc_libcint_integrals, only: libcint_molecule_t, build_df_mo_tensor
+   use mqc_libcint_integrals, only: libcint_molecule_t, build_df_mo_tensor, pair_index
    implicit none
    private
 
@@ -73,7 +73,7 @@ contains
          !! against an unfrozen one disagrees by tens of millihartree for a
          !! reason that has nothing to do with the implementation.
 
-      real(dp), allocatable :: ao_eri(:, :, :, :)
+      real(dp), allocatable :: ao_eri(:, :)
       real(dp), allocatable :: ovov(:, :, :, :)
       integer :: n_ao, n_mo, n_v, n_o, frozen
       integer :: i, j, a, b
@@ -103,7 +103,7 @@ contains
          return
       end if
 
-      call mol%eris(ao_eri)
+      call mol%eris_packed(ao_eri)
       call transform_ovov(ao_eri, coeff, frozen, n_occ, n_ao, n_mo, ovov)
       deallocate (ao_eri)
 
@@ -246,87 +246,92 @@ contains
    end subroutine run_libcint_ri_mp2
 
    subroutine transform_ovov(eri, coeff, frozen, n_occ, n_ao, n_mo, ovov)
-      !! (mu nu|la si) -> (ia|jb), one index at a time, without copying
+      !! (pq|rs) over packed AO pairs -> (ia|jb), in two symmetric halves
       !!
-      !! Each quarter contracts one AO index against one coefficient block, and
-      !! each is a gemm. The care is entirely in the layout: every intermediate
-      !! is held so that the slice the next quarter reads is contiguous, and is
-      !! handed to BLAS through a bounds-remapped pointer rather than `reshape`.
+      !! With the AO pairs packed, the four quarter transforms fall into two
+      !! identical halves. One column of the packed tensor is a whole AO pair
+      !! index held fixed while the other runs, so unpacking it into an nao by
+      !! nao matrix and taking C_occ^T M C_vir transforms that pair to (ia) in
+      !! two gemms. Doing it once down the columns and once down the rows is the
+      !! whole transformation:
       !!
-      !! That distinction is not cosmetic. `reshape` always materialises a
-      !! temporary, so viewing one occupied orbital's block as a matrix copied
-      !! nao^3 elements per orbital -- 573 MB on a water hexamer in cc-pVDZ,
-      !! to feed gemms that together do less work than the copying. Pointer
-      !! remapping is the same view for nothing.
+      !!     (pq|rs) --unpack pq--> (ia|rs) --unpack rs--> (ia|jb)
       !!
-      !! The layouts, in order:
-      !!
-      !!   q1 (nu la si, i)   quarter 1 contracts mu
-      !!   q2 (la si, a, i)   quarter 2 contracts nu
-      !!   q3 (si, j)         quarter 3 contracts la, per (i,a)
-      !!   ovov (i, a, j, b)  quarter 4 contracts si
-      !!
-      !! Each is chosen so the following quarter reads down a column.
-      real(dp), intent(in), target, contiguous :: eri(:, :, :, :)
+      !! The unpack is the price of the packing, and it is a good trade: it
+      !! touches nao^2 elements where the dense form wrote nao^4 across eight
+      !! stride patterns to avoid it.
+      real(dp), intent(in) :: eri(:, :)      !! (n_pair, n_pair), see `pair_index`
       real(dp), intent(in) :: coeff(:, :)
       integer, intent(in) :: frozen, n_occ, n_ao, n_mo
       real(dp), allocatable, intent(out) :: ovov(:, :, :, :)
 
       real(dp), allocatable :: c_occ(:, :), c_vir(:, :)
-      real(dp), allocatable, target :: q1(:, :), q2(:, :, :)
-      real(dp), allocatable :: q3(:, :), q4(:, :)
-      real(dp), pointer, contiguous :: view(:, :)
-      integer :: n_o, n_v, i, a, j
+      real(dp), allocatable :: half(:, :)
+      real(dp), allocatable :: m(:, :), tmp(:, :), block_ov(:, :)
+      integer :: n_o, n_v, n_pair, pq, i, a, j, b, p, q
 
       n_o = n_occ - frozen
       n_v = n_mo - n_occ
+      n_pair = n_ao*(n_ao + 1)/2
 
       allocate (c_occ(n_ao, n_o), c_vir(n_ao, n_v))
       c_occ = coeff(:, frozen + 1:n_occ)
       c_vir = coeff(:, n_occ + 1:n_mo)
 
-      ! Quarter 1: mu against the occupied block, over the whole tensor at once.
-      ! The occupied index lands last so the next quarter reads columns.
-      allocate (q1(n_ao*n_ao*n_ao, n_o))
-      view(1:n_ao, 1:n_ao*n_ao*n_ao) => eri
-      call pic_gemm(view, c_occ, q1, transa="T")
-
-      ! Quarter 2: nu against the virtual block, one occupied orbital at a time.
-      ! Each step owns its slice of q2, so the threads share nothing but q1,
-      ! which they only read.
-      allocate (q2(n_ao*n_ao, n_v, n_o))
-      !$omp parallel do default(none) shared(q1, q2, c_vir, n_o, n_ao) &
-      !$omp    private(i, view) schedule(static)
-      do i = 1, n_o
-         view(1:n_ao, 1:n_ao*n_ao) => q1(:, i)
-         call pic_gemm(view, c_vir, q2(:, :, i), transa="T")
-      end do
-      !$omp end parallel do
-      deallocate (q1)
-
-      ! Quarters 3 and 4: la then si, per (i,a). Both slices are columns.
-      ! Quarters 3 and 4 likewise: (i,a) indexes a slice of q2 and a slice of
-      ! ovov, both owned outright, so the scratch is per-thread and the rest is
-      ! read-only.
-      allocate (ovov(n_o, n_v, n_o, n_v))
-      !$omp parallel default(none) shared(q2, ovov, c_occ, c_vir, n_o, n_v, n_ao) &
-      !$omp    private(i, a, j, view, q3, q4)
-      allocate (q3(n_o, n_ao), q4(n_o, n_v))
+      ! First half: every packed bra pair transformed to (ia), leaving (ia|rs).
+      ! Held with the packed index first so the second half reads columns.
+      allocate (half(n_pair, n_o*n_v))
+      !$omp parallel default(none) &
+      !$omp    shared(eri, half, c_occ, c_vir, n_pair, n_ao, n_o, n_v) &
+      !$omp    private(pq, p, q, i, a, m, tmp, block_ov)
+      allocate (m(n_ao, n_ao), tmp(n_o, n_ao), block_ov(n_o, n_v))
       !$omp do schedule(static)
-      do i = 1, n_o
+      do pq = 1, n_pair
+         do q = 1, n_ao
+            do p = 1, n_ao
+               m(p, q) = eri(pair_index(p, q), pq)
+            end do
+         end do
+         call pic_gemm(c_occ, m, tmp, transa="T")
+         call pic_gemm(tmp, c_vir, block_ov)
          do a = 1, n_v
-            view(1:n_ao, 1:n_ao) => q2(:, a, i)
-            call pic_gemm(c_occ, view, q3, transa="T")
-            call pic_gemm(q3, c_vir, q4)
-            do j = 1, n_o
-               ovov(i, a, j, :) = q4(j, :)
+            do i = 1, n_o
+               half(pq, (a - 1)*n_o + i) = block_ov(i, a)
             end do
          end do
       end do
       !$omp end do
-      deallocate (q3, q4)
+      deallocate (m, tmp, block_ov)
       !$omp end parallel
-      deallocate (q2, c_occ, c_vir)
+
+      ! Second half: the same operation on the ket pair, for each (ia).
+      allocate (ovov(n_o, n_v, n_o, n_v))
+      !$omp parallel default(none) &
+      !$omp    shared(half, ovov, c_occ, c_vir, n_pair, n_ao, n_o, n_v) &
+      !$omp    private(pq, p, q, i, a, j, b, m, tmp, block_ov)
+      allocate (m(n_ao, n_ao), tmp(n_o, n_ao), block_ov(n_o, n_v))
+      !$omp do schedule(static) collapse(2)
+      do a = 1, n_v
+         do i = 1, n_o
+            do q = 1, n_ao
+               do p = 1, n_ao
+                  m(p, q) = half(pair_index(p, q), (a - 1)*n_o + i)
+               end do
+            end do
+            call pic_gemm(c_occ, m, tmp, transa="T")
+            call pic_gemm(tmp, c_vir, block_ov)
+            do b = 1, n_v
+               do j = 1, n_o
+                  ovov(i, a, j, b) = block_ov(j, b)
+               end do
+            end do
+         end do
+      end do
+      !$omp end do
+      deallocate (m, tmp, block_ov)
+      !$omp end parallel
+
+      deallocate (half, c_occ, c_vir)
    end subroutine transform_ovov
 
 end module mqc_libcint_mp2

--- a/backends/libcint/mqc_libcint_mp2.f90
+++ b/backends/libcint/mqc_libcint_mp2.f90
@@ -271,10 +271,13 @@ contains
       c_occ = coeff(:, frozen + 1:n_occ)
       c_vir = coeff(:, n_occ + 1:n_mo)
 
-      ! Quarter 1: (mu nu|la si) -> (i nu|la si). One gemm over the whole
-      ! tensor, mu contracted against the occupied block.
-      allocate (q1(n_o, n_ao*n_ao*n_ao))
-      call pic_gemm(c_occ, reshape(eri, [n_ao, n_ao*n_ao*n_ao]), q1, transa="T")
+      ! Quarter 1: (mu nu|la si) -> (nu la si, i), mu contracted against the
+      ! occupied block. Held with the occupied index *last*, so that the next
+      ! quarter reads one occupied orbital's block contiguously. The obvious
+      ! (i, nu la si) layout makes that read a strided gather of nao^3 elements
+      ! per orbital, which costs more than the gemm it feeds.
+      allocate (q1(n_ao*n_ao*n_ao, n_o))
+      call pic_gemm(reshape(eri, [n_ao, n_ao*n_ao*n_ao]), c_occ, q1, transa="T")
 
       ! Quarter 2: (i nu|la si) -> (i a|la si). nu has to lead, so the i index
       ! is walked and each slice transposed into place. n_o gemms rather than
@@ -285,7 +288,7 @@ contains
          real(dp), allocatable :: slice(:, :)
          allocate (slice(n_v, n_ao*n_ao))
          do i = 1, n_o
-            work = reshape(q1(i, :), [n_ao, n_ao*n_ao])
+            work = reshape(q1(:, i), [n_ao, n_ao*n_ao])
             call pic_gemm(c_vir, work, slice, transa="T")
             do a = 1, n_v
                q2((a - 1)*n_o + i, :) = slice(a, :)

--- a/backends/libcint/mqc_libcint_mp2.f90
+++ b/backends/libcint/mqc_libcint_mp2.f90
@@ -292,16 +292,27 @@ contains
       call pic_gemm(view, c_occ, q1, transa="T")
 
       ! Quarter 2: nu against the virtual block, one occupied orbital at a time.
+      ! Each step owns its slice of q2, so the threads share nothing but q1,
+      ! which they only read.
       allocate (q2(n_ao*n_ao, n_v, n_o))
+      !$omp parallel do default(none) shared(q1, q2, c_vir, n_o, n_ao) &
+      !$omp    private(i, view) schedule(static)
       do i = 1, n_o
          view(1:n_ao, 1:n_ao*n_ao) => q1(:, i)
          call pic_gemm(view, c_vir, q2(:, :, i), transa="T")
       end do
+      !$omp end parallel do
       deallocate (q1)
 
       ! Quarters 3 and 4: la then si, per (i,a). Both slices are columns.
-      allocate (q3(n_o, n_ao), q4(n_o, n_v))
+      ! Quarters 3 and 4 likewise: (i,a) indexes a slice of q2 and a slice of
+      ! ovov, both owned outright, so the scratch is per-thread and the rest is
+      ! read-only.
       allocate (ovov(n_o, n_v, n_o, n_v))
+      !$omp parallel default(none) shared(q2, ovov, c_occ, c_vir, n_o, n_v, n_ao) &
+      !$omp    private(i, a, j, view, q3, q4)
+      allocate (q3(n_o, n_ao), q4(n_o, n_v))
+      !$omp do schedule(static)
       do i = 1, n_o
          do a = 1, n_v
             view(1:n_ao, 1:n_ao) => q2(:, a, i)
@@ -312,7 +323,10 @@ contains
             end do
          end do
       end do
-      deallocate (q2, q3, q4, c_occ, c_vir)
+      !$omp end do
+      deallocate (q3, q4)
+      !$omp end parallel
+      deallocate (q2, c_occ, c_vir)
    end subroutine transform_ovov
 
 end module mqc_libcint_mp2

--- a/backends/libcint/mqc_libcint_mp2.f90
+++ b/backends/libcint/mqc_libcint_mp2.f90
@@ -73,7 +73,7 @@ contains
          !! against an unfrozen one disagrees by tens of millihartree for a
          !! reason that has nothing to do with the implementation.
 
-      real(dp), allocatable :: eri(:, :, :, :)
+      real(dp), allocatable :: ao_eri(:, :, :, :)
       real(dp), allocatable :: ovov(:, :, :, :)
       integer :: n_ao, n_mo, n_v, n_o, frozen
       integer :: i, j, a, b
@@ -103,9 +103,9 @@ contains
          return
       end if
 
-      call mol%eris(eri)
-      call transform_ovov(eri, coeff, frozen, n_occ, n_ao, n_mo, ovov)
-      deallocate (eri)
+      call mol%eris(ao_eri)
+      call transform_ovov(ao_eri, coeff, frozen, n_occ, n_ao, n_mo, ovov)
+      deallocate (ao_eri)
 
       ! The denominators are all strictly negative for a stable reference, so a
       ! non-negative one means the SCF solution is not a minimum. Rather than
@@ -246,22 +246,36 @@ contains
    end subroutine run_libcint_ri_mp2
 
    subroutine transform_ovov(eri, coeff, frozen, n_occ, n_ao, n_mo, ovov)
-      !! (mu nu|la si) -> (ia|jb), one index at a time
+      !! (mu nu|la si) -> (ia|jb), one index at a time, without copying
       !!
-      !! Each quarter is a gemm over a reshaped view: the AO index being
-      !! transformed is made the leading dimension, the remaining three are
-      !! flattened into the trailing one, and the coefficient block multiplies
-      !! from the left. Fortran's column-major order is what makes that free --
-      !! eri(mu, nu, la, si) already has mu contiguous, so the first quarter
-      !! needs no copy at all.
-      real(dp), intent(in) :: eri(:, :, :, :)
+      !! Each quarter contracts one AO index against one coefficient block, and
+      !! each is a gemm. The care is entirely in the layout: every intermediate
+      !! is held so that the slice the next quarter reads is contiguous, and is
+      !! handed to BLAS through a bounds-remapped pointer rather than `reshape`.
+      !!
+      !! That distinction is not cosmetic. `reshape` always materialises a
+      !! temporary, so viewing one occupied orbital's block as a matrix copied
+      !! nao^3 elements per orbital -- 573 MB on a water hexamer in cc-pVDZ,
+      !! to feed gemms that together do less work than the copying. Pointer
+      !! remapping is the same view for nothing.
+      !!
+      !! The layouts, in order:
+      !!
+      !!   q1 (nu la si, i)   quarter 1 contracts mu
+      !!   q2 (la si, a, i)   quarter 2 contracts nu
+      !!   q3 (si, j)         quarter 3 contracts la, per (i,a)
+      !!   ovov (i, a, j, b)  quarter 4 contracts si
+      !!
+      !! Each is chosen so the following quarter reads down a column.
+      real(dp), intent(in), target, contiguous :: eri(:, :, :, :)
       real(dp), intent(in) :: coeff(:, :)
       integer, intent(in) :: frozen, n_occ, n_ao, n_mo
       real(dp), allocatable, intent(out) :: ovov(:, :, :, :)
 
       real(dp), allocatable :: c_occ(:, :), c_vir(:, :)
-      real(dp), allocatable :: q1(:, :), q2(:, :), q3(:, :), q4(:, :)
-      real(dp), allocatable :: work(:, :)
+      real(dp), allocatable, target :: q1(:, :), q2(:, :, :)
+      real(dp), allocatable :: q3(:, :), q4(:, :)
+      real(dp), pointer, contiguous :: view(:, :)
       integer :: n_o, n_v, i, a, j
 
       n_o = n_occ - frozen
@@ -271,77 +285,34 @@ contains
       c_occ = coeff(:, frozen + 1:n_occ)
       c_vir = coeff(:, n_occ + 1:n_mo)
 
-      ! Quarter 1: (mu nu|la si) -> (nu la si, i), mu contracted against the
-      ! occupied block. Held with the occupied index *last*, so that the next
-      ! quarter reads one occupied orbital's block contiguously. The obvious
-      ! (i, nu la si) layout makes that read a strided gather of nao^3 elements
-      ! per orbital, which costs more than the gemm it feeds.
+      ! Quarter 1: mu against the occupied block, over the whole tensor at once.
+      ! The occupied index lands last so the next quarter reads columns.
       allocate (q1(n_ao*n_ao*n_ao, n_o))
-      call pic_gemm(reshape(eri, [n_ao, n_ao*n_ao*n_ao]), c_occ, q1, transa="T")
+      view(1:n_ao, 1:n_ao*n_ao*n_ao) => eri
+      call pic_gemm(view, c_occ, q1, transa="T")
 
-      ! Quarter 2: (i nu|la si) -> (i a|la si). nu has to lead, so the i index
-      ! is walked and each slice transposed into place. n_o gemms rather than
-      ! one, which is the price of not holding a second full-size copy.
-      allocate (q2(n_o*n_v, n_ao*n_ao))
-      allocate (work(n_ao, n_ao*n_ao))
-      block
-         real(dp), allocatable :: slice(:, :)
-         allocate (slice(n_v, n_ao*n_ao))
-         do i = 1, n_o
-            work = reshape(q1(:, i), [n_ao, n_ao*n_ao])
-            call pic_gemm(c_vir, work, slice, transa="T")
-            do a = 1, n_v
-               q2((a - 1)*n_o + i, :) = slice(a, :)
-            end do
-         end do
-         deallocate (slice)
-      end block
-      deallocate (q1, work)
+      ! Quarter 2: nu against the virtual block, one occupied orbital at a time.
+      allocate (q2(n_ao*n_ao, n_v, n_o))
+      do i = 1, n_o
+         view(1:n_ao, 1:n_ao*n_ao) => q1(:, i)
+         call pic_gemm(view, c_vir, q2(:, :, i), transa="T")
+      end do
+      deallocate (q1)
 
-      ! Quarter 3: (ia|la si) -> (ia|j si), contracting la.
-      allocate (q3(n_o*n_v, n_o*n_ao))
-      block
-         real(dp), allocatable :: m(:, :), r(:, :)
-         integer :: ia
-         allocate (m(n_ao, n_ao), r(n_o, n_ao))
-         do ia = 1, n_o*n_v
-            m = reshape(q2(ia, :), [n_ao, n_ao])
-            call pic_gemm(c_occ, m, r, transa="T")
-            do j = 1, n_o
-               q3(ia, (j - 1)*n_ao + 1:j*n_ao) = r(j, :)
-            end do
-         end do
-         deallocate (m, r)
-      end block
-      deallocate (q2)
-
-      ! Quarter 4: (ia|j si) -> (ia|jb), contracting si.
-      allocate (q4(n_o*n_v, n_o*n_v))
-      block
-         real(dp), allocatable :: m(:, :), r(:, :)
-         integer :: ia
-         allocate (m(n_ao, n_o), r(n_v, n_o))
-         do ia = 1, n_o*n_v
-            m = reshape(q3(ia, :), [n_ao, n_o])
-            call pic_gemm(c_vir, m, r, transa="T")
-            do j = 1, n_o
-               q4(ia, (j - 1)*n_v + 1:j*n_v) = r(:, j)
-            end do
-         end do
-         deallocate (m, r)
-      end block
-      deallocate (q3)
-
-      ! Unpack into the shape the energy loop reads, (i, a, j, b).
+      ! Quarters 3 and 4: la then si, per (i,a). Both slices are columns.
+      allocate (q3(n_o, n_ao), q4(n_o, n_v))
       allocate (ovov(n_o, n_v, n_o, n_v))
-      do j = 1, n_o
+      do i = 1, n_o
          do a = 1, n_v
-            do i = 1, n_o
-               ovov(i, a, j, :) = q4((a - 1)*n_o + i, (j - 1)*n_v + 1:j*n_v)
+            view(1:n_ao, 1:n_ao) => q2(:, a, i)
+            call pic_gemm(c_occ, view, q3, transa="T")
+            call pic_gemm(q3, c_vir, q4)
+            do j = 1, n_o
+               ovov(i, a, j, :) = q4(j, :)
             end do
          end do
       end do
-      deallocate (q4, c_occ, c_vir)
+      deallocate (q2, q3, q4, c_occ, c_vir)
    end subroutine transform_ovov
 
 end module mqc_libcint_mp2


### PR DESCRIPTION
Optimizes the MP2 four-index transform in the libcint backend: exploits eightfold permutational symmetry when filling the in-core integrals, stops copying between the quarter transforms, threads the in-core integrals and the transform, and packs the AO pairs (the layout PySCF stores, and the reason it scaled better).

Touches `mqc_libcint_integrals.f90` and `mqc_libcint_mp2.f90`.

**Commits**
- use the eightfold symmetry when filling the in-core integrals
- stop copying between the quarter transforms
- thread the in-core integrals and the four-index transform
- pack the AO pairs, which is what PySCF stores and why it scaled better

---
_Stacked on `perf/three-centre-driver`. This PR's diff is relative to that branch._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
