### PR TITLE
Add spin-orbital CCSD and (T) on the CPU

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -401,6 +401,10 @@ if(MQC_ENABLE_LIBCINT)
   add_executable(check_rhf ${PROJECT_SOURCE_DIR}/validation/check_rhf.f90)
   target_include_directories(check_rhf PRIVATE "${CMAKE_BINARY_DIR}/modules")
   target_link_libraries(check_rhf PRIVATE ${main_lib} cint_fortran cint)
+
+  add_executable(check_cc ${PROJECT_SOURCE_DIR}/validation/check_cc.f90)
+  target_include_directories(check_cc PRIVATE "${CMAKE_BINARY_DIR}/modules")
+  target_link_libraries(check_cc PRIVATE ${main_lib} cint_fortran cint)
 endif()
 
 add_executable(check_session_run

--- a/backends/libcint/CMakeLists.txt
+++ b/backends/libcint/CMakeLists.txt
@@ -15,4 +15,4 @@ target_sources(
   ${main_lib}
   PRIVATE mqc_libcint_atomic_guess.f90 mqc_libcint_bridge.f90
           mqc_libcint_direct.f90 mqc_libcint_integrals.f90 mqc_libcint_rhf.f90
-          mqc_libcint_mp2.f90)
+          mqc_libcint_mp2.f90 mqc_libcint_cc.f90)

--- a/backends/libcint/CMakeLists.txt
+++ b/backends/libcint/CMakeLists.txt
@@ -13,6 +13,10 @@
 # ON.
 target_sources(
   ${main_lib}
-  PRIVATE mqc_libcint_atomic_guess.f90 mqc_libcint_bridge.f90
-          mqc_libcint_direct.f90 mqc_libcint_integrals.f90 mqc_libcint_rhf.f90
-          mqc_libcint_mp2.f90 mqc_libcint_cc.f90)
+  PRIVATE mqc_libcint_atomic_guess.f90
+          mqc_libcint_bridge.f90
+          mqc_libcint_direct.f90
+          mqc_libcint_integrals.f90
+          mqc_libcint_rhf.f90
+          mqc_libcint_mp2.f90
+          mqc_libcint_cc.f90)

--- a/backends/libcint/mqc_libcint_cc.f90
+++ b/backends/libcint/mqc_libcint_cc.f90
@@ -103,10 +103,12 @@ contains
       real(dp) :: v
 
       v = 0.0_dp
-      if (same_spin(p, r) .and. same_spin(q, s)) &
+      if (same_spin(p, r) .and. same_spin(q, s)) then
          v = v + mo(spatial(p), spatial(r), spatial(q), spatial(s))
-      if (same_spin(p, s) .and. same_spin(q, r)) &
+      end if
+      if (same_spin(p, s) .and. same_spin(q, r)) then
          v = v - mo(spatial(p), spatial(s), spatial(q), spatial(r))
+      end if
    end function asym
 
    subroutine spin_orbital_integrals(mo, n_so, w)
@@ -351,15 +353,39 @@ contains
       real(dp), intent(in) :: t1(:, :), t2(:, :, :, :)
       real(dp), intent(out) :: t1n(:, :), t2n(:, :, :, :)
 
-      real(dp), allocatable :: tau(:, :, :, :), taut(:, :, :, :)
+      ! Every contraction over `tau` runs over either the particle pair or the
+      ! hole pair, never a mixture, so `tau` is held as a matrix over those
+      ! compound indices from the start -- ab = (b-1) n_v + a, ij = (j-1) n_o + i.
+      ! That is what turns the four terms it appears in into four gemms. `taut`
+      ! stays four-index: the intermediates it feeds contract over one particle
+      ! and both holes, which is not a matrix product in this layout.
+      real(dp), allocatable :: tau2(:, :), taut(:, :, :, :)
       real(dp), allocatable :: fae(:, :), fmi(:, :), fme(:, :)
-      real(dp), allocatable :: wmnij(:, :, :, :), wabef(:, :, :, :), wmbej(:, :, :, :)
+      real(dp), allocatable :: wmnij(:, :), wabef(:, :), wmbej(:, :, :, :)
+      real(dp), allocatable :: oovv2(:, :), lad(:, :)
       real(dp), allocatable :: gae(:, :), gmi(:, :)
-      integer :: i, j, m, n, a, b, e, f
+      integer :: i, j, m, n, a, b, e, f, ab, ij, mn, ef
       real(dp) :: acc, d, term
 
-      allocate (tau(nv, nv, no, no), taut(nv, nv, no, no))
-      call build_tau(t1, t2, no, nv, tau, taut)
+      allocate (tau2(nv*nv, no*no), taut(nv, nv, no, no))
+      call build_tau(t1, t2, no, nv, tau2, taut)
+
+      ! <mn||ef> as a matrix over the two pairs, which is the shape three of the
+      ! gemms below want it in.
+      allocate (oovv2(no*no, nv*nv))
+      !$omp parallel do default(none) shared(w, oovv2, no, nv) &
+      !$omp    private(m, n, e, f, mn, ef) schedule(static) collapse(2)
+      do f = 1, nv
+         do e = 1, nv
+            ef = (f - 1)*nv + e
+            do n = 1, no
+               do m = 1, no
+                  oovv2((n - 1)*no + m, ef) = w(m, n, no + e, no + f)
+               end do
+            end do
+         end do
+      end do
+      !$omp end parallel do
 
       ! ---- one-body intermediates (Stanton 3-5) -----------------------------
       allocate (fae(nv, nv), fmi(no, no), fme(no, nv))
@@ -421,34 +447,35 @@ contains
       end do
 
       ! ---- two-body intermediates (Stanton 6-8) -----------------------------
-      allocate (wmnij(no, no, no, no), wabef(nv, nv, nv, nv), wmbej(no, nv, nv, no))
+      allocate (wmnij(no*no, no*no), wabef(nv*nv, nv*nv), wmbej(no, nv, nv, no))
 
-      !$omp parallel do default(none) shared(w, t1, tau, wmnij, no, nv) &
-      !$omp    private(m, n, i, j, e, f, acc) schedule(static) collapse(2)
+      ! The quadratic term of each ladder intermediate is a gemm, so it goes in
+      ! first and the linear terms are added on top of it.
+      call pic_gemm(oovv2, tau2, wmnij, alpha=0.25_dp, beta=0.0_dp)
+      !$omp parallel do default(none) shared(w, t1, wmnij, no, nv) &
+      !$omp    private(m, n, i, j, e, acc, ij) schedule(static) collapse(2)
       do j = 1, no
          do i = 1, no
+            ij = (j - 1)*no + i
             do n = 1, no
                do m = 1, no
                   acc = w(m, n, i, j)
                   do e = 1, nv
                      acc = acc + t1(e, j)*w(m, n, i, no + e) - t1(e, i)*w(m, n, j, no + e)
                   end do
-                  do f = 1, nv
-                     do e = 1, nv
-                        acc = acc + 0.25_dp*tau(e, f, i, j)*w(m, n, no + e, no + f)
-                     end do
-                  end do
-                  wmnij(m, n, i, j) = acc
+                  wmnij((n - 1)*no + m, ij) = wmnij((n - 1)*no + m, ij) + acc
                end do
             end do
          end do
       end do
       !$omp end parallel do
 
-      !$omp parallel do default(none) shared(w, t1, tau, wabef, no, nv) &
-      !$omp    private(a, b, e, f, m, n, acc) schedule(static) collapse(2)
+      call pic_gemm(tau2, oovv2, wabef, alpha=0.25_dp, beta=0.0_dp)
+      !$omp parallel do default(none) shared(w, t1, wabef, no, nv) &
+      !$omp    private(a, b, e, f, m, acc, ef) schedule(static) collapse(2)
       do f = 1, nv
          do e = 1, nv
+            ef = (f - 1)*nv + e
             do b = 1, nv
                do a = 1, nv
                   acc = w(no + a, no + b, no + e, no + f)
@@ -458,17 +485,23 @@ contains
                      acc = acc + t1(b, m)*w(m, no + a, no + e, no + f) &
                            - t1(a, m)*w(m, no + b, no + e, no + f)
                   end do
-                  do n = 1, no
-                     do m = 1, no
-                        acc = acc + 0.25_dp*tau(a, b, m, n)*w(m, n, no + e, no + f)
-                     end do
-                  end do
-                  wabef(a, b, e, f) = acc
+                  wabef((b - 1)*nv + a, ef) = wabef((b - 1)*nv + a, ef) + acc
                end do
             end do
          end do
       end do
       !$omp end parallel do
+
+      ! ---- both ladders, one gemm each --------------------------------------
+      !
+      ! The two terms that dominate CCSD: n_o^4 n_v^2 for the holes and
+      ! n_v^4 n_o^2 for the particles. As scalar loops they also had the worst
+      ! access pattern in the module -- for fixed (a,b) the particle ladder walks
+      ! `wabef` down strides of n_v^2 and n_v^3 -- and moving them here took the
+      ! T2 equation from 90 seconds of CPU time to a gemm.
+      allocate (lad(nv*nv, no*no))
+      call pic_gemm(tau2, wmnij, lad, alpha=0.5_dp, beta=0.0_dp)
+      call pic_gemm(wabef, tau2, lad, alpha=0.5_dp, beta=1.0_dp)
 
       !$omp parallel do default(none) shared(w, t1, t2, wmbej, no, nv) &
       !$omp    private(m, b, e, j, f, n, acc) schedule(static) collapse(2)
@@ -567,7 +600,7 @@ contains
       end do
 
       !$omp parallel do default(none) &
-      !$omp    shared(w, eps, t1, t2, tau, wmnij, wabef, wmbej, gae, gmi, t2n, no, nv) &
+      !$omp    shared(w, eps, t1, t2, lad, wmbej, gae, gmi, t2n, no, nv) &
       !$omp    private(a, b, i, j, e, f, m, n, acc, d, term) schedule(static) collapse(2)
       do j = 1, no
          do i = 1, no
@@ -585,17 +618,8 @@ contains
                      acc = acc - t2(a, b, i, m)*gmi(m, j) + t2(a, b, j, m)*gmi(m, i)
                   end do
 
-                  ! Ladders: hole-hole and particle-particle.
-                  do n = 1, no
-                     do m = 1, no
-                        acc = acc + 0.5_dp*tau(a, b, m, n)*wmnij(m, n, i, j)
-                     end do
-                  end do
-                  do f = 1, nv
-                     do e = 1, nv
-                        acc = acc + 0.5_dp*tau(e, f, i, j)*wabef(a, b, e, f)
-                     end do
-                  end do
+                  ! Both ladders, already contracted above.
+                  acc = acc + lad((b - 1)*nv + a, (j - 1)*no + i)
 
                   ! Rings: P(ij)P(ab) over the four index pairings.
                   do m = 1, no
@@ -634,10 +658,11 @@ contains
       end do
       !$omp end parallel do
 
-      deallocate (tau, taut, fae, fmi, fme, wmnij, wabef, wmbej, gae, gmi)
+      deallocate (tau2, taut, fae, fmi, fme, wmnij, wabef, wmbej, gae, gmi)
+      deallocate (oovv2, lad)
    end subroutine ccsd_iteration
 
-   subroutine build_tau(t1, t2, no, nv, tau, taut)
+   subroutine build_tau(t1, t2, no, nv, tau2, taut)
       !! The two effective doubles the intermediates are written in
       !!
       !!     tau      = t2 + t1 t1 - t1 t1   (transposed)
@@ -648,19 +673,20 @@ contains
       !! millihartree. Built together so the difference is visible in one place.
       real(dp), intent(in) :: t1(:, :), t2(:, :, :, :)
       integer, intent(in) :: no, nv
-      real(dp), intent(out) :: tau(:, :, :, :), taut(:, :, :, :)
+      real(dp), intent(out) :: tau2(:, :)          !! (ab, ij)
+      real(dp), intent(out) :: taut(:, :, :, :)
 
       integer :: i, j, a, b
       real(dp) :: cross
 
