### PR TITLE
Wire coupled cluster into the input deck

### DIFF
--- a/backends/libcint/mqc_libcint_bridge.f90
+++ b/backends/libcint/mqc_libcint_bridge.f90
@@ -27,6 +27,7 @@ module mqc_libcint_bridge
    use mqc_libcint_atomic_guess, only: build_atomic_guess, parse_guess_name, &
                                        guess_display_name
    use mqc_libcint_mp2, only: mp2_result_t, run_libcint_mp2, run_libcint_ri_mp2
+   use mqc_libcint_cc, only: cc_result_t, run_libcint_ccsd
    implicit none
    private
 
@@ -83,6 +84,29 @@ contains
                                "implemented on the CPU backend: the fitted J and K are "// &
                                "written for one density. Run unrestricted without "// &
                                "density_fitting, or restricted with it.")
+         result%has_error = .true.
+         return
+      end if
+
+      ! Refused rather than quietly downgraded, on the same principle as the
+      ! unrestricted density fitting above. Coupled cluster here is written over a
+      ! restricted reference, and the fitted route does not exist yet at all -- a
+      ! deck asking for either would otherwise get a Hartree-Fock energy, or a
+      ! conventional CCSD reported as RI, and nothing in the output would say so.
+      if (settings%run_cc .and. unrestricted) then
+         call result%error%set(ERROR_VALIDATION, "coupled cluster on the CPU backend "// &
+                               "needs a restricted reference: it is written in spin "// &
+                               "orbitals over RHF orbitals, and an unrestricted "// &
+                               "reference needs its own alpha and beta transform. Run "// &
+                               "a closed-shell system, or use MP2.")
+         result%has_error = .true.
+         return
+      end if
+      if (settings%run_cc .and. settings%corr_density_fitting) then
+         call result%error%set(ERROR_VALIDATION, "RI coupled cluster is not implemented "// &
+                               "on the CPU backend. Ask for 'ccsd' or 'ccsd(t)' rather "// &
+                               "than 'ri-ccsd', or set "// &
+                               "keywords.correlation.density_fitting to false.")
          result%has_error = .true.
          return
       end if
@@ -273,6 +297,53 @@ contains
                      "   OS x", settings%scs_os
                   write (*, "(a,f20.12)") "  E(corr) scaled ", result%energy%mp2%total()
                end if