-      !$omp parallel do default(none) shared(t1, t2, tau, taut, no, nv) &
+      !$omp parallel do default(none) shared(t1, t2, tau2, taut, no, nv) &
       !$omp    private(i, j, a, b, cross) schedule(static) collapse(2)
       do j = 1, no
          do i = 1, no
             do b = 1, nv
                do a = 1, nv
                   cross = t1(a, i)*t1(b, j) - t1(b, i)*t1(a, j)
-                  tau(a, b, i, j) = t2(a, b, i, j) + cross
+                  tau2((b - 1)*nv + a, (j - 1)*no + i) = t2(a, b, i, j) + cross
                   taut(a, b, i, j) = t2(a, b, i, j) + 0.5_dp*cross
                end do
             end do
@@ -695,19 +721,33 @@ contains
       real(dp), intent(out) :: e_triples
 
       real(dp), allocatable :: t3c(:, :, :), t3d(:, :, :)
+      real(dp), allocatable :: ovvv_p(:, :, :), t2bc(:, :, :)
+      real(dp), allocatable :: ovoo_p(:, :, :, :), oovv_p(:, :, :)
+      real(dp), allocatable :: acc(:, :), bcc(:, :), gg(:, :, :), dd(:, :, :)
       integer :: i, j, k, a, b, c
       real(dp) :: d, e_local
 
       e_triples = 0.0_dp
 
-      !$omp parallel default(none) shared(w, eps, t1, t2, no, nv) &
-      !$omp    private(i, j, k, a, b, c, d, t3c, t3d, e_local) reduction(+:e_triples)
+      ! Four integral blocks and one amplitude block, repacked so the
+      ! contractions below are gemms over contiguous memory rather than strided
+      ! reads out of the full spin-orbital tensor. All of them are small -- the
+      ! largest is n_o n_v^3, 4.4 MB at 38 virtuals -- and each is touched
+      ! n_occ^3 times, so packing once is the whole optimisation.
+      call pack_triples_blocks(w, t2, no, nv, ovvv_p, t2bc, ovoo_p, oovv_p)
+
+      !$omp parallel default(none) &
+      !$omp    shared(eps, t1, t2, no, nv, ovvv_p, t2bc, ovoo_p, oovv_p) &
+      !$omp    private(i, j, k, a, b, c, d, t3c, t3d, e_local, acc, bcc, gg, dd) &
+      !$omp    reduction(+:e_triples)
       allocate (t3c(nv, nv, nv), t3d(nv, nv, nv))
+      allocate (acc(nv, nv*nv), bcc(nv*nv, nv), gg(nv, nv, nv), dd(nv, nv, nv))
       !$omp do schedule(dynamic) collapse(2)
       do i = 1, no
          do j = 1, no
             do k = 1, no
-               call triples_block(w, t1, t2, no, nv, i, j, k, t3c, t3d)
+               call triples_block(t1, t2, no, nv, i, j, k, ovvv_p, t2bc, ovoo_p, &
+                                  oovv_p, acc, bcc, gg, dd, t3c, t3d)
                e_local = 0.0_dp
                do c = 1, nv
                   do b = 1, nv
@@ -725,88 +765,164 @@ contains
          end do
       end do
       !$omp end do
-      deallocate (t3c, t3d)
+      deallocate (t3c, t3d, acc, bcc, gg, dd)
       !$omp end parallel
+
+      deallocate (ovvv_p, t2bc, ovoo_p, oovv_p)
    end subroutine triples_correction
 
-   subroutine triples_block(w, t1, t2, no, nv, i, j, k, t3c, t3d)
+   subroutine pack_triples_blocks(w, t2, no, nv, ovvv_p, t2bc, ovoo_p, oovv_p)
+      !! Repack what (T) contracts, so each contraction is a gemm
+      !!
+      !! The compound index is always `bc = (c-1) n_v + b`, which puts it in the
+      !! position a gemm wants: leading for the amplitude block it contracts over,
+      !! trailing for the integral block it indexes.
+      real(dp), intent(in) :: w(:, :, :, :), t2(:, :, :, :)
+      integer, intent(in) :: no, nv
+      real(dp), allocatable, intent(out) :: ovvv_p(:, :, :)    !! (e, bc, i) = <ie||bc>
+      real(dp), allocatable, intent(out) :: t2bc(:, :, :)      !! (bc, m, i) = t2(b,c,i,m)
+      real(dp), allocatable, intent(out) :: ovoo_p(:, :, :, :)  !! (m, a, j, k) = <ma||jk>
+      real(dp), allocatable, intent(out) :: oovv_p(:, :, :)    !! (bc, j, k) = <jk||bc>
+
+      integer :: i, j, k, m, a, b, c, bc
+
+      allocate (ovvv_p(nv, nv*nv, no), t2bc(nv*nv, no, no))
+      allocate (ovoo_p(no, nv, no, no), oovv_p(nv*nv, no, no))
+
+      !$omp parallel do default(none) shared(w, ovvv_p, no, nv) &
+      !$omp    private(i, b, c, bc) schedule(static)
+      do i = 1, no
+         do c = 1, nv
+            do b = 1, nv
+               bc = (c - 1)*nv + b
+               ovvv_p(:, bc, i) = w(i, no + 1:no + nv, no + b, no + c)
+            end do
+         end do
+      end do
+      !$omp end parallel do
+
+      !$omp parallel do default(none) shared(t2, t2bc, no, nv) &
+      !$omp    private(i, m, b, c, bc) schedule(static) collapse(2)
+      do i = 1, no
+         do m = 1, no
+            do c = 1, nv
+               do b = 1, nv
+                  bc = (c - 1)*nv + b
+                  t2bc(bc, m, i) = t2(b, c, i, m)
+               end do
+            end do
+         end do
+      end do
+      !$omp end parallel do
+
+      !$omp parallel do default(none) shared(w, ovoo_p, oovv_p, no, nv) &
+      !$omp    private(j, k, m, a, b, c, bc) schedule(static) collapse(2)
+      do k = 1, no
+         do j = 1, no
+            do a = 1, nv
+               do m = 1, no
+                  ovoo_p(m, a, j, k) = w(m, no + a, j, k)
+               end do
+            end do
+            do c = 1, nv
+               do b = 1, nv
+                  bc = (c - 1)*nv + b
+                  oovv_p(bc, j, k) = w(j, k, no + b, no + c)
+               end do
+            end do
+         end do
+      end do
+      !$omp end parallel do
+   end subroutine pack_triples_blocks
+
+   subroutine triples_block(t1, t2, no, nv, i, j, k, ovvv_p, t2bc, ovoo_p, oovv_p, &
+                            acc, bcc, gg, dd, t3c, t3d)
       !! The connected and disconnected triples numerators for one (i,j,k)
       !!
       !! P(i/jk) is the three-term permutation f(ijk) - f(jik) - f(kji), and
-      !! P(a/bc) likewise, so each numerator is nine signed contributions. Built
-      !! by looping the nine explicitly rather than by a permutation helper: the
-      !! signs are the whole content of the expression, and a helper would hide
-      !! exactly the thing worth reading.
-      real(dp), intent(in) :: w(:, :, :, :), t1(:, :), t2(:, :, :, :)
+      !! P(a/bc) likewise, so each numerator is nine signed contributions. The
+      !! nine are not nine pieces of work, though, and that is the whole point of
+      !! this arrangement: for a fixed occupied permutation the quantity being
+      !! permuted over the virtuals,
+      !!
+      !!     G(a,b,c) = -sum_e t2(a,e,j,k) <ie||bc> - sum_m t2(b,c,i,m) <ma||jk>
+      !!
+      !! is one object over all (a,b,c), and P(a/bc) then only reads it at
+      !! permuted indices. So three occupied permutations give three pairs of
+      !! gemms, and the virtual permutations cost nothing but the indexing.
+      !!
+      !! Written the direct way -- nine calls to a function computing one element
+      !! -- this was 118 of 260 seconds of the whole program, because every one of
+      !! the nine redid an O(n_vir) sum for every (a,b,c). The equations are
+      !! unchanged; only the order of the loops is.
+      !!
+      !! The scratch arrays come in from the caller rather than being allocated
+      !! here: this runs n_occ^3 times, and four allocations per call was itself
+      !! measurable.
+      real(dp), intent(in) :: t1(:, :), t2(:, :, :, :)
       integer, intent(in) :: no, nv, i, j, k
+      real(dp), intent(in) :: ovvv_p(:, :, :), t2bc(:, :, :)
+      real(dp), intent(in) :: ovoo_p(:, :, :, :), oovv_p(:, :, :)
+      real(dp), intent(inout) :: acc(:, :), bcc(:, :)    !! Scratch, (nv, nv^2) and (nv^2, nv)
+      real(dp), intent(inout) :: gg(:, :, :), dd(:, :, :)  !! Scratch, (nv, nv, nv)
       real(dp), intent(out) :: t3c(:, :, :), t3d(:, :, :)
 
       integer, parameter :: N_PERM = 3
-      integer :: oi(N_PERM), ov(N_PERM), po, pv, a, b, c
-      real(dp) :: sign_o, sign_v
+      integer :: oi(N_PERM)
+      integer :: po, a, b, c, bc, pi, pj, pk
+      real(dp) :: sign_o
 
       t3c = 0.0_dp
       t3d = 0.0_dp
 
-      do c = 1, nv
-         do b = 1, nv
-            do a = 1, nv
-               do po = 1, N_PERM
-                  ! P(i/jk): identity, then i<->j, then i<->k, the last two
-                  ! carrying a minus.
-                  select case (po)
-                  case (1)
-                     oi = [i, j, k]
-                     sign_o = 1.0_dp
-                  case (2)
-                     oi = [j, i, k]
-                     sign_o = -1.0_dp
-                  case default
-                     oi = [k, j, i]
-                     sign_o = -1.0_dp
-                  end select
-                  do pv = 1, N_PERM
-                     select case (pv)
-                     case (1)
-                        ov = [a, b, c]
-                        sign_v = 1.0_dp
-                     case (2)
-                        ov = [b, a, c]
-                        sign_v = -1.0_dp
-                     case default
-                        ov = [c, b, a]
-                        sign_v = -1.0_dp
-                     end select
-                     t3d(a, b, c) = t3d(a, b, c) + sign_o*sign_v &
-                                    *t1(ov(1), oi(1)) &
-                                    *w(oi(2), oi(3), no + ov(2), no + ov(3))
-                     t3c(a, b, c) = t3c(a, b, c) + sign_o*sign_v &
-                                    *connected_term(w, t2, no, nv, oi, ov)
-                  end do
+      do po = 1, N_PERM
+         ! P(i/jk): identity, then i<->j, then i<->k, the last two with a minus.
+         select case (po)
+         case (1)
+            oi = [i, j, k]
+            sign_o = 1.0_dp
+         case (2)
+            oi = [j, i, k]
+            sign_o = -1.0_dp
+         case default
+            oi = [k, j, i]
+            sign_o = -1.0_dp
+         end select
+         pi = oi(1)
+         pj = oi(2)
+         pk = oi(3)
+
+         ! -sum_e t2(a,e,j,k) <ie||bc>, as (nv,nv) x (nv,nv^2). The amplitude
+         ! slice t2(:,:,pj,pk) is already contiguous, so it goes in as it lies.
+         call pic_gemm(t2(:, :, pj, pk), ovvv_p(:, :, pi), acc, alpha=-1.0_dp, beta=0.0_dp)
+
+         ! -sum_m t2(b,c,i,m) <ma||jk>, as (nv^2,no) x (no,nv).
+         call pic_gemm(t2bc(:, :, pi), ovoo_p(:, :, pj, pk), bcc, &
+                       alpha=-1.0_dp, beta=0.0_dp)
+
+         do c = 1, nv
+            do b = 1, nv
+               bc = (c - 1)*nv + b
+               do a = 1, nv
+                  gg(a, b, c) = acc(a, bc) + bcc(bc, a)
+                  dd(a, b, c) = t1(a, pi)*oovv_p(bc, pj, pk)
+               end do
+            end do
+         end do
+
+         ! P(a/bc) reads the same two arrays at permuted indices.
+         do c = 1, nv
+            do b = 1, nv
+               do a = 1, nv
+                  t3c(a, b, c) = t3c(a, b, c) + sign_o &
+                                 *(gg(a, b, c) - gg(b, a, c) - gg(c, b, a))
+                  t3d(a, b, c) = t3d(a, b, c) + sign_o &
+                                 *(dd(a, b, c) - dd(b, a, c) - dd(c, b, a))
                end do
             end do
          end do
       end do
    end subroutine triples_block
-
-   pure function connected_term(w, t2, no, nv, oi, ov) result(v)
-      !! sum_e t2(a,e,j,k) <ei||bc> - sum_m t2(b,c,i,m) <ma||jk>
-      real(dp), intent(in) :: w(:, :, :, :), t2(:, :, :, :)
-      integer, intent(in) :: no, nv, oi(3), ov(3)
-      real(dp) :: v
-
-      integer :: e, m
-
-      v = 0.0_dp
-      do e = 1, nv
-         ! <ei||bc> = -<ie||bc>, one pair swap.
-         v = v - t2(ov(1), e, oi(2), oi(3)) &
-             *w(oi(1), no + e, no + ov(2), no + ov(3))
-      end do
-      do m = 1, no
-         v = v - t2(ov(2), ov(3), oi(1), m)*w(m, no + ov(1), oi(2), oi(3))
-      end do
-   end function connected_term
 
    subroutine pack_amplitudes(t1, t2, no, nv, flat)
       !! t1 and t2 laid end to end, for DIIS

--- a/backends/libcint/mqc_libcint_cc.f90
+++ b/backends/libcint/mqc_libcint_cc.f90
@@ -1,0 +1,855 @@
+!! Coupled cluster on the CPU, in the spin-orbital basis
+module mqc_libcint_cc
+   !! CCSD and CCSD(T) over an RHF reference, written in spin orbitals.
+   !!
+   !! Spin orbitals rather than a spin-adapted closed-shell formulation, and the
+   !! arithmetic argument loses on purpose. This is the reference path -- the same
+   !! one where conventional MP2 exists so RI-MP2 has something exact to be
+   !! checked against -- so one set of equations out of any textbook, correct and
+   !! checkable term by term, is worth more than four times the speed on the half
+   !! of cases that are closed shell. Revisit if CCSD becomes something people
+   !! run rather than something people check against.
+   !!
+   !! The consequence is that everything here is indexed by spin orbital. Active
+   !! spatial orbital `p` becomes spin orbitals `2p-1` (alpha) and `2p` (beta), so
+   !! `spatial(s) = (s+1)/2` and `is_alpha(s) = mod(s,2) == 1`. Interleaving
+   !! rather than blocking the spins is what keeps occupied and virtual
+   !! contiguous: the first `2*n_occ` spin orbitals are occupied, whatever the
+   !! spin pattern.
+   !!
+   !! The antisymmetrised integrals are
+   !!
+   !!     <pq||rs> = (pr|qs) - (ps|qr)
+   !!
+   !! with each spatial integral surviving only if the spins on the two indices
+   !! it pairs agree. Note the index reordering: the transform produces chemists'
+   !! notation and the equations are written in physicists'. That conversion is
+   !! the single most likely place for a sign or index error in the whole module,
+   !! so it happens in exactly one function -- `asym` -- and that function is unit
+   !! tested on its own antisymmetry.
+   !!
+   !! The amplitude equations follow Stanton, Gauss, Watts and Bartlett (JCP 94,
+   !! 4334 (1991)) with their one- and two-body intermediates. Written without
+   !! them the equations are both unreadable and slow; written with them they are
+   !! neither, and the table in that paper is worth following literally.
+   !!
+   !! **Frozen core** drops orbitals from the active space before anything else
+   !! happens, so nothing below this line knows they existed.
+   !!
+   !! **What this is not.** Every integral block is materialised, including
+   !! `<ab||cd>` at n_vir^4 in spin orbitals. That is the wall, and it is
+   !! deliberate: correctness first, on systems small enough to check against
+   !! PySCF, with the particle-particle ladder as the obvious first thing to fit
+   !! or batch when this needs to be fast. See the memory note in
+   !! `run_libcint_ccsd`.
+   use pic_types, only: dp
+   use pic_blas_interfaces, only: pic_gemm
+   use mqc_error, only: error_t, ERROR_VALIDATION
+   use mqc_diis, only: diis_state_t
+   use mqc_libcint_integrals, only: libcint_molecule_t
+   use mqc_libcint_mp2, only: transform_block
+   implicit none
+   private
+
+   public :: cc_result_t
+   public :: run_libcint_ccsd
+   public :: spin_orbital_integrals   !! Exported so a test can check antisymmetry
+
+   type :: cc_result_t
+      !! What a converged coupled cluster calculation leaves behind
+      real(dp) :: e_singles = 0.0_dp    !! The t1 t1 part of the correlation energy
+      real(dp) :: e_doubles = 0.0_dp    !! The t2 part
+      real(dp) :: e_triples = 0.0_dp    !! (T), zero unless it was asked for
+      real(dp) :: e_mp2 = 0.0_dp
+         !! MP2 from these same spin-orbital integrals. Free -- it is the first
+         !! iteration's energy -- and the sharpest check available on the
+         !! antisymmetrisation and the denominators, because `run_libcint_mp2`
+         !! already agrees with PySCF and this must reproduce it exactly.
+      real(dp) :: e_correlation = 0.0_dp  !! singles + doubles + triples
+      integer :: iterations = 0
+      logical :: converged = .false.
+   end type cc_result_t
+
+contains
+
+   pure function spatial(s) result(p)
+      !! Which spatial orbital a spin orbital belongs to
+      integer, intent(in) :: s
+      integer :: p
+      p = (s + 1)/2
+   end function spatial
+
+   pure function same_spin(s, t) result(same)
+      !! Whether two spin orbitals carry the same spin
+      integer, intent(in) :: s, t
+      logical :: same
+      same = mod(s, 2) == mod(t, 2)
+   end function same_spin
+
+   pure function asym(mo, p, q, r, s) result(v)
+      !! <pq||rs> from the spatial MO tensor, in spin orbitals
+      !!
+      !! The one place chemists' notation becomes physicists'. `mo` is
+      !! (pq|rs) as the transform produced it, so
+      !!
+      !!     <pq||rs> = (pr|qs) - (ps|qr)
+      !!
+      !! and a spatial integral contributes only when both index pairs it
+      !! couples share a spin -- (pr|qs) needs spin(p) == spin(r) and
+      !! spin(q) == spin(s), which is the Kronecker delta the spin integration
+      !! leaves behind.
+      real(dp), intent(in) :: mo(:, :, :, :)
+      integer, intent(in) :: p, q, r, s
+      real(dp) :: v
+
+      v = 0.0_dp
+      if (same_spin(p, r) .and. same_spin(q, s)) &
+         v = v + mo(spatial(p), spatial(r), spatial(q), spatial(s))
+      if (same_spin(p, s) .and. same_spin(q, r)) &
+         v = v - mo(spatial(p), spatial(s), spatial(q), spatial(r))
+   end function asym
+
+   subroutine spin_orbital_integrals(mo, n_so, w)
+      !! The full antisymmetrised spin-orbital tensor <pq||rs>
+      !!
+      !! Built whole rather than as blocks. The blocks below are slices of it, and
+      !! carving them out of one tensor cannot disagree about a sign the way six
+      !! separate constructions could.
+      real(dp), intent(in) :: mo(:, :, :, :)
+      integer, intent(in) :: n_so
+      real(dp), allocatable, intent(out) :: w(:, :, :, :)
+
+      integer :: p, q, r, s
+
+      allocate (w(n_so, n_so, n_so, n_so))
+      !$omp parallel do default(none) shared(w, mo, n_so) private(p, q, r, s) &
+      !$omp    schedule(static) collapse(2)
+      do s = 1, n_so
+         do r = 1, n_so
+            do q = 1, n_so
+               do p = 1, n_so
+                  w(p, q, r, s) = asym(mo, p, q, r, s)
+               end do
+            end do
+         end do
+      end do
+      !$omp end parallel do
+   end subroutine spin_orbital_integrals
+
+   subroutine run_libcint_ccsd(mol, coeff, orbital_energies, n_occ, frozen, &
+                               max_iter, energy_tol, want_triples, verbose, &
+                               result, error, diis_vectors)
+      !! Drive CCSD, and optionally (T), to convergence
+      !!
+      !! **Memory.** The spin-orbital tensor is (2 n_act)^4, which is sixteen
+      !! times the spatial one: 42 MB at 24 active orbitals, 1.1 GB at 48, and
+      !! out of reach not long after. That ceiling is why this is a reference
+      !! implementation and is checked on molecules that fit inside it. The (T)
+      !! step is the exception and holds no triples amplitude -- it works one
+      !! occupied triple at a time, n_vir^3 at once.
+      type(libcint_molecule_t), intent(in) :: mol
+      real(dp), intent(in) :: coeff(:, :)              !! MO coefficients, (n_ao, n_mo)
+      real(dp), intent(in) :: orbital_energies(:)
+      integer, intent(in) :: n_occ                     !! Spatial occupied count
+      integer, intent(in) :: frozen                    !! Spatial orbitals to freeze
+      integer, intent(in) :: max_iter
+      real(dp), intent(in) :: energy_tol
+      logical, intent(in) :: want_triples
+      logical, intent(in) :: verbose
+      type(cc_result_t), intent(out) :: result
+      type(error_t), intent(inout) :: error
+      integer, intent(in), optional :: diis_vectors
+
+      real(dp), allocatable :: eri(:, :), mo(:, :, :, :), w(:, :, :, :)
+      real(dp), allocatable :: c_act(:, :), eps(:)
+      real(dp), allocatable :: t1(:, :), t2(:, :, :, :), t1n(:, :), t2n(:, :, :, :)
+      real(dp), allocatable :: flat(:), err_flat(:)
+      type(diis_state_t) :: diis
+      logical :: extrapolated
+      integer :: n_ao, n_mo, n_act, n_o, n_v, no, nv, n_so, iter, diis_size
+      integer :: i, a, s
+      real(dp) :: e_corr, e_old, de
+
+      n_ao = size(coeff, 1)
+      n_mo = size(coeff, 2)
+
+      if (frozen < 0 .or. frozen >= n_occ) then
+         call error%set(ERROR_VALIDATION, "CCSD: the frozen core count must leave at "// &
+                        "least one occupied orbital")
+         return
+      end if
+      n_act = n_mo - frozen
+      n_o = n_occ - frozen
+      n_v = n_mo - n_occ
+      if (n_v < 1) then
+         call error%set(ERROR_VALIDATION, "CCSD: no virtual orbitals -- the basis is "// &
+                        "saturated by the occupied space and there is nothing to excite into")
+         return
+      end if
+
+      no = 2*n_o
+      nv = 2*n_v
+      n_so = no + nv
+
+      diis_size = 8
+      if (present(diis_vectors)) diis_size = diis_vectors
+
+      if (verbose) then
+         write (*, "(a,i0,a,i0,a,i0)") "  coupled cluster: ", n_so, " spin orbitals, ", &
+            no, " occupied, ", nv, " virtual"
+         if (frozen > 0) write (*, "(a,i0,a)") "  frozen core: ", frozen, " spatial orbitals"
+      end if
+
+      ! ---- integrals --------------------------------------------------------
+      call mol%eris_packed(eri)
+      allocate (c_act(n_ao, n_act))
+      c_act = coeff(:, frozen + 1:n_mo)
+      call transform_block(eri, c_act, c_act, c_act, c_act, mo)
+      deallocate (eri, c_act)
+
+      call spin_orbital_integrals(mo, n_so, w)
+      deallocate (mo)
+
+      ! Spin-orbital energies. Canonical, so the Fock matrix is this diagonal and
+      ! nothing else -- which is what lets every denominator below be a sum of
+      ! four of these rather than a matrix element.
+      allocate (eps(n_so))
+      do s = 1, n_so
+         eps(s) = orbital_energies(frozen + spatial(s))
+      end do
+
+      ! ---- MP2, as the checkpoint before any amplitude equation --------------
+      allocate (t1(nv, no), t2(nv, nv, no, no))
+      t1 = 0.0_dp
+      call mp2_amplitudes(w, eps, no, nv, t2, result%e_mp2)
+      if (verbose) write (*, "(a,f20.12)") "  MP2 (spin orbital) = ", result%e_mp2
+
+      ! ---- CCSD -------------------------------------------------------------
+      allocate (t1n(nv, no), t2n(nv, nv, no, no))
+      allocate (flat(nv*no + nv*nv*no*no), err_flat(nv*no + nv*nv*no*no))
+      call diis%init(diis_size, size(flat), size(err_flat))
+
+      e_old = 0.0_dp
+      result%converged = .false.
+      do iter = 1, max_iter
+         call ccsd_iteration(w, eps, no, nv, t1, t2, t1n, t2n)
+
+         ! Extrapolate on the amplitudes with the step as the error vector, which
+         ! is the same trick `mqc_diis` already plays on the Fock matrix: the
+         ! step vanishes exactly at convergence, so it is the right thing to
+         ! drive to zero.
+         call pack_amplitudes(t1n, t2n, no, nv, flat)
+         call pack_step(t1n, t2n, t1, t2, no, nv, err_flat)
+         call diis%push(flat, err_flat)
+         call diis%extrapolate(flat, extrapolated)
+         if (extrapolated) call unpack_amplitudes(flat, no, nv, t1n, t2n)
+
+         t1 = t1n
+         t2 = t2n
+
+         call ccsd_energy(w, t1, t2, no, nv, result%e_singles, result%e_doubles)
+         e_corr = result%e_singles + result%e_doubles
+         de = abs(e_corr - e_old)
+         if (verbose) write (*, "(a,i4,a,f20.12,a,es10.3,a,i0)") &
+            "  cc iter ", iter, "  E_corr = ", e_corr, "  dE = ", de, &
+            "  diis ", diis%count()
+
+         e_old = e_corr
+         result%iterations = iter
+         if (iter > 1 .and. de < energy_tol) then
+            result%converged = .true.
+            exit
+         end if
+      end do
+      call diis%destroy()
+
+      if (.not. result%converged) then
+         call error%set(ERROR_VALIDATION, "CCSD did not converge")
+         return
+      end if
+
+      ! ---- (T) --------------------------------------------------------------
+      if (want_triples) then
+         call triples_correction(w, eps, t1, t2, no, nv, result%e_triples)
+         if (verbose) write (*, "(a,f20.12)") "  (T) = ", result%e_triples
+      end if
+
+      result%e_correlation = result%e_singles + result%e_doubles + result%e_triples
+   end subroutine run_libcint_ccsd
+
+   subroutine mp2_amplitudes(w, eps, no, nv, t2, e_mp2)
+      !! First-order doubles, and the MP2 energy they give
+      !!
+      !!     t_ij^ab = <ij||ab> / D_ij^ab,   E = 1/4 sum <ij||ab> t_ij^ab
+      !!
+      !! This is the free checkpoint the plan asks for: it must reproduce
+      !! `run_libcint_mp2` exactly, and that already agrees with PySCF. If it
+      !! does not, the antisymmetrisation or the spin-orbital index map is wrong
+      !! and no amplitude equation after it can be right.
+      real(dp), intent(in) :: w(:, :, :, :), eps(:)
+      integer, intent(in) :: no, nv
+      real(dp), intent(out) :: t2(:, :, :, :)
+      real(dp), intent(out) :: e_mp2
+
+      integer :: i, j, a, b
+      real(dp) :: d
+
+      e_mp2 = 0.0_dp
+      !$omp parallel do default(none) shared(w, eps, t2, no, nv) &
+      !$omp    private(i, j, a, b, d) reduction(+:e_mp2) schedule(static) collapse(2)
+      do j = 1, no
+         do i = 1, no
+            do b = 1, nv
+               do a = 1, nv
+                  d = eps(i) + eps(j) - eps(no + a) - eps(no + b)
+                  t2(a, b, i, j) = w(i, j, no + a, no + b)/d
+                  e_mp2 = e_mp2 + 0.25_dp*w(i, j, no + a, no + b)*t2(a, b, i, j)
+               end do
+            end do
+         end do
+      end do
+      !$omp end parallel do
+   end subroutine mp2_amplitudes
+
+   subroutine ccsd_energy(w, t1, t2, no, nv, e_singles, e_doubles)
+      !! E_CCSD = 1/4 sum <ij||ab> t_ij^ab + 1/2 sum <ij||ab> t_i^a t_j^b
+      !!
+      !! Reported as two numbers because `cc_energy_t` carries them separately and
+      !! a lumped correlation energy cannot be taken apart afterwards. The f_ia
+      !! t_i^a term of the general expression is absent: the reference is
+      !! canonical, so the occupied-virtual Fock block is zero.
+      real(dp), intent(in) :: w(:, :, :, :), t1(:, :), t2(:, :, :, :)
+      integer, intent(in) :: no, nv
+      real(dp), intent(out) :: e_singles, e_doubles
+
+      integer :: i, j, a, b
+      real(dp) :: v
+
+      e_singles = 0.0_dp
+      e_doubles = 0.0_dp
+      !$omp parallel do default(none) shared(w, t1, t2, no, nv) &
+      !$omp    private(i, j, a, b, v) reduction(+:e_singles, e_doubles) &
+      !$omp    schedule(static) collapse(2)
+      do j = 1, no
+         do i = 1, no
+            do b = 1, nv
+               do a = 1, nv
+                  v = w(i, j, no + a, no + b)
+                  e_doubles = e_doubles + 0.25_dp*v*t2(a, b, i, j)
+                  e_singles = e_singles + 0.5_dp*v*t1(a, i)*t1(b, j)
+               end do
+            end do
+         end do
+      end do
+      !$omp end parallel do
+   end subroutine ccsd_energy
+
+   subroutine ccsd_iteration(w, eps, no, nv, t1, t2, t1n, t2n)
+      !! One CCSD amplitude update, through the Stanton et al. intermediates
+      real(dp), intent(in) :: w(:, :, :, :), eps(:)
+      integer, intent(in) :: no, nv
+      real(dp), intent(in) :: t1(:, :), t2(:, :, :, :)
+      real(dp), intent(out) :: t1n(:, :), t2n(:, :, :, :)
+
+      real(dp), allocatable :: tau(:, :, :, :), taut(:, :, :, :)
+      real(dp), allocatable :: fae(:, :), fmi(:, :), fme(:, :)
+      real(dp), allocatable :: wmnij(:, :, :, :), wabef(:, :, :, :), wmbej(:, :, :, :)
+      real(dp), allocatable :: gae(:, :), gmi(:, :)
+      integer :: i, j, m, n, a, b, e, f
+      real(dp) :: acc, d, term
+
+      allocate (tau(nv, nv, no, no), taut(nv, nv, no, no))
+      call build_tau(t1, t2, no, nv, tau, taut)
+
+      ! ---- one-body intermediates (Stanton 3-5) -----------------------------
+      allocate (fae(nv, nv), fmi(no, no), fme(no, nv))
+
+      !$omp parallel do default(none) shared(w, t1, taut, fae, no, nv) &
+      !$omp    private(a, e, m, f, n, acc) schedule(static)
+      do e = 1, nv
+         do a = 1, nv
+            acc = 0.0_dp
+            do m = 1, no
+               do f = 1, nv
+                  acc = acc + t1(f, m)*w(m, no + a, no + f, no + e)
+               end do
+            end do
+            do n = 1, no
+               do m = 1, no
+                  do f = 1, nv
+                     acc = acc - 0.5_dp*taut(a, f, m, n)*w(m, n, no + e, no + f)
+                  end do
+               end do
+            end do
+            fae(a, e) = acc
+         end do
+      end do
+      !$omp end parallel do
+
+      !$omp parallel do default(none) shared(w, t1, taut, fmi, no, nv) &
+      !$omp    private(m, i, e, n, f, acc) schedule(static)
+      do i = 1, no
+         do m = 1, no
+            acc = 0.0_dp
+            do n = 1, no
+               do e = 1, nv
+                  acc = acc + t1(e, n)*w(m, n, i, no + e)
+               end do
+            end do
+            do n = 1, no
+               do f = 1, nv
+                  do e = 1, nv
+                     acc = acc + 0.5_dp*taut(e, f, i, n)*w(m, n, no + e, no + f)
+                  end do
+               end do
+            end do
+            fmi(m, i) = acc
+         end do
+      end do
+      !$omp end parallel do
+
+      do e = 1, nv
+         do m = 1, no
+            acc = 0.0_dp
+            do n = 1, no
+               do f = 1, nv
+                  acc = acc + t1(f, n)*w(m, n, no + e, no + f)
+               end do
+            end do
+            fme(m, e) = acc
+         end do
+      end do
+
+      ! ---- two-body intermediates (Stanton 6-8) -----------------------------
+      allocate (wmnij(no, no, no, no), wabef(nv, nv, nv, nv), wmbej(no, nv, nv, no))
+
+      !$omp parallel do default(none) shared(w, t1, tau, wmnij, no, nv) &
+      !$omp    private(m, n, i, j, e, f, acc) schedule(static) collapse(2)
+      do j = 1, no
+         do i = 1, no
+            do n = 1, no
+               do m = 1, no
+                  acc = w(m, n, i, j)
+                  do e = 1, nv
+                     acc = acc + t1(e, j)*w(m, n, i, no + e) - t1(e, i)*w(m, n, j, no + e)
+                  end do
+                  do f = 1, nv
+                     do e = 1, nv
+                        acc = acc + 0.25_dp*tau(e, f, i, j)*w(m, n, no + e, no + f)
+                     end do
+                  end do
+                  wmnij(m, n, i, j) = acc
+               end do
+            end do
+         end do
+      end do
+      !$omp end parallel do
+
+      !$omp parallel do default(none) shared(w, t1, tau, wabef, no, nv) &
+      !$omp    private(a, b, e, f, m, n, acc) schedule(static) collapse(2)
+      do f = 1, nv
+         do e = 1, nv
+            do b = 1, nv
+               do a = 1, nv
+                  acc = w(no + a, no + b, no + e, no + f)
+                  do m = 1, no
+                     ! <am||ef> = -<ma||ef>, and likewise for b. Writing it this
+                     ! way keeps every integral read out of the same block.
+                     acc = acc + t1(b, m)*w(m, no + a, no + e, no + f) &
+                           - t1(a, m)*w(m, no + b, no + e, no + f)
+                  end do
+                  do n = 1, no
+                     do m = 1, no
+                        acc = acc + 0.25_dp*tau(a, b, m, n)*w(m, n, no + e, no + f)
+                     end do
+                  end do
+                  wabef(a, b, e, f) = acc
+               end do
+            end do
+         end do
+      end do
+      !$omp end parallel do
+
+      !$omp parallel do default(none) shared(w, t1, t2, wmbej, no, nv) &
+      !$omp    private(m, b, e, j, f, n, acc) schedule(static) collapse(2)
+      do j = 1, no
+         do e = 1, nv
+            do b = 1, nv
+               do m = 1, no
+                  acc = w(m, no + b, no + e, j)
+                  do f = 1, nv
+                     acc = acc + t1(f, j)*w(m, no + b, no + e, no + f)
+                  end do
+                  do n = 1, no
+                     ! <mn||ej> = <mn||je> with the last pair swapped, hence the
+                     ! sign: -(-ooov) = +.
+                     acc = acc + t1(b, n)*w(m, n, j, no + e)
+                  end do
+                  do n = 1, no
+                     do f = 1, nv
+                        acc = acc - (0.5_dp*t2(f, b, j, n) + t1(f, j)*t1(b, n)) &
+                              *w(m, n, no + e, no + f)
+                     end do
+                  end do
+                  wmbej(m, b, e, j) = acc
+               end do
+            end do
+         end do
+      end do
+      !$omp end parallel do
+
+      ! ---- T1 (Stanton 1) ---------------------------------------------------
+      !$omp parallel do default(none) shared(w, eps, t1, t2, fae, fmi, fme, t1n, no, nv) &
+      !$omp    private(a, i, e, m, n, f, acc, d) schedule(static)
+      do i = 1, no
+         do a = 1, nv
+            acc = 0.0_dp
+            do e = 1, nv
+               acc = acc + t1(e, i)*fae(a, e)
+            end do
+            do m = 1, no
+               acc = acc - t1(a, m)*fmi(m, i)
+            end do
+            do m = 1, no
+               do e = 1, nv
+                  acc = acc + t2(a, e, i, m)*fme(m, e)
+               end do
+            end do
+            do n = 1, no
+               do f = 1, nv
+                  acc = acc - t1(f, n)*w(n, no + a, i, no + f)
+               end do
+            end do
+            do m = 1, no
+               do f = 1, nv
+                  do e = 1, nv
+                     acc = acc - 0.5_dp*t2(e, f, i, m)*w(m, no + a, no + e, no + f)
+                  end do
+               end do
+            end do
+            do n = 1, no
+               do m = 1, no
+                  do e = 1, nv
+                     ! <nm||ei> = <mn||ie>, two pair swaps.
+                     acc = acc - 0.5_dp*t2(a, e, m, n)*w(m, n, i, no + e)
+                  end do
+               end do
+            end do
+            d = eps(i) - eps(no + a)
+            t1n(a, i) = acc/d
+         end do
+      end do
+      !$omp end parallel do
+
+      ! ---- T2 (Stanton 2) ---------------------------------------------------
+      !
+      ! The two damped one-body intermediates are hoisted: they depend on the
+      ! index being permuted, not on the amplitude being solved for, so building
+      ! them once outside is worth n_o n_v of arithmetic each.
+      allocate (gae(nv, nv), gmi(no, no))
+      do e = 1, nv
+         do a = 1, nv
+            acc = fae(a, e)
+            do m = 1, no
+               acc = acc - 0.5_dp*t1(a, m)*fme(m, e)
+            end do
+            gae(a, e) = acc
+         end do
+      end do
+      do i = 1, no
+         do m = 1, no
+            acc = fmi(m, i)
+            do e = 1, nv
+               acc = acc + 0.5_dp*t1(e, i)*fme(m, e)
+            end do
+            gmi(m, i) = acc
+         end do
+      end do
+
+      !$omp parallel do default(none) &
+      !$omp    shared(w, eps, t1, t2, tau, wmnij, wabef, wmbej, gae, gmi, t2n, no, nv) &
+      !$omp    private(a, b, i, j, e, f, m, n, acc, d, term) schedule(static) collapse(2)
+      do j = 1, no
+         do i = 1, no
+            do b = 1, nv
+               do a = 1, nv
+                  acc = w(i, j, no + a, no + b)
+
+                  ! P(ab) sum_e t2(a,e,i,j) Gae(b,e)
+                  do e = 1, nv
+                     acc = acc + t2(a, e, i, j)*gae(b, e) - t2(b, e, i, j)*gae(a, e)
+                  end do
+
+                  ! -P(ij) sum_m t2(a,b,i,m) Gmi(m,j)
+                  do m = 1, no
+                     acc = acc - t2(a, b, i, m)*gmi(m, j) + t2(a, b, j, m)*gmi(m, i)
+                  end do
+
+                  ! Ladders: hole-hole and particle-particle.
+                  do n = 1, no
+                     do m = 1, no
+                        acc = acc + 0.5_dp*tau(a, b, m, n)*wmnij(m, n, i, j)
+                     end do
+                  end do
+                  do f = 1, nv
+                     do e = 1, nv
+                        acc = acc + 0.5_dp*tau(e, f, i, j)*wabef(a, b, e, f)
+                     end do
+                  end do
+
+                  ! Rings: P(ij)P(ab) over the four index pairings.
+                  do m = 1, no
+                     do e = 1, nv
+                        term = t2(a, e, i, m)*wmbej(m, b, e, j) &
+                               - t1(e, i)*t1(a, m)*w(m, no + b, no + e, j)
+                        acc = acc + term
+                        term = t2(a, e, j, m)*wmbej(m, b, e, i) &
+                               - t1(e, j)*t1(a, m)*w(m, no + b, no + e, i)
+                        acc = acc - term
+                        term = t2(b, e, i, m)*wmbej(m, a, e, j) &
+                               - t1(e, i)*t1(b, m)*w(m, no + a, no + e, j)
+                        acc = acc - term
+                        term = t2(b, e, j, m)*wmbej(m, a, e, i) &
+                               - t1(e, j)*t1(b, m)*w(m, no + a, no + e, i)
+                        acc = acc + term
+                     end do
+                  end do
+
+                  ! P(ij) sum_e t1(e,i) <ab||ej>
+                  do e = 1, nv
+                     acc = acc + t1(e, i)*w(no + a, no + b, no + e, j) &
+                           - t1(e, j)*w(no + a, no + b, no + e, i)
+                  end do
+
+                  ! -P(ab) sum_m t1(a,m) <mb||ij>
+                  do m = 1, no
+                     acc = acc - t1(a, m)*w(m, no + b, i, j) + t1(b, m)*w(m, no + a, i, j)
+                  end do
+
+                  d = eps(i) + eps(j) - eps(no + a) - eps(no + b)
+                  t2n(a, b, i, j) = acc/d
+               end do
+            end do
+         end do
+      end do
+      !$omp end parallel do
+
+      deallocate (tau, taut, fae, fmi, fme, wmnij, wabef, wmbej, gae, gmi)
+   end subroutine ccsd_iteration
+
+   subroutine build_tau(t1, t2, no, nv, tau, taut)
+      !! The two effective doubles the intermediates are written in
+      !!
+      !!     tau      = t2 + t1 t1 - t1 t1   (transposed)
+      !!     tau~     = t2 + 1/2 (t1 t1 - t1 t1)
+      !!
+      !! Two of them, differing only in that half, and mixing them up is a
+      !! mistake that still converges -- to the wrong energy by a few
+      !! millihartree. Built together so the difference is visible in one place.
+      real(dp), intent(in) :: t1(:, :), t2(:, :, :, :)
+      integer, intent(in) :: no, nv
+      real(dp), intent(out) :: tau(:, :, :, :), taut(:, :, :, :)
+
+      integer :: i, j, a, b
+      real(dp) :: cross
+
+      !$omp parallel do default(none) shared(t1, t2, tau, taut, no, nv) &
+      !$omp    private(i, j, a, b, cross) schedule(static) collapse(2)
+      do j = 1, no
+         do i = 1, no
+            do b = 1, nv
+               do a = 1, nv
+                  cross = t1(a, i)*t1(b, j) - t1(b, i)*t1(a, j)
+                  tau(a, b, i, j) = t2(a, b, i, j) + cross
+                  taut(a, b, i, j) = t2(a, b, i, j) + 0.5_dp*cross
+               end do
+            end do
+         end do
+      end do
+      !$omp end parallel do
+   end subroutine build_tau
+
+   subroutine triples_correction(w, eps, t1, t2, no, nv, e_triples)
+      !! (T), the perturbative triples correction
+      !!
+      !! Non-iterative, so one pass after CCSD converges, and n_occ^3 n_vir^4 --
+      !! the wall. No triples amplitude is stored: the two n_vir^3 blocks are
+      !! rebuilt for each occupied triple, which is what keeps this inside memory
+      !! when a full t3 would be n_o^3 n_v^3.
+      !!
+      !!     E(T) = 1/36 sum t3c D (t3c + t3d)
+      !!
+      !! with the connected and disconnected triples
+      !!
+      !!     t3d D = P(i/jk) P(a/bc) t1(a,i) <jk||bc>
+      !!     t3c D = P(i/jk) P(a/bc) [ sum_e t2(a,e,j,k) <ei||bc>
+      !!                               - sum_m t2(b,c,i,m) <ma||jk> ]
+      !!
+      !! The 1/36 is the price of summing every permutation of both triples
+      !! rather than restricting to i<j<k and a<b<c. Restricting is the obvious
+      !! optimisation and is deliberately not done here -- the unrestricted form
+      !! is what the equations say, and this is the pass that has to be right
+      !! before anything is made fast.
+      real(dp), intent(in) :: w(:, :, :, :), eps(:), t1(:, :), t2(:, :, :, :)
+      integer, intent(in) :: no, nv
+      real(dp), intent(out) :: e_triples
+
+      real(dp), allocatable :: t3c(:, :, :), t3d(:, :, :)
+      integer :: i, j, k, a, b, c
+      real(dp) :: d, e_local
+
+      e_triples = 0.0_dp
+
+      !$omp parallel default(none) shared(w, eps, t1, t2, no, nv) &
+      !$omp    private(i, j, k, a, b, c, d, t3c, t3d, e_local) reduction(+:e_triples)
+      allocate (t3c(nv, nv, nv), t3d(nv, nv, nv))
+      !$omp do schedule(dynamic) collapse(2)
+      do i = 1, no
+         do j = 1, no
+            do k = 1, no
+               call triples_block(w, t1, t2, no, nv, i, j, k, t3c, t3d)
+               e_local = 0.0_dp
+               do c = 1, nv
+                  do b = 1, nv
+                     do a = 1, nv
+                        d = eps(i) + eps(j) + eps(k) &
+                            - eps(no + a) - eps(no + b) - eps(no + c)
+                        ! t3c and t3d arrive as numerators; dividing here rather
+                        ! than twice inside the block keeps the block additive.
+                        e_local = e_local + t3c(a, b, c)*(t3c(a, b, c) + t3d(a, b, c))/d
+                     end do
+                  end do
+               end do
+               e_triples = e_triples + e_local/36.0_dp
+            end do
+         end do
+      end do
+      !$omp end do
+      deallocate (t3c, t3d)
+      !$omp end parallel
+   end subroutine triples_correction
+
+   subroutine triples_block(w, t1, t2, no, nv, i, j, k, t3c, t3d)
+      !! The connected and disconnected triples numerators for one (i,j,k)
+      !!
+      !! P(i/jk) is the three-term permutation f(ijk) - f(jik) - f(kji), and
+      !! P(a/bc) likewise, so each numerator is nine signed contributions. Built
+      !! by looping the nine explicitly rather than by a permutation helper: the
+      !! signs are the whole content of the expression, and a helper would hide
+      !! exactly the thing worth reading.
+      real(dp), intent(in) :: w(:, :, :, :), t1(:, :), t2(:, :, :, :)
+      integer, intent(in) :: no, nv, i, j, k
+      real(dp), intent(out) :: t3c(:, :, :), t3d(:, :, :)
+
+      integer, parameter :: N_PERM = 3
+      integer :: oi(N_PERM), ov(N_PERM), po, pv, a, b, c
+      real(dp) :: sign_o, sign_v
+
+      t3c = 0.0_dp
+      t3d = 0.0_dp
+
+      do c = 1, nv
+         do b = 1, nv
+            do a = 1, nv
+               do po = 1, N_PERM
+                  ! P(i/jk): identity, then i<->j, then i<->k, the last two
+                  ! carrying a minus.
+                  select case (po)
+                  case (1)
+                     oi = [i, j, k]
+                     sign_o = 1.0_dp
+                  case (2)
+                     oi = [j, i, k]
+                     sign_o = -1.0_dp
+                  case default
+                     oi = [k, j, i]
+                     sign_o = -1.0_dp
+                  end select
+                  do pv = 1, N_PERM
+                     select case (pv)
+                     case (1)
+                        ov = [a, b, c]
+                        sign_v = 1.0_dp
+                     case (2)
+                        ov = [b, a, c]
+                        sign_v = -1.0_dp
+                     case default
+                        ov = [c, b, a]
+                        sign_v = -1.0_dp
+                     end select
+                     t3d(a, b, c) = t3d(a, b, c) + sign_o*sign_v &
+                                    *t1(ov(1), oi(1)) &
+                                    *w(oi(2), oi(3), no + ov(2), no + ov(3))
+                     t3c(a, b, c) = t3c(a, b, c) + sign_o*sign_v &
+                                    *connected_term(w, t2, no, nv, oi, ov)
+                  end do
+               end do
+            end do
+         end do
+      end do
+   end subroutine triples_block
+
+   pure function connected_term(w, t2, no, nv, oi, ov) result(v)
+      !! sum_e t2(a,e,j,k) <ei||bc> - sum_m t2(b,c,i,m) <ma||jk>
+      real(dp), intent(in) :: w(:, :, :, :), t2(:, :, :, :)
+      integer, intent(in) :: no, nv, oi(3), ov(3)
+      real(dp) :: v
+
+      integer :: e, m
+
+      v = 0.0_dp
+      do e = 1, nv
+         ! <ei||bc> = -<ie||bc>, one pair swap.
+         v = v - t2(ov(1), e, oi(2), oi(3)) &
+             *w(oi(1), no + e, no + ov(2), no + ov(3))
+      end do
+      do m = 1, no
+         v = v - t2(ov(2), ov(3), oi(1), m)*w(m, no + ov(1), oi(2), oi(3))
+      end do
+   end function connected_term
+
+   subroutine pack_amplitudes(t1, t2, no, nv, flat)
+      !! t1 and t2 laid end to end, for DIIS
+      real(dp), intent(in) :: t1(:, :), t2(:, :, :, :)
+      integer, intent(in) :: no, nv
+      real(dp), intent(out) :: flat(:)
+
+      integer :: n1
+
+      n1 = nv*no
+      flat(1:n1) = reshape(t1, [n1])
+      flat(n1 + 1:n1 + nv*nv*no*no) = reshape(t2, [nv*nv*no*no])
+   end subroutine pack_amplitudes
+
+   subroutine unpack_amplitudes(flat, no, nv, t1, t2)
+      !! The inverse of `pack_amplitudes`
+      real(dp), intent(in) :: flat(:)
+      integer, intent(in) :: no, nv
+      real(dp), intent(out) :: t1(:, :), t2(:, :, :, :)
+
+      integer :: n1
+
+      n1 = nv*no
+      t1 = reshape(flat(1:n1), [nv, no])
+      t2 = reshape(flat(n1 + 1:n1 + nv*nv*no*no), [nv, nv, no, no])
+   end subroutine unpack_amplitudes
+
+   subroutine pack_step(t1n, t2n, t1, t2, no, nv, flat)
+      !! The change in the amplitudes, which is the DIIS error vector
+      !!
+      !! It vanishes exactly at a fixed point of the amplitude equations, which
+      !! is what convergence means here, so it is the right quantity to
+      !! extrapolate against -- the same argument as the FDS - SDF commutator in
+      !! the SCF.
+      real(dp), intent(in) :: t1n(:, :), t2n(:, :, :, :), t1(:, :), t2(:, :, :, :)
+      integer, intent(in) :: no, nv
+      real(dp), intent(out) :: flat(:)
+
+      integer :: n1
+
+      n1 = nv*no
+      flat(1:n1) = reshape(t1n - t1, [n1])
+      flat(n1 + 1:n1 + nv*nv*no*no) = reshape(t2n - t2, [nv*nv*no*no])
+   end subroutine pack_step
+
+end module mqc_libcint_cc