+               write (*, "(a,f20.12)") "  E total        ", result%energy%total()
+            end if
+         end block
+      end if
+
+      if (settings%run_cc) then
+         block
+            type(cc_result_t) :: cc
+            integer :: frozen
+
+            ! The same frozen-core rule the MP2 block applies, deliberately
+            ! duplicated rather than hoisted: the two blocks are independent, and
+            ! a shared local would silently couple them if one ever wanted a
+            ! different count.
+            frozen = settings%n_frozen_core
+            if (frozen < 0) frozen = core_orbital_count(fragment%element_numbers)
+            if (.not. settings%freeze_core) frozen = 0
+
+            call run_libcint_ccsd(mol, scf%orbitals, scf%orbital_energies, &
+                                  fragment%nelec/2, frozen, settings%cc_max_iter, &
+                                  settings%cc_tolerance, settings%cc_triples, &
+                                  settings%verbose, cc, error, &
+                                  diis_vectors=settings%cc_diis_size)
+            if (error%has_error()) then
+               call result%error%set(ERROR_VALIDATION, "CCSD: "//error%get_message())
+               result%has_error = .true.
+               call mol%destroy()
+               return
+            end if
+
+            ! energy_t sums scf + mp2%total() + cc%total(), so only the components
+            ! go in. All three are filled rather than a lumped correlation energy:
+            ! a total cannot be taken apart afterwards, and the singles/doubles
+            ! split is what says whether the T1 amplitudes are doing anything.
+            result%energy%cc%singles = cc%e_singles
+            result%energy%cc%doubles = cc%e_doubles
+            result%energy%cc%triples = cc%e_triples
+            if (settings%verbose) then
+               write (*, "(a,i0,a,l1)") "  CCSD: iterations ", cc%iterations, &
+                  "  converged ", cc%converged
+               write (*, "(a,f20.12)") "  E(MP2)         ", cc%e_mp2
+               write (*, "(a,f20.12)") "  E(singles)     ", cc%e_singles
+               write (*, "(a,f20.12)") "  E(doubles)     ", cc%e_doubles
+               if (settings%cc_triples) then
+                  write (*, "(a,f20.12)") "  E(T)           ", cc%e_triples
+               end if
+               write (*, "(a,f20.12)") "  E(corr)        ", result%energy%cc%total()
                write (*, "(a,f20.12)") "  E total        ", result%energy%total()
             end if
          end block

--- a/src/io/mqc_config_adapter.f90
+++ b/src/io/mqc_config_adapter.f90
@@ -9,6 +9,7 @@ module mqc_config_adapter
    use mqc_error, only: error_t, ERROR_VALIDATION
    use mqc_calculation_keywords, only: hessian_keywords_t, aimd_keywords_t, scf_keywords_t
    use mqc_method_config, only: method_config_t
+   use mqc_method_types, only: METHOD_TYPE_CCSD_T
    use pic_logger, only: logger => global_logger
    implicit none
    private
@@ -171,6 +172,19 @@ contains
       driver_config%method_config%corr%use_scs = mqc_config%corr_scs
       driver_config%method_config%corr%scs_ss = mqc_config%corr_scs_ss
       driver_config%method_config%corr%scs_os = mqc_config%corr_scs_os
+      driver_config%method_config%cc%max_iter = mqc_config%cc_maxiter
+      driver_config%method_config%cc%amplitude_convergence = mqc_config%cc_tolerance
+      driver_config%method_config%cc%use_diis = mqc_config%cc_diis
+      driver_config%method_config%cc%diis_size = mqc_config%cc_diis_size
+      ! The method name settles the triples unless a deck said otherwise:
+      ! "ccsd(t)" and "ccsd" are separate method types, so the distinction
+      ! survives the parse and does not have to be recovered from the spelling
+      ! the way RI does.
+      driver_config%method_config%cc%include_triples = &
+         (mqc_config%method == METHOD_TYPE_CCSD_T)
+      if (mqc_config%cc_triples_set) then
+         driver_config%method_config%cc%include_triples = mqc_config%cc_triples
+      end if
       if (allocated(mqc_config%scf_guess)) then
          driver_config%method_config%scf%guess = mqc_config%scf_guess
       end if

--- a/src/io/mqc_config_types.f90
+++ b/src/io/mqc_config_types.f90
@@ -93,6 +93,17 @@ module mqc_config_types
       logical :: corr_scs = .false.        !! Spin-component scaling
       real(dp) :: corr_scs_ss = 1.0_dp/3.0_dp
       real(dp) :: corr_scs_os = 1.2_dp
+      ! keywords.cc -- what only an iterative correlation method needs
+      integer :: cc_maxiter = 100
+      real(dp) :: cc_tolerance = 1.0e-8_dp
+      logical :: cc_triples_set = .false.
+         !! Whether a deck named `triples` explicitly. Without this there is no
+         !! way to tell "triples: false" from "the key was absent", and the
+         !! method name has to lose to an explicit keyword while winning over an
+         !! absent one.
+      logical :: cc_triples = .false.
+      logical :: cc_diis = .true.
+      integer :: cc_diis_size = 8
          !! Fit J and K against the auxiliary basis, on the CPU backend
          !! Let a non-converged SCF into the expansion instead of stopping.
          !! Off by default: the energy of an SCF that ran out of iterations is

--- a/src/io/mqc_json_config_reader.f90
+++ b/src/io/mqc_json_config_reader.f90
@@ -208,6 +208,16 @@ contains
       call optional_logical(json, "keywords.correlation.scs", config%corr_scs)
       call optional_real(json, "keywords.correlation.scs_ss", config%corr_scs_ss)
       call optional_real(json, "keywords.correlation.scs_os", config%corr_scs_os)
+      call optional_int(json, "keywords.cc.maxiter", config%cc_maxiter)
+      call optional_real(json, "keywords.cc.tolerance", config%cc_tolerance)
+      call optional_logical(json, "keywords.cc.diis", config%cc_diis)
+      call optional_int(json, "keywords.cc.diis_size", config%cc_diis_size)
+      ! Recorded as "was it named" as well as "what was it", because the method
+      ! name is the usual source of this and only an explicit keyword may
+      ! override it. `optional_logical` leaves its target alone when the key is
+      ! absent, which cannot distinguish absent from false on its own.
+      call optional_logical_seen(json, "keywords.cc.triples", config%cc_triples, &
+                                 config%cc_triples_set)
 
       ! Both spellings of the displacement key are accepted, as the JSON
       ! generator used to allow.
@@ -717,6 +727,23 @@ contains
       call json%get(path, found_value, found)
       if (found) value = found_value
    end subroutine optional_real
+
+   subroutine optional_logical_seen(json, path, value, seen)
+      !! Fetch a boolean, and say whether the deck named it
+      !!
+      !! Needed wherever a default comes from somewhere other than the field's
+      !! initialiser -- the method name, say -- because "absent" and "false" have
+      !! to be told apart before the name can be allowed to lose to a keyword.
+      type(json_file), intent(inout) :: json
+      character(len=*), intent(in) :: path
+      logical, intent(inout) :: value
+      logical, intent(out) :: seen
+
+      logical :: found_value
+
+      call json%get(path, found_value, seen)
+      if (seen) value = found_value
+   end subroutine optional_logical_seen
 
    subroutine optional_logical(json, path, value)
       !! Fetch a boolean if present, leaving `value` at its default otherwise

--- a/src/io/mqc_json_schema.f90
+++ b/src/io/mqc_json_schema.f90
@@ -97,6 +97,8 @@ contains
       call check_grandchild_object(core, root, "keywords", "correlation", &
                                    correlation_keys(), error)
       if (error%has_error()) return
+      call check_grandchild_object(core, root, "keywords", "cc", cc_keys(), error)
+      if (error%has_error()) return
       call check_grandchild_object(core, root, "keywords", "hessian", hessian_keys(), error)
       if (error%has_error()) return
       call check_grandchild_object(core, root, "keywords", "aimd", aimd_keys(), error)
@@ -180,6 +182,7 @@ contains
       call allow(keys, "fragmentation")
       call allow(keys, "xtb")
       call allow(keys, "correlation")
+      call allow(keys, "cc")
    end function keywords_keys
 
    function scf_keys() result(keys)
@@ -209,6 +212,23 @@ contains
       call allow(keys, "scs_ss")
       call allow(keys, "scs_os")
    end function correlation_keys
+
+   function cc_keys() result(keys)
+      !! Coupled-cluster settings, separate from "correlation"
+      !!
+      !! `correlation` holds what every post-Hartree-Fock method shares -- the
+      !! frozen core, the fitting, the auxiliary basis. These are the ones only an
+      !! iterative method has: how long to iterate and how hard, and whether the
+      !! triples correction runs. `triples` is here as an override; ordinarily the
+      !! method name settles it, since "ccsd" and "ccsd(t)" are separate method
+      !! types rather than one type with a flag.
+      type(key_set_t) :: keys
+      call allow(keys, "maxiter")
+      call allow(keys, "tolerance")
+      call allow(keys, "triples")
+      call allow(keys, "diis")
+      call allow(keys, "diis_size")
+   end function cc_keys
 
    function hessian_keys() result(keys)
       type(key_set_t) :: keys

--- a/src/methods/mqc_cuest_iface.f90
+++ b/src/methods/mqc_cuest_iface.f90
@@ -33,6 +33,14 @@ module mqc_cuest_iface
       character(len=256) :: corr_aux_basis = ""
       real(dp) :: scs_ss = 1.0_dp       !! Spin-component scaling, one for plain MP2
       real(dp) :: scs_os = 1.0_dp
+      ! Coupled cluster. CPU backend only -- cuEST has no CC -- and refused
+      ! rather than ignored there, so a deck cannot ask the GPU for CCSD and be
+      ! handed Hartree-Fock.
+      logical :: run_cc = .false.
+      logical :: cc_triples = .false.   !! Run the perturbative (T) after CCSD
+      integer :: cc_max_iter = 100
+      real(dp) :: cc_tolerance = 1.0e-8_dp
+      integer :: cc_diis_size = 8
          !! Read by the CPU backend only; cuEST always fits.
          !! Auxiliary (JKFIT) basis. Required: cuEST fits J and K always.
       character(len=32) :: functional = ""

--- a/src/methods/mqc_method_factory.F90
+++ b/src/methods/mqc_method_factory.F90
@@ -6,6 +6,7 @@ module mqc_method_factory
    use pic_types, only: int32, dp
    use mqc_method_types, only: METHOD_TYPE_GFN1, METHOD_TYPE_GFN2, METHOD_TYPE_HF, &
                                METHOD_TYPE_DFT, METHOD_TYPE_MCSCF, METHOD_TYPE_MP2, &
+                               METHOD_TYPE_CCSD, METHOD_TYPE_CCSD_T, &
                                method_type_to_string
    use mqc_method_config, only: method_config_t
    use mqc_method_base, only: qc_method_t
@@ -84,6 +85,19 @@ contains
             allocate (method, source=hf)
          end block
 
+         ! Both spellings land on the same method object, as MP2 does, and for
+         ! the same reason: coupled cluster is a Hartree-Fock calculation plus a
+         ! correction built from its orbitals. Which of the two ran is carried by
+         ! config%cc%include_triples, which the adapter set from the method type
+         ! -- so the two cases are identical here on purpose rather than by
+         ! oversight.
+      case (METHOD_TYPE_CCSD, METHOD_TYPE_CCSD_T)
+         block
+            type(hf_method_t) :: hf
+            call configure_hf(hf, config, with_cc=.true.)
+            allocate (method, source=hf)
+         end block
+
       case (METHOD_TYPE_DFT)
          block
             type(dft_method_t) :: dft
@@ -137,10 +151,13 @@ contains
    end subroutine configure_xtb
 #endif
 
-   subroutine configure_hf(m, config, with_mp2)
+   subroutine configure_hf(m, config, with_mp2, with_cc)
       !! Configure a Hartree-Fock method instance from config%scf (shared SCF settings)
       type(hf_method_t), intent(inout) :: m
       type(method_config_t), intent(in) :: config
+      logical, intent(in), optional :: with_cc
+         !! Follow the reference with coupled cluster. Same argument as
+         !! `with_mp2`: a method, not an option.
       logical, intent(in), optional :: with_mp2
          !! Follow the reference with MP2. MP2 is dispatched onto the same
          !! method object rather than a class of its own, because that is what
@@ -156,6 +173,13 @@ contains
 
       ! SCF settings from shared config%scf
       if (present(with_mp2)) m%options%run_mp2 = with_mp2
+      if (present(with_cc)) m%options%run_cc = with_cc
+      m%options%cc_triples = config%cc%include_triples
+      m%options%cc_max_iter = config%cc%max_iter
+      m%options%cc_tolerance = config%cc%amplitude_convergence
+      ! Zero turns DIIS off, which is how the SCF spells the same thing.
+      m%options%cc_diis_size = config%cc%diis_size
+      if (.not. config%cc%use_diis) m%options%cc_diis_size = 0
       ! From config%corr, not config%scf: the reference and the correlation
       ! treatment are configured separately and may disagree.
       m%options%freeze_core = config%corr%freeze_core

--- a/src/methods/mqc_method_hf.F90
+++ b/src/methods/mqc_method_hf.F90
@@ -41,6 +41,14 @@ module mqc_method_hf
       character(len=256) :: corr_aux_basis = ""
       real(dp) :: scs_ss = 1.0_dp
       real(dp) :: scs_os = 1.0_dp
+      logical :: run_cc = .false.
+         !! Follow the reference with coupled cluster. Set by the factory from
+         !! the method name, for the same reason `run_mp2` is: "ccsd" is a
+         !! method, not an option on Hartree-Fock.
+      logical :: cc_triples = .false.
+      integer :: cc_max_iter = 100
+      real(dp) :: cc_tolerance = 1.0e-8_dp
+      integer :: cc_diis_size = 8
          !! Fit J and K rather than computing exact integrals (CPU backend)
       logical :: spherical = .true.
          !! Use spherical (true) or Cartesian (false) basis
@@ -108,6 +116,11 @@ contains
       settings%freeze_core = this%options%freeze_core
       settings%n_frozen_core = this%options%n_frozen_core
       settings%corr_density_fitting = this%options%corr_density_fitting
+      settings%run_cc = this%options%run_cc
+      settings%cc_triples = this%options%cc_triples
+      settings%cc_max_iter = this%options%cc_max_iter
+      settings%cc_tolerance = this%options%cc_tolerance
+      settings%cc_diis_size = this%options%cc_diis_size
       settings%corr_aux_basis = this%options%corr_aux_basis
       settings%scs_ss = this%options%scs_ss
       settings%scs_os = this%options%scs_os

--- a/test/test_mqc_json_reader.f90
+++ b/test/test_mqc_json_reader.f90
@@ -51,6 +51,7 @@ contains
                   new_unittest("inline_symbols_and_geometry", test_inline_geometry), &
                   new_unittest("error_missing_schema", test_missing_schema), &
                   new_unittest("error_missing_molecules", test_missing_molecules), &
+                  new_unittest("cc_keywords", test_cc_keywords), &
                   new_unittest("error_malformed_json", test_malformed) &
                   ]
    end subroutine collect_mqc_json_reader_tests