--- a/backends/libcint/mqc_libcint_mp2.f90
+++ b/backends/libcint/mqc_libcint_mp2.f90
@@ -41,6 +41,10 @@ module mqc_libcint_mp2
    public :: run_libcint_mp2
    public :: run_libcint_ri_mp2
    public :: mp2_result_t
+   ! Exported for coupled cluster, which needs every MO block rather than just
+   ! (ia|jb). Lives here because this is where the two-half transform is, and a
+   ! second copy of it in the CC module is a second chance to transpose a half.
+   public :: transform_block
 
    type :: mp2_result_t
       !! What an MP2 calculation leaves behind
@@ -246,7 +250,26 @@ contains
    end subroutine run_libcint_ri_mp2
 
    subroutine transform_ovov(eri, coeff, frozen, n_occ, n_ao, n_mo, ovov)
-      !! (pq|rs) over packed AO pairs -> (ia|jb), in two symmetric halves
+      !! (pq|rs) over packed AO pairs -> (ia|jb)
+      !!
+      !! A thin caller for `transform_block`, kept so the MP2 path reads as the
+      !! one block it wants rather than as the general routine underneath.
+      real(dp), intent(in) :: eri(:, :)      !! (n_pair, n_pair), see `pair_index`
+      real(dp), intent(in) :: coeff(:, :)
+      integer, intent(in) :: frozen, n_occ, n_ao, n_mo
+      real(dp), allocatable, intent(out) :: ovov(:, :, :, :)
+
+      real(dp), allocatable :: c_occ(:, :), c_vir(:, :)
+
+      allocate (c_occ(n_ao, n_occ - frozen), c_vir(n_ao, n_mo - n_occ))
+      c_occ = coeff(:, frozen + 1:n_occ)
+      c_vir = coeff(:, n_occ + 1:n_mo)
+      call transform_block(eri, c_occ, c_vir, c_occ, c_vir, ovov)
+      deallocate (c_occ, c_vir)
+   end subroutine transform_ovov
+
+   subroutine transform_block(eri, c1, c2, c3, c4, out)
+      !! (pq|rs) over packed AO pairs -> (12|34) for any four coefficient blocks
       !!
       !! With the AO pairs packed, the four quarter transforms fall into two
       !! identical halves. One column of the packed tensor is a whole AO pair