@@ -473,6 +474,52 @@ contains
       if (allocated(error)) return
       call check(error, config%nodes_per_group, 4)
    end subroutine test_nodes_per_group
+
+   subroutine test_cc_keywords(error)
+      !! keywords.cc, and that "triples" records whether it was named
+      !!
+      !! The presence flag is the part worth testing. The triples default comes
+      !! from the method name rather than from the field's initialiser -- "ccsd"
+      !! and "ccsd(t)" being separate method types -- so a deck writing
+      !! `"triples": false` has to be distinguishable from one that said nothing,
+      !! or the name could never be overridden downward.
+      type(error_type), allocatable, intent(out) :: error
+      type(mqc_config_t) :: config
+      type(error_t) :: parse_error
+
+      call write_deck('"method": "ccsd(t)", "basis": "sto-3g"', "Energy", &
+                      '"cc": {"maxiter": 40, "tolerance": 1.0e-10, '// &
+                      '"triples": false, "diis": false, "diis_size": 4}', &
+                      "", two_atoms())
+      call read_deck(config, parse_error)
+
+      call check(error,.not. parse_error%has_error(), parse_error%get_message())
+      if (allocated(error)) return
+      call check(error, config%cc_maxiter, 40)
+      if (allocated(error)) return
+      call check(error, close_enough(config%cc_tolerance, 1.0e-10_dp))
+      if (allocated(error)) return
+      call check(error, config%cc_diis, .false., "cc.diis should be settable")
+      if (allocated(error)) return
+      call check(error, config%cc_diis_size, 4)
+      if (allocated(error)) return
+      call check(error, config%cc_triples, .false., "an explicit triples:false is read")
+      if (allocated(error)) return
+      call check(error, config%cc_triples_set, .true., &
+                 "naming triples must be recorded as named")
+      if (allocated(error)) return
+
+      ! Absent, so the method name decides and the adapter must not be overridden.
+      call write_deck('"method": "ccsd(t)", "basis": "sto-3g"', "Energy", "", "", &
+                      two_atoms())
+      call read_deck(config, parse_error)
+      call check(error,.not. parse_error%has_error(), parse_error%get_message())
+      if (allocated(error)) return
+      call check(error, config%cc_triples_set, .false., &
+                 "an absent triples key must not read as named")
+      if (allocated(error)) return
+      call check(error, config%cc_maxiter, 100, "cc.maxiter keeps its default")
+   end subroutine test_cc_keywords
 
    subroutine test_solvation(error)
       !! Every xTB solvation knob, including the two only .mqc could reach

--- a/tools/cpu_validation/gen_cpu_validation.py
+++ b/tools/cpu_validation/gen_cpu_validation.py
@@ -268,6 +268,28 @@ MP2_CASES = [
 # accepts one and warns, and that is deliberately not covered by a reference
 # case -- the point of the warning is that the number is poor, and pinning a
 # poor number teaches nothing.
+# Decks under inputs/ that this script must not delete. They are inputs to other
+# things -- run_cpu_guess_comparison.sh drives the peptide one across all four
+# initial guesses -- and are not validation cases, so they have no reference
+# energy and no entry in the manifest. Without this they match the cpu_*.json
+# sweep below and vanish on the next regeneration.
+HAND_MAINTAINED = {
+    "cpu_peptide46_sto-3g.json",
+}
+
+# Coupled cluster. Small on purpose: the spin-orbital tensor is (2 n_act)^4, so
+# water/cc-pVDZ is 42 MB and anything much larger stops being a validation case
+# and starts being a benchmark. Both spellings appear because they are separate
+# method types, and a deck asking for "ccsd(t)" that quietly ran CCSD would agree
+# with a CCSD reference perfectly.
+CC_CASES = [
+    ("water", "sto-3g", "ccsd", 0),
+    ("water", "sto-3g", "ccsd(t)", 0),
+    ("water", "cc-pvdz", "ccsd", 1),
+    ("water", "cc-pvdz", "ccsd(t)", 1),
+    ("ch4", "sto-3g", "ccsd(t)", 1),
+]
+
 RI_MP2_CASES = [
     ("water", "cc-pvdz", "cc-pvdz-rifit", 0),
     ("water", "cc-pvdz", "cc-pvdz-rifit", 1),
@@ -413,7 +435,8 @@ def write_xyz(path, mol):
     path.write_text("\n".join(body) + "\n")
 
 
-def deck_json(xyz_rel, basis, aux="", multiplicity=1, method="hf", correlation=None):
+def deck_json(xyz_rel, basis, aux="", multiplicity=1, method="hf", correlation=None,
+              cc=None):
     model = {"method": method, "basis": basis}
     if aux:
         model["aux_basis"] = aux
@@ -432,6 +455,8 @@ def deck_json(xyz_rel, basis, aux="", multiplicity=1, method="hf", correlation=N
         deck["keywords"]["scf"]["density_fitting"] = True
     if correlation:
         deck["keywords"]["correlation"] = correlation
+    if cc:
+        deck["keywords"]["cc"] = cc
     return deck
 
 
@@ -491,6 +516,37 @@ def pyscf_mp2(atoms, basis, method, frozen):
         ecorr = 1.3*pt.e_corr_os
     else:
         ecorr = pt.e_corr_os + pt.e_corr_ss
+    return float(escf + ecorr), mol.nao
+
+
+def pyscf_cc(atoms, basis, method, frozen):
+    """Reference CCSD or CCSD(T) total energy.
+
+    The triples come from ``ccsd_t()`` rather than from a CCSD(T) driver, which
+    is what PySCF offers and what ``validation/check_cc.f90`` compares against
+    too -- the two references being produced the same way is the point.
+    """
+    from pyscf import cc, gto, scf
+
+    mol = gto.Mole()
+    mol.atom = [(s, (x, y, z)) for s, x, y, z in atoms]
+    mol.unit = "Angstrom"
+    symbols = {a[0] for a in atoms}
+    mol.basis = {s: bse_to_pyscf(basis, s) for s in symbols}
+    mol.charge = 0
+    mol.spin = 0
+    mol.cart = molecule_form(basis, symbols) == CARTESIAN
+    mol.verbose = 0
+    mol.build()
+    mf = scf.RHF(mol)
+    mf.conv_tol = 1e-12
+    escf = mf.kernel()
+    mycc = cc.CCSD(mf, frozen=frozen)
+    mycc.conv_tol = 1e-11
+    mycc.kernel()
+    ecorr = mycc.e_corr
+    if method == "ccsd(t)":
+        ecorr += mycc.ccsd_t()
     return float(escf + ecorr), mol.nao
 
 
@@ -627,6 +683,29 @@ def main():
         })
         print(f"{mol.label:6s} {basis:12s} {method:8s} frozen={frozen}  nao={nao:4d} E={energy:.12f}", flush=True)
 
+    for name, basis, method, frozen in CC_CASES:
+        mol = MOLECULES[name]
+        energy, nao = pyscf_cc(mol.atoms, basis, method, frozen)
+        tag = method.replace("(", "").replace(")", "")
+        deck = f"inputs/cpu_{name}_{normalize_basis_name(basis)}_{tag}_f{frozen}.json"
+        written.add((VALIDATION / deck).name)
+        if not args.dry_run:
+            # A tighter amplitude tolerance than the default 1e-8, so the case
+            # tests the equations rather than where the iteration was stopped.
+            (VALIDATION / deck).write_text(
+                json.dumps(deck_json(mol.xyz, basis, method=method,
+                                     correlation={"freeze_core": frozen > 0,
+                                                  "n_frozen_core": frozen},
+                                     cc={"tolerance": 1e-10}), indent=4) + "\n"
+            )
+        tests.append({
+            "name": f"{method.upper()} {mol.label} {basis} frozen {frozen} (CPU)",
+            "input": deck,
+            "expected_energy": round(energy, 12),
+            "type": "unfragmented",
+        })
+        print(f"{mol.label:6s} {basis:12s} {method:8s} frozen={frozen}  nao={nao:4d} E={energy:.12f}", flush=True)
+
     for name, basis, aux, frozen in RI_MP2_CASES:
         mol = MOLECULES[name]
         energy, nao = pyscf_ri_mp2(mol.atoms, basis, aux, frozen)
@@ -677,8 +756,11 @@ def main():
         return 0
 
     # Drop decks left behind by an earlier, wider case list, so that what is on
-    # disk is exactly what this script produces.
+    # disk is exactly what this script produces -- except the few that are
+    # deliberately hand-maintained and merely happen to share the prefix.
     for stale in sorted(INPUTS.glob("cpu_*.json")):
+        if stale.name in HAND_MAINTAINED:
+            continue
         if stale.name not in written:
             stale.unlink()
             print(f"removed stale {stale.name}")

--- a/validation/inputs/cpu_ch4_sto-3g_ccsdt_f1.json
+++ b/validation/inputs/cpu_ch4_sto-3g_ccsdt_f1.json
@@ -1,0 +1,36 @@
+{
+    "schema": {
+        "name": "mqc-frag",
+        "version": "1.0"
+    },
+    "molecules": [
+        {
+            "xyz": "sample_inputs/ch4.xyz",
+            "molecular_charge": 0,
+            "molecular_multiplicity": 1
+        }
+    ],
+    "model": {
+        "method": "ccsd(t)",
+        "basis": "sto-3g"
+    },
+    "keywords": {
+        "scf": {
+            "maxiter": 100,
+            "tolerance": 1e-08
+        },
+        "correlation": {
+            "freeze_core": true,
+            "n_frozen_core": 1
+        },
+        "cc": {
+            "tolerance": 1e-10
+        }
+    },
+    "system": {
+        "logger": {
+            "level": "Verbose"
+        }
+    },
+    "driver": "Energy"
+}

--- a/validation/inputs/cpu_water_cc-pvdz_ccsd_f1.json
+++ b/validation/inputs/cpu_water_cc-pvdz_ccsd_f1.json
@@ -1,0 +1,36 @@
+{
+    "schema": {
+        "name": "mqc-frag",
+        "version": "1.0"
+    },
+    "molecules": [
+        {
+            "xyz": "sample_inputs/w1.xyz",
+            "molecular_charge": 0,
+            "molecular_multiplicity": 1
+        }
+    ],
+    "model": {
+        "method": "ccsd",
+        "basis": "cc-pvdz"
+    },
+    "keywords": {
+        "scf": {
+            "maxiter": 100,
+            "tolerance": 1e-08
+        },
+        "correlation": {
+            "freeze_core": true,
+            "n_frozen_core": 1
+        },
+        "cc": {
+            "tolerance": 1e-10
+        }
+    },
+    "system": {
+        "logger": {
+            "level": "Verbose"
+        }
+    },
+    "driver": "Energy"
+}

--- a/validation/inputs/cpu_water_cc-pvdz_ccsdt_f1.json
+++ b/validation/inputs/cpu_water_cc-pvdz_ccsdt_f1.json
@@ -1,0 +1,36 @@
+{
+    "schema": {
+        "name": "mqc-frag",
+        "version": "1.0"
+    },
+    "molecules": [
+        {
+            "xyz": "sample_inputs/w1.xyz",
+            "molecular_charge": 0,
+            "molecular_multiplicity": 1
+        }
+    ],
+    "model": {
+        "method": "ccsd(t)",
+        "basis": "cc-pvdz"
+    },
+    "keywords": {
+        "scf": {
+            "maxiter": 100,
+            "tolerance": 1e-08
+        },
+        "correlation": {
+            "freeze_core": true,
+            "n_frozen_core": 1
+        },
+        "cc": {
+            "tolerance": 1e-10
+        }
+    },
+    "system": {
+        "logger": {
+            "level": "Verbose"
+        }
+    },
+    "driver": "Energy"
+}

--- a/validation/inputs/cpu_water_sto-3g_ccsd_f0.json
+++ b/validation/inputs/cpu_water_sto-3g_ccsd_f0.json
@@ -1,0 +1,36 @@
+{
+    "schema": {
+        "name": "mqc-frag",
+        "version": "1.0"
+    },
+    "molecules": [
+        {
+            "xyz": "sample_inputs/w1.xyz",
+            "molecular_charge": 0,
+            "molecular_multiplicity": 1
+        }
+    ],
+    "model": {
+        "method": "ccsd",
+        "basis": "sto-3g"
+    },
+    "keywords": {
+        "scf": {
+            "maxiter": 100,
+            "tolerance": 1e-08
+        },
+        "correlation": {
+            "freeze_core": false,
+            "n_frozen_core": 0
+        },
+        "cc": {
+            "tolerance": 1e-10
+        }
+    },
+    "system": {
+        "logger": {
+            "level": "Verbose"
+        }
+    },
+    "driver": "Energy"
+}

--- a/validation/inputs/cpu_water_sto-3g_ccsdt_f0.json
+++ b/validation/inputs/cpu_water_sto-3g_ccsdt_f0.json
@@ -1,0 +1,36 @@
+{
+    "schema": {
+        "name": "mqc-frag",
+        "version": "1.0"
+    },
+    "molecules": [
+        {
+            "xyz": "sample_inputs/w1.xyz",
+            "molecular_charge": 0,
+            "molecular_multiplicity": 1
+        }
+    ],
+    "model": {
+        "method": "ccsd(t)",
+        "basis": "sto-3g"
+    },
+    "keywords": {
+        "scf": {
+            "maxiter": 100,
+            "tolerance": 1e-08
+        },
+        "correlation": {
+            "freeze_core": false,
+            "n_frozen_core": 0
+        },
+        "cc": {
+            "tolerance": 1e-10
+        }
+    },
+    "system": {
+        "logger": {
+            "level": "Verbose"
+        }
+    },
+    "driver": "Energy"
+}

--- a/validation/validation_tests_cpu.json
+++ b/validation/validation_tests_cpu.json
@@ -47,7 +47,7 @@
         {
             "name": "RHF HF sto-3g (CPU)",
             "input": "inputs/cpu_hf_sto-3g.json",
-            "expected_energy": -98.570757663478,
+            "expected_energy": -98.570757663479,
             "type": "unfragmented"
         },
         {
@@ -179,7 +179,7 @@
         {
             "name": "RHF SiH4 3-21g (CPU)",
             "input": "inputs/cpu_sih4_3-21g.json",
-            "expected_energy": -289.686914238601,
+            "expected_energy": -289.6869142386,
             "type": "unfragmented"
         },
         {
@@ -281,13 +281,13 @@
         {
             "name": "RHF SiH4 6-31g (CPU)",
             "input": "inputs/cpu_sih4_6-31g.json",
-            "expected_energy": -291.173723638595,
+            "expected_energy": -291.173723638596,
             "type": "unfragmented"
         },
         {
             "name": "RHF PH3 6-31g (CPU)",
             "input": "inputs/cpu_ph3_6-31g.json",
-            "expected_energy": -342.395943319632,
+            "expected_energy": -342.395943319633,
             "type": "unfragmented"
         },
         {
@@ -377,7 +377,7 @@
         {
             "name": "RHF AlH3 cc-pvdz (CPU)",
             "input": "inputs/cpu_alh3_cc-pvdz.json",
-            "expected_energy": -243.631755712985,
+            "expected_energy": -243.631755712986,
             "type": "unfragmented"
         },
         {
@@ -389,7 +389,7 @@
         {
             "name": "RHF PH3 cc-pvdz (CPU)",
             "input": "inputs/cpu_ph3_cc-pvdz.json",
-            "expected_energy": -342.470428497942,
+            "expected_energy": -342.47042849794,
             "type": "unfragmented"
         },
         {
@@ -473,7 +473,7 @@
         {
             "name": "RHF CH4 aug-cc-pvdz (CPU)",
             "input": "inputs/cpu_ch4_aug-cc-pvdz.json",
-            "expected_energy": -40.199617623933,
+            "expected_energy": -40.199617623934,
             "type": "unfragmented"
         },
         {
@@ -503,13 +503,13 @@
         {
             "name": "RHF H2S aug-cc-pvdz (CPU)",
             "input": "inputs/cpu_h2s_aug-cc-pvdz.json",
-            "expected_energy": -398.698035963355,
+            "expected_energy": -398.698035963354,
             "type": "unfragmented"
         },
         {
             "name": "RHF HCl aug-cc-pvdz (CPU)",
             "input": "inputs/cpu_hcl_aug-cc-pvdz.json",
-            "expected_energy": -460.092615494768,
+            "expected_energy": -460.092615494769,
             "type": "unfragmented"
         },
         {
@@ -551,7 +551,7 @@
         {
             "name": "RHF SiH4 def2-svp (CPU)",
             "input": "inputs/cpu_sih4_def2-svp.json",
-            "expected_energy": -291.15392386055,
+            "expected_energy": -291.153923860553,
             "type": "unfragmented"
         },
         {
@@ -611,7 +611,7 @@
         {
             "name": "RHF NH3 def2-tzvp (CPU)",
             "input": "inputs/cpu_nh3_def2-tzvp.json",
-            "expected_energy": -56.21826806891,
+            "expected_energy": -56.218268068911,
             "type": "unfragmented"
         },
         {
@@ -647,25 +647,25 @@
         {
             "name": "RHF AlH3 def2-tzvp (CPU)",
             "input": "inputs/cpu_alh3_def2-tzvp.json",
-            "expected_energy": -243.641284905954,
+            "expected_energy": -243.641284905955,
             "type": "unfragmented"
         },
         {
             "name": "RHF SiH4 def2-tzvp (CPU)",
             "input": "inputs/cpu_sih4_def2-tzvp.json",
-            "expected_energy": -291.257893577061,
+            "expected_energy": -291.257893577065,
             "type": "unfragmented"
         },
         {
             "name": "RHF PH3 def2-tzvp (CPU)",
             "input": "inputs/cpu_ph3_def2-tzvp.json",
-            "expected_energy": -342.483090810071,
+            "expected_energy": -342.483090810072,
             "type": "unfragmented"
         },
         {
             "name": "RHF H2S def2-tzvp (CPU)",
             "input": "inputs/cpu_h2s_def2-tzvp.json",
-            "expected_energy": -398.706600110124,
+            "expected_energy": -398.706600110122,
             "type": "unfragmented"
         },
         {
@@ -677,7 +677,7 @@
         {
             "name": "RHF Ar def2-tzvp (CPU)",
             "input": "inputs/cpu_ar_def2-tzvp.json",
-            "expected_energy": -526.802760332527,
+            "expected_energy": -526.802760332526,
             "type": "unfragmented"
         },
         {
@@ -701,25 +701,25 @@
         {
             "name": "RHF BH3 6-31g* (CPU)",
             "input": "inputs/cpu_bh3_6-31g_st_.json",
-            "expected_energy": -26.390003144424,
+            "expected_energy": -26.390003144425,
             "type": "unfragmented"
         },
         {
             "name": "RHF CH4 6-31g* (CPU)",
             "input": "inputs/cpu_ch4_6-31g_st_.json",
-            "expected_energy": -40.195141002378,
+            "expected_energy": -40.195141002379,
             "type": "unfragmented"
         },
         {
             "name": "RHF NH3 6-31g* (CPU)",
             "input": "inputs/cpu_nh3_6-31g_st_.json",
-            "expected_energy": -56.184108039707,
+            "expected_energy": -56.184108039706,
             "type": "unfragmented"
         },
         {
             "name": "RHF H2O 6-31g* (CPU)",
             "input": "inputs/cpu_water_6-31g_st_.json",
-            "expected_energy": -76.010317945971,
+            "expected_energy": -76.01031794597,
             "type": "unfragmented"
         },
         {
@@ -743,25 +743,25 @@
         {
             "name": "RHF MgH2 6-31g* (CPU)",
             "input": "inputs/cpu_mgh2_6-31g_st_.json",
-            "expected_energy": -200.715451153879,
+            "expected_energy": -200.71545115388,
             "type": "unfragmented"
         },
         {
             "name": "RHF AlH3 6-31g* (CPU)",
             "input": "inputs/cpu_alh3_6-31g_st_.json",
-            "expected_energy": -243.616255399696,
+            "expected_energy": -243.616255399695,
             "type": "unfragmented"
         },
         {
             "name": "RHF SiH4 6-31g* (CPU)",
             "input": "inputs/cpu_sih4_6-31g_st_.json",
-            "expected_energy": -291.225102847643,
+            "expected_energy": -291.225102847644,
             "type": "unfragmented"
         },
         {
             "name": "RHF PH3 6-31g* (CPU)",
             "input": "inputs/cpu_ph3_6-31g_st_.json",
-            "expected_energy": -342.447342229633,
+            "expected_energy": -342.447342229634,
             "type": "unfragmented"
         },
         {
@@ -851,31 +851,31 @@
         {
             "name": "RHF AlH3 6-31g** (CPU)",
             "input": "inputs/cpu_alh3_6-31g_st__st_.json",
-            "expected_energy": -243.618987027898,
+            "expected_energy": -243.618987027897,
             "type": "unfragmented"
         },
         {
             "name": "RHF SiH4 6-31g** (CPU)",
             "input": "inputs/cpu_sih4_6-31g_st__st_.json",
-            "expected_energy": -291.230819820062,
+            "expected_energy": -291.230819820064,
             "type": "unfragmented"
         },
         {
             "name": "RHF PH3 6-31g** (CPU)",
             "input": "inputs/cpu_ph3_6-31g_st__st_.json",
-            "expected_energy": -342.453623634122,
+            "expected_energy": -342.453623634121,
             "type": "unfragmented"
         },
         {
             "name": "RHF H2S 6-31g** (CPU)",
             "input": "inputs/cpu_h2s_6-31g_st__st_.json",
-            "expected_energy": -398.674799073107,
+            "expected_energy": -398.674799073106,
             "type": "unfragmented"
         },
         {
             "name": "RHF HCl 6-31g** (CPU)",
             "input": "inputs/cpu_hcl_6-31g_st__st_.json",
-            "expected_energy": -460.066160564696,
+            "expected_energy": -460.066160564697,
             "type": "unfragmented"
         },
         {
@@ -965,7 +965,7 @@
         {
             "name": "MP2 H2O def2-svp frozen 1 (CPU)",
             "input": "inputs/cpu_water_def2-svp_mp2_f1.json",
-            "expected_energy": -76.161689337977,
+            "expected_energy": -76.161689337976,
             "type": "unfragmented"
         },
         {
@@ -978,6 +978,36 @@
             "name": "MP2 NH3 cc-pvdz frozen 1 (CPU)",
             "input": "inputs/cpu_nh3_cc-pvdz_mp2_f1.json",
             "expected_energy": -56.381946912509,
+            "type": "unfragmented"
+        },
+        {
+            "name": "CCSD H2O sto-3g frozen 0 (CPU)",
+            "input": "inputs/cpu_water_sto-3g_ccsd_f0.json",
+            "expected_energy": -75.011179639395,
+            "type": "unfragmented"
+        },
+        {
+            "name": "CCSD(T) H2O sto-3g frozen 0 (CPU)",
+            "input": "inputs/cpu_water_sto-3g_ccsdt_f0.json",
+            "expected_energy": -75.011252381782,
+            "type": "unfragmented"
+        },
+        {
+            "name": "CCSD H2O cc-pvdz frozen 1 (CPU)",
+            "input": "inputs/cpu_water_cc-pvdz_ccsd_f1.json",
+            "expected_energy": -76.237533859112,
+            "type": "unfragmented"
+        },
+        {
+            "name": "CCSD(T) H2O cc-pvdz frozen 1 (CPU)",
+            "input": "inputs/cpu_water_cc-pvdz_ccsdt_f1.json",
+            "expected_energy": -76.240549582971,
+            "type": "unfragmented"
+        },
+        {
+            "name": "CCSD(T) CH4 sto-3g frozen 1 (CPU)",
+            "input": "inputs/cpu_ch4_sto-3g_ccsdt_f1.json",
+            "expected_energy": -39.805169969886,
             "type": "unfragmented"
         },
         {


### PR DESCRIPTION
## Summary

Wires the CPU coupled-cluster method into the input deck so it can be reached from JSON.

- Config plumbing: `mqc_config_types.f90`, `mqc_json_config_reader.f90`, `mqc_json_schema.f90`, `mqc_config_adapter.f90`
- Method factory / HF path hookup (`mqc_method_factory.F90`, `mqc_method_hf.F90`, `mqc_cuest_iface.f90`)
- libcint bridge entry point (`mqc_libcint_bridge.f90`)
- Validation decks for CCSD / CCSD(T) plus generator updates

## Tests

- `test/test_mqc_json_reader.f90` — new reader cases for the CC keywords
- New `validation/inputs/cpu_*_ccsd*_*.json` decks + `validation_tests_cpu.json`

## Stack

Part of the CPU coupled-cluster stack (base ← top):

1. `feat/cpu-atomic-guess` (#157)
2. `feat/cpu-coupled-cluster` (#158)
3. **`feat/cc-wiring`** (#159) ← this PR
4. `feat/cpu-ri-cc` (#160)