@@ -260,31 +283,36 @@ contains
       !! The unpack is the price of the packing, and it is a good trade: it
       !! touches nao^2 elements where the dense form wrote nao^4 across eight
       !! stride patterns to avoid it.
+      !!
+      !! Which blocks come out is entirely the caller's four coefficient
+      !! matrices: C_occ/C_vir twice over gives (ia|jb) for MP2, and C_act four
+      !! times over gives the whole active MO tensor, which is what coupled
+      !! cluster needs. Nothing here knows the difference, which is the point --
+      !! the alternative was six near-identical transforms and six chances to
+      !! transpose one.
       real(dp), intent(in) :: eri(:, :)      !! (n_pair, n_pair), see `pair_index`
-      real(dp), intent(in) :: coeff(:, :)
-      integer, intent(in) :: frozen, n_occ, n_ao, n_mo
-      real(dp), allocatable, intent(out) :: ovov(:, :, :, :)
+      real(dp), intent(in) :: c1(:, :), c2(:, :)   !! Bra pair, left and right
+      real(dp), intent(in) :: c3(:, :), c4(:, :)   !! Ket pair, left and right
+      real(dp), allocatable, intent(out) :: out(:, :, :, :)
 
-      real(dp), allocatable :: c_occ(:, :), c_vir(:, :)
       real(dp), allocatable :: half(:, :)
-      real(dp), allocatable :: m(:, :), tmp(:, :), block_ov(:, :)
-      integer :: n_o, n_v, n_pair, pq, i, a, j, b, p, q
+      real(dp), allocatable :: m(:, :), tmp(:, :), blk(:, :)
+      integer :: n_ao, n1, n2, n3, n4, n_pair, pq, l, mm, n, o, p, q
 
-      n_o = n_occ - frozen
-      n_v = n_mo - n_occ
+      n_ao = size(c1, 1)
+      n1 = size(c1, 2)
+      n2 = size(c2, 2)
+      n3 = size(c3, 2)
+      n4 = size(c4, 2)
       n_pair = n_ao*(n_ao + 1)/2
 
-      allocate (c_occ(n_ao, n_o), c_vir(n_ao, n_v))
-      c_occ = coeff(:, frozen + 1:n_occ)
-      c_vir = coeff(:, n_occ + 1:n_mo)
-
-      ! First half: every packed bra pair transformed to (ia), leaving (ia|rs).
+      ! First half: every packed bra pair transformed to (12), leaving (12|rs).
       ! Held with the packed index first so the second half reads columns.
-      allocate (half(n_pair, n_o*n_v))
+      allocate (half(n_pair, n1*n2))
       !$omp parallel default(none) &
-      !$omp    shared(eri, half, c_occ, c_vir, n_pair, n_ao, n_o, n_v) &
-      !$omp    private(pq, p, q, i, a, m, tmp, block_ov)
-      allocate (m(n_ao, n_ao), tmp(n_o, n_ao), block_ov(n_o, n_v))
+      !$omp    shared(eri, half, c1, c2, n_pair, n_ao, n1, n2) &
+      !$omp    private(pq, p, q, l, mm, m, tmp, blk)
+      allocate (m(n_ao, n_ao), tmp(n1, n_ao), blk(n1, n2))
       !$omp do schedule(static)
       do pq = 1, n_pair
          do q = 1, n_ao
@@ -292,46 +320,46 @@ contains
                m(p, q) = eri(pair_index(p, q), pq)
             end do
          end do
-         call pic_gemm(c_occ, m, tmp, transa="T")
-         call pic_gemm(tmp, c_vir, block_ov)
-         do a = 1, n_v
-            do i = 1, n_o
-               half(pq, (a - 1)*n_o + i) = block_ov(i, a)
+         call pic_gemm(c1, m, tmp, transa="T")
+         call pic_gemm(tmp, c2, blk)
+         do mm = 1, n2
+            do l = 1, n1
+               half(pq, (mm - 1)*n1 + l) = blk(l, mm)
             end do
          end do
       end do
       !$omp end do
-      deallocate (m, tmp, block_ov)
+      deallocate (m, tmp, blk)
       !$omp end parallel
 
-      ! Second half: the same operation on the ket pair, for each (ia).
-      allocate (ovov(n_o, n_v, n_o, n_v))
+      ! Second half: the same operation on the ket pair, for each (12).
+      allocate (out(n1, n2, n3, n4))
       !$omp parallel default(none) &
-      !$omp    shared(half, ovov, c_occ, c_vir, n_pair, n_ao, n_o, n_v) &
-      !$omp    private(pq, p, q, i, a, j, b, m, tmp, block_ov)
-      allocate (m(n_ao, n_ao), tmp(n_o, n_ao), block_ov(n_o, n_v))
+      !$omp    shared(half, out, c3, c4, n_pair, n_ao, n1, n2, n3, n4) &
+      !$omp    private(pq, p, q, l, mm, n, o, m, tmp, blk)
+      allocate (m(n_ao, n_ao), tmp(n3, n_ao), blk(n3, n4))
       !$omp do schedule(static) collapse(2)
-      do a = 1, n_v
-         do i = 1, n_o
+      do mm = 1, n2
+         do l = 1, n1
             do q = 1, n_ao
                do p = 1, n_ao
-                  m(p, q) = half(pair_index(p, q), (a - 1)*n_o + i)
+                  m(p, q) = half(pair_index(p, q), (mm - 1)*n1 + l)
                end do
             end do
-            call pic_gemm(c_occ, m, tmp, transa="T")
-            call pic_gemm(tmp, c_vir, block_ov)
-            do b = 1, n_v
-               do j = 1, n_o
-                  ovov(i, a, j, b) = block_ov(j, b)
+            call pic_gemm(c3, m, tmp, transa="T")
+            call pic_gemm(tmp, c4, blk)
+            do o = 1, n4
+               do n = 1, n3
+                  out(l, mm, n, o) = blk(n, o)
                end do
             end do
          end do
       end do
       !$omp end do
-      deallocate (m, tmp, block_ov)
+      deallocate (m, tmp, blk)
       !$omp end parallel
 
-      deallocate (half, c_occ, c_vir)
-   end subroutine transform_ovov
+      deallocate (half)
+   end subroutine transform_block
 
 end module mqc_libcint_mp2

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -82,6 +82,13 @@ if(MQC_ENABLE_LIBCINT)
   addtest(mqc_libcint_guess)
   target_link_libraries(test_mqc_libcint_guess PRIVATE cint_fortran cint)
 
+  # Coupled cluster, against the identities a reference energy cannot see:
+  # <pq||rs> antisymmetry, spin-forbidden integrals vanishing exactly, and the
+  # spin-orbital MP2 equalling the conventional one. PySCF comparison lives in
+  # validation/check_cc.f90, which needs the basis files.
+  addtest(mqc_libcint_cc)
+  target_link_libraries(test_mqc_libcint_cc PRIVATE cint_fortran cint)
+
   # Conventional MP2: the structural properties a reference energy cannot see,
   # chiefly that the four-index transform keeps (ia|jb) == (jb|ia).
   addtest(mqc_libcint_mp2)

--- a/test/test_mqc_libcint_cc.f90
+++ b/test/test_mqc_libcint_cc.f90
@@ -1,0 +1,315 @@
+module test_mqc_libcint_cc
+   !! Pins coupled cluster against what a reference energy cannot see.
+   !!
+   !! `validation/check_cc.f90` already compares CCSD and (T) to PySCF, which is
+   !! the check that matters and the one that would catch a wrong equation. It
+   !! needs the basis files and takes seconds, so it is a manual program rather
+   !! than a unit test. What is here instead are the properties that hold by
+   !! construction, and whose failure would mean something structurally wrong
+   !! rather than numerically off:
+   !!
+   !!   * `<pq||rs>` is antisymmetric under swapping either pair, and symmetric
+   !!     under swapping both. The conversion from chemists' to physicists'
+   !!     notation is the likeliest place in the module for a sign error, and
+   !!     these identities are exact -- they cannot be satisfied approximately by
+   !!     a plausible-looking tensor.
+   !!   * a spin-forbidden integral vanishes. Spin integration leaves Kronecker
+   !!     deltas, and dropping them gives an answer that still converges.
+   !!   * MP2 out of the spin-orbital machinery equals conventional MP2 exactly.
+   !!     Two entirely separate routes to one number.
+   !!   * CCSD correlation lies below MP2, and (T) below that, for a closed-shell
+   !!     molecule at its minimum.
+   !!   * freezing a core orbital raises the correlation energy by millihartree,
+   !!     not by tens -- which is what a frozen-core indexing error looks like.
+   use testdrive, only: new_unittest, unittest_type, error_type, check
+   use pic_types, only: dp
+   use mqc_error, only: error_t
+   use mqc_libcint_integrals, only: libcint_molecule_t, build_libcint_molecule
+   use mqc_libcint_rhf, only: rhf_result_t, run_libcint_rhf
+   use mqc_libcint_mp2, only: mp2_result_t, run_libcint_mp2
+   use mqc_libcint_cc, only: cc_result_t, run_libcint_ccsd, spin_orbital_integrals
+   implicit none
+   private
+   public :: collect_mqc_libcint_cc_tests
+
+   real(dp), parameter :: ANG = 1.8897261254578281_dp
+
+contains
+
+   subroutine collect_mqc_libcint_cc_tests(testsuite)
+      type(unittest_type), allocatable, intent(out) :: testsuite(:)
+
+      testsuite = [ &
+                  new_unittest("antisymmetrised_integrals_are_antisymmetric", test_antisymmetry), &
+                  new_unittest("spin_forbidden_integrals_vanish", test_spin_blocks), &
+                  new_unittest("spin_orbital_mp2_equals_conventional", test_mp2_identity), &
+                  new_unittest("ccsd_lies_below_mp2_and_triples_below_that", test_ordering), &
+                  new_unittest("freezing_a_core_orbital_raises_correlation", test_frozen) &
+                  ]
+   end subroutine collect_mqc_libcint_cc_tests
+
+   subroutine water(mol, err, basis)
+      type(libcint_molecule_t), intent(out) :: mol
+      type(error_t), intent(inout) :: err
+      character(len=*), intent(in) :: basis
+      real(dp) :: c(3, 3)
+
+      c = reshape([0.0_dp, 0.0_dp, 0.10077199490609_dp*ANG, &
+                   0.0_dp, 0.77250895271063_dp*ANG, -0.46780199741728_dp*ANG, &
+                   0.0_dp, -0.77250895280218_dp*ANG, -0.46780199748881_dp*ANG], [3, 3])
+      call build_libcint_molecule([8, 1, 1], ["O ", "H ", "H "], c, basis, mol, err)
+   end subroutine water
+
+   subroutine converged_water(mol, scf, err, basis)
+      type(libcint_molecule_t), intent(out) :: mol
+      type(rhf_result_t), intent(out) :: scf
+      type(error_t), intent(inout) :: err
+      character(len=*), intent(in) :: basis
+
+      call water(mol, err, basis)
+      if (err%has_error()) return
+      call run_libcint_rhf(mol, 10, 200, 1.0e-11_dp, 1.0e-9_dp, .false., scf, err, &
+                           in_core=.true.)
+   end subroutine converged_water
+
+   subroutine test_antisymmetry(error)
+      !! <pq||rs> = -<qp||rs> = -<pq||sr> = <qp||sr>
+      !!
+      !! Checked on every element of a small case rather than on a sample. The
+      !! tensor is 14^4 in water/STO-3G, which is cheap enough to check whole, and
+      !! a sampled check would pass on a tensor that is antisymmetric almost
+      !! everywhere -- which is exactly what one wrong spin delta produces.
+      type(error_type), allocatable, intent(out) :: error
+      type(libcint_molecule_t) :: mol
+      type(rhf_result_t) :: scf
+      type(error_t) :: err
+      real(dp), allocatable :: eri(:, :), mo(:, :, :, :), w(:, :, :, :), c_act(:, :)
+      integer :: n_so, p, q, r, s
+      real(dp) :: worst_bra, worst_ket, worst_both
+
+      call converged_water(mol, scf, err, "sto-3g")
+      call check(error,.not. err%has_error() .and. scf%converged, "water SCF must converge")
+      if (allocated(error)) return
+
+      call build_mo_tensor(mol, scf%orbitals, mo)
+      n_so = 2*size(scf%orbitals, 2)
+      call spin_orbital_integrals(mo, n_so, w)
+
+      worst_bra = 0.0_dp
+      worst_ket = 0.0_dp
+      worst_both = 0.0_dp
+      do s = 1, n_so
+         do r = 1, n_so
+            do q = 1, n_so
+               do p = 1, n_so
+                  worst_bra = max(worst_bra, abs(w(p, q, r, s) + w(q, p, r, s)))
+                  worst_ket = max(worst_ket, abs(w(p, q, r, s) + w(p, q, s, r)))
+                  worst_both = max(worst_both, abs(w(p, q, r, s) - w(q, p, s, r)))
+               end do
+            end do
+         end do
+      end do
+
+      call check(error, worst_bra < 1.0e-13_dp, "swapping the bra pair must flip the sign")
+      if (allocated(error)) return
+      call check(error, worst_ket < 1.0e-13_dp, "swapping the ket pair must flip the sign")
+      if (allocated(error)) return
+      call check(error, worst_both < 1.0e-13_dp, "swapping both pairs must change nothing")
+
+      call mol%destroy()
+   end subroutine test_antisymmetry
+
+   subroutine test_spin_blocks(error)
+      !! An integral coupling opposite spins on both pairings is exactly zero
+      !!
+      !! With interleaved spins, `p` and `p+1` are the same spatial orbital with
+      !! opposite spin. <pq||rs> then vanishes identically whenever neither
+      !! pairing survives spin integration, and "identically" means bitwise --
+      !! this is a term that was never added, not one that cancelled.
+      type(error_type), allocatable, intent(out) :: error
+      type(libcint_molecule_t) :: mol
+      type(rhf_result_t) :: scf
+      type(error_t) :: err
+      real(dp), allocatable :: mo(:, :, :, :), w(:, :, :, :)
+      integer :: n_so, p, q, r, s
+      logical :: found
+      real(dp) :: worst
+
+      call converged_water(mol, scf, err, "sto-3g")
+      call check(error,.not. err%has_error() .and. scf%converged, "water SCF must converge")
+      if (allocated(error)) return
+
+      call build_mo_tensor(mol, scf%orbitals, mo)
+      n_so = 2*size(scf%orbitals, 2)
+      call spin_orbital_integrals(mo, n_so, w)
+
+      worst = 0.0_dp
+      found = .false.
+      do s = 1, n_so
+         do r = 1, n_so
+            do q = 1, n_so
+               do p = 1, n_so
+                  ! Neither (p,r)(q,s) nor (p,s)(q,r) is spin-allowed.
+                  if (mod(p, 2) /= mod(r, 2) .and. mod(p, 2) /= mod(s, 2)) then
+                     found = .true.
+                     worst = max(worst, abs(w(p, q, r, s)))
+                  end if
+               end do
+            end do
+         end do
+      end do
+
+      call check(error, found, "there must be spin-forbidden combinations to check")
+      if (allocated(error)) return
+      call check(error, worst == 0.0_dp, "a spin-forbidden integral must be exactly zero")
+
+      call mol%destroy()
+   end subroutine test_spin_blocks
+
+   subroutine test_mp2_identity(error)
+      !! Spin-orbital MP2 must reproduce the conventional path exactly
+      type(error_type), allocatable, intent(out) :: error
+      type(libcint_molecule_t) :: mol
+      type(rhf_result_t) :: scf
+      type(mp2_result_t) :: mp2
+      type(cc_result_t) :: cc
+      type(error_t) :: err
+
+      call converged_water(mol, scf, err, "sto-3g")
+      call check(error,.not. err%has_error() .and. scf%converged, "water SCF must converge")
+      if (allocated(error)) return
+
+      call run_libcint_mp2(mol, scf%orbitals, scf%orbital_energies, 5, scf%energy, &
+                           mp2, err)
+      call check(error,.not. err%has_error(), "conventional MP2 must run")
+      if (allocated(error)) return
+
+      call run_libcint_ccsd(mol, scf%orbitals, scf%orbital_energies, 5, 0, &
+                            60, 1.0e-11_dp, .false., .false., cc, err)
+      call check(error,.not. err%has_error() .and. cc%converged, "CCSD must converge")
+      if (allocated(error)) return
+
+      ! Two separate transforms, two separate energy expressions, one number.
+      call check(error, abs(cc%e_mp2 - mp2%correlation) < 1.0e-12_dp, &
+                 "spin-orbital MP2 must equal the conventional MP2 it is built beside")
+
+      call mol%destroy()
+   end subroutine test_mp2_identity
+
+   subroutine test_ordering(error)
+      !! E_CCSD < E_MP2 < 0, and (T) below CCSD, at a closed-shell minimum
+      !!
+      !! Not a law in general -- MP2 can overshoot, and (T) can come out positive
+      !! for a stretched bond or a poor reference -- which is why this is asserted
+      !! on water at its equilibrium geometry, where it is reliably true. It
+      !! catches a sign error in the energy expression that a converged
+      !! calculation would otherwise report happily.
+      type(error_type), allocatable, intent(out) :: error
+      type(libcint_molecule_t) :: mol
+      type(rhf_result_t) :: scf
+      type(cc_result_t) :: cc
+      type(error_t) :: err
+      real(dp) :: e_ccsd
+
+      call converged_water(mol, scf, err, "sto-3g")
+      call check(error,.not. err%has_error() .and. scf%converged, "water SCF must converge")
+      if (allocated(error)) return
+
+      call run_libcint_ccsd(mol, scf%orbitals, scf%orbital_energies, 5, 0, &
+                            60, 1.0e-11_dp, .true., .false., cc, err)
+      call check(error,.not. err%has_error() .and. cc%converged, "CCSD must converge")
+      if (allocated(error)) return
+
+      e_ccsd = cc%e_singles + cc%e_doubles
+      call check(error, cc%e_mp2 < 0.0_dp, "MP2 correlation must be negative")
+      if (allocated(error)) return
+      call check(error, e_ccsd < cc%e_mp2, "CCSD must recover more correlation than MP2")
+      if (allocated(error)) return
+      call check(error, cc%e_triples < 0.0_dp, "(T) must be negative here")
+      if (allocated(error)) return
+      ! A guard on magnitude as well as sign: (T) is a correction, and one the
+      ! size of the doubles would mean the 1/36 or a permutation sign is wrong.
+      call check(error, abs(cc%e_triples) < 0.1_dp*abs(e_ccsd), &
+                 "(T) must be small beside the CCSD correlation energy")
+
+      call mol%destroy()
+   end subroutine test_ordering
+
+   subroutine test_frozen(error)
+      !! Freezing the oxygen core raises the correlation energy, by millihartree
+      !!
+      !! The magnitude is the content. A frozen-core off-by-one that dropped a
+      !! valence orbital instead of the core, or shifted the orbital energies
+      !! against the coefficients, changes this by tens of millihartree -- and
+      !! still converges.
+      type(error_type), allocatable, intent(out) :: error
+      type(libcint_molecule_t) :: mol
+      type(rhf_result_t) :: scf
+      type(cc_result_t) :: all_e, frozen_e
+      type(error_t) :: err
+      real(dp) :: e_all, e_frozen, gap
+
+      call converged_water(mol, scf, err, "sto-3g")
+      call check(error,.not. err%has_error() .and. scf%converged, "water SCF must converge")
+      if (allocated(error)) return
+
+      call run_libcint_ccsd(mol, scf%orbitals, scf%orbital_energies, 5, 0, &
+                            60, 1.0e-11_dp, .false., .false., all_e, err)
+      call check(error,.not. err%has_error() .and. all_e%converged, "CCSD must converge")
+      if (allocated(error)) return
+      call run_libcint_ccsd(mol, scf%orbitals, scf%orbital_energies, 5, 1, &
+                            60, 1.0e-11_dp, .false., .false., frozen_e, err)
+      call check(error,.not. err%has_error() .and. frozen_e%converged, &
+                 "frozen-core CCSD must converge")
+      if (allocated(error)) return
+
+      e_all = all_e%e_singles + all_e%e_doubles
+      e_frozen = frozen_e%e_singles + frozen_e%e_doubles
+      gap = e_frozen - e_all
+
+      call check(error, gap > 0.0_dp, "freezing a core orbital must raise the energy")
+      if (allocated(error)) return
+      call check(error, gap < 0.05_dp, &
+                 "the frozen-core shift must be millihartree, not tens of them")
+
+      call mol%destroy()
+   end subroutine test_frozen
+
+   subroutine build_mo_tensor(mol, coeff, mo)
+      !! The active MO tensor, the way the CC driver builds it
+      use mqc_libcint_mp2, only: transform_block
+      type(libcint_molecule_t), intent(in) :: mol
+      real(dp), intent(in) :: coeff(:, :)
+      real(dp), allocatable, intent(out) :: mo(:, :, :, :)
+
+      real(dp), allocatable :: eri(:, :)
+
+      call mol%eris_packed(eri)
+      call transform_block(eri, coeff, coeff, coeff, coeff, mo)
+      deallocate (eri)
+   end subroutine build_mo_tensor
+
+end module test_mqc_libcint_cc
+
+program tester
+   use, intrinsic :: iso_fortran_env, only: error_unit
+   use testdrive, only: run_testsuite, new_testsuite, testsuite_type
+   use test_mqc_libcint_cc, only: collect_mqc_libcint_cc_tests
+   implicit none
+   integer :: stat, is
+   type(testsuite_type), allocatable :: testsuites(:)
+   character(len=*), parameter :: fmt = '("#", *(1x, a))'
+
+   stat = 0
+   testsuites = [new_testsuite("mqc_libcint_cc", collect_mqc_libcint_cc_tests)]
+
+   do is = 1, size(testsuites)
+      write (error_unit, fmt) "Testing:", testsuites(is)%name
+      call run_testsuite(testsuites(is)%collect, error_unit, stat)
+   end do
+
+   if (stat > 0) then
+      write (error_unit, "(i0, 1x, a)") stat, "test(s) failed!"
+      error stop
+   end if
+end program tester

--- a/validation/check_cc.f90
+++ b/validation/check_cc.f90
@@ -1,0 +1,145 @@
+!! Manual check that the CPU coupled cluster reproduces PySCF
+!!
+!!     cmake -B build -DMQC_ENABLE_LIBCINT=ON && ./build/check_cc
+!!
+!! Runs RHF, then CCSD and (T), on a ladder of systems chosen so a failure
+!! localises. The milestone order of CC_PLAN.md, in one program:
+!!
+!!   * **MP2 out of the spin-orbital integrals must equal `run_libcint_mp2`.**
+!!     Checked first and to 1e-10, because it is free -- MP2 is the first CCSD
+!!     iteration's energy -- and because it isolates the three things most
+!!     likely to be wrong (the antisymmetrisation, the spin-orbital index map,
+!!     the denominators) with no amplitude equations in the way. If this
+!!     disagrees, nothing after it can be right.
+!!   * **CCSD against PySCF `cc.CCSD`**, and **(T) against `.ccsd_t()`**.
+!!
+!! References are PySCF 2.14 fed this repository's own basis JSON through
+!! `bse_to_pyscf`, not PySCF's internal tables: on Pople sets those differ in
+!! the eighth decimal, which is enough to look exactly like a bug here. See
+!! tools/cpu_validation/gen_cpu_validation.py.
+program check_cc
+   use pic_types, only: dp
+   use mqc_libcint_integrals, only: libcint_molecule_t, build_libcint_molecule
+   use mqc_libcint_rhf, only: rhf_result_t, run_libcint_rhf
+   use mqc_libcint_mp2, only: mp2_result_t, run_libcint_mp2
+   use mqc_libcint_cc, only: cc_result_t, run_libcint_ccsd
+   use mqc_error, only: error_t
+   implicit none
+
+   real(dp), parameter :: ANG = 1.8897261254578281_dp
+   integer :: failures
+
+   failures = 0
+
+   ! H2O / STO-3G, no frozen core. Small enough to debug by hand: seven spatial
+   ! orbitals, fourteen spin orbitals, four virtual.
+   call one_case("H2O sto-3g    ", "sto-3g", 0, &
+                 -74.962005712275_dp, &      ! PySCF RHF
+                 -0.035266770320_dp, &       ! PySCF MP2 correlation
+                 -0.049173927119_dp, &       ! PySCF CCSD correlation
+                 -0.000072742387_dp)         ! PySCF (T)
+
+   ! The same molecule in a basis with a d shell, which is where an angular
+   ! momentum error in the transform would first show.
+   call one_case("H2O cc-pvdz   ", "cc-pvdz", 0, &
+                 -76.026435906898_dp, &
+                 -0.203838686392_dp, &
+                 -0.213190638318_dp, &
+                 -0.003037892387_dp)
+
+   ! The frozen-core path, on the same molecule so only the freezing changes.
+   call one_case("H2O cc-pvdz f1", "cc-pvdz", 1, &
+                 -76.026435906898_dp, &
+                 -0.201503456922_dp, &
+                 -0.211097952217_dp, &
+                 -0.003015723855_dp)
+
+   write (*, "(A)") ""
+   if (failures == 0) then
+      write (*, "(A)") "[cc] all ok -- CCSD(T) reproduces PySCF"
+   else
+      write (*, "(A,I0,A)") "[cc] ", failures, " FAILURE(S)"
+      error stop 1
+   end if
+
+contains
+
+   subroutine one_case(label, basis, frozen, e_scf_ref, e_mp2_ref, e_ccsd_ref, e_t_ref)
+      character(len=*), intent(in) :: label, basis
+      integer, intent(in) :: frozen
+      real(dp), intent(in) :: e_scf_ref, e_mp2_ref, e_ccsd_ref, e_t_ref
+
+      type(libcint_molecule_t) :: mol
+      type(rhf_result_t) :: scf
+      type(mp2_result_t) :: mp2
+      type(cc_result_t) :: cc
+      type(error_t) :: err
+      real(dp) :: c(3, 3)
+      real(dp) :: e_ccsd
+      integer :: n_occ
+
+      ! The geometry every CPU water case in the validation suite uses.
+      c = reshape([0.0_dp, 0.00000000009155_dp*ANG, 0.10077199490609_dp*ANG, &
+                   0.0_dp, 0.77250895271063_dp*ANG, -0.46780199741728_dp*ANG, &
+                   0.0_dp, -0.77250895280218_dp*ANG, -0.46780199748881_dp*ANG], [3, 3])
+      call build_libcint_molecule([8, 1, 1], ["O ", "H ", "H "], c, basis, mol, err)
+      if (err%has_error()) then
+         write (*, "(A,A,A,A)") "[cc] ", label, " basis failed: ", err%get_message()
+         failures = failures + 1
+         return
+      end if
+
+      n_occ = 5
+      call run_libcint_rhf(mol, 10, 200, 1.0e-11_dp, 1.0e-9_dp, .false., scf, err, &
+                           in_core=.true.)
+      if (err%has_error() .or. .not. scf%converged) then
+         write (*, "(A,A,A)") "[cc] ", label, " SCF failed"
+         failures = failures + 1
+         return
+      end if
+      call report(label//" SCF ", scf%energy, e_scf_ref, 1.0e-8_dp)
+
+      ! Conventional MP2 through the existing path, as the thing the
+      ! spin-orbital MP2 has to reproduce exactly.
+      call run_libcint_mp2(mol, scf%orbitals, scf%orbital_energies, n_occ, &
+                           scf%energy, mp2, err, n_frozen=frozen)
+      if (err%has_error()) then
+         write (*, "(A,A,A,A)") "[cc] ", label, " MP2 failed: ", err%get_message()
+         failures = failures + 1
+         return
+      end if
+
+      call run_libcint_ccsd(mol, scf%orbitals, scf%orbital_energies, n_occ, frozen, &
+                            100, 1.0e-11_dp, .true., .false., cc, err)
+      if (err%has_error()) then
+         write (*, "(A,A,A,A)") "[cc] ", label, " CCSD failed: ", err%get_message()
+         failures = failures + 1
+         call mol%destroy()
+         return
+      end if
+
+      ! The free checkpoint: same MP2, two entirely different routes to it.
+      call report(label//" MP2=", cc%e_mp2, mp2%correlation, 1.0e-10_dp)
+      call report(label//" MP2 ", cc%e_mp2, e_mp2_ref, 1.0e-7_dp)
+      e_ccsd = cc%e_singles + cc%e_doubles
+      call report(label//" CCSD", e_ccsd, e_ccsd_ref, 1.0e-8_dp)
+      call report(label//" (T) ", cc%e_triples, e_t_ref, 1.0e-8_dp)
+
+      call mol%destroy()
+   end subroutine one_case
+
+   subroutine report(what, got, want, tol)
+      character(len=*), intent(in) :: what
+      real(dp), intent(in) :: got, want, tol
+
+      if (abs(got - want) <= tol) then
+         write (*, "(A,A,A,F18.10,A,ES10.3)") "  ok   ", what, " ", got, "  diff ", &
+            abs(got - want)
+      else
+         write (*, "(A,A,A,F18.10,A,F18.10,A,ES10.3)") &
+            "  FAIL ", what, " got ", got, " want ", want, " diff ", abs(got - want)
+         failures = failures + 1
+      end if
+   end subroutine report
+
+end program check_cc


### PR DESCRIPTION
## Summary

Adds a CPU coupled-cluster implementation on the libcint backend.

- Spin-orbital **CCSD** and **CCSD(T)** on the CPU (`mqc_libcint_cc.f90`)
- Routes the coupled-cluster hot spots through GEMM
- Reworks the MP2 path (`mqc_libcint_mp2.f90`) to share machinery

## Tests

- `test/test_mqc_libcint_cc.f90` — unit coverage for the new CC routines
- `validation/check_cc.f90` — physics validation driver

## Stack

Part of the CPU coupled-cluster stack (base ← top):

1. `feat/cpu-atomic-guess` (#157)
2. **`feat/cpu-coupled-cluster`** (#158) ← this PR
3. `feat/cc-wiring` (#159)
4. `feat/cpu-ri-cc` (#160)
