### PR TITLE
document the methods that arrived without docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,8 +171,25 @@ end type
 
 ## Methods Available
 
+Semi-empirical, via tblite:
+
 - `GFN1` - GFN1-xTB (faster, older parametrization)
 - `GFN2` - GFN2-xTB (recommended, more accurate)
+
+Ab initio on the CPU, via libcint (`backends/libcint/`):
+
+- `HF` - restricted and unrestricted; direct, in-core, or density-fitted
+- `MP2`, `SCS-MP2`, `SOS-MP2`, `RI-MP2`
+- `CCSD`, `CCSD(T)`, `RI-CCSD`, `RI-CCSD(T)` - spin orbital, RHF reference
+
+An `RI-`/`DF-` prefix parses to the same method type as the bare name, so the
+intent is recovered in the reader by `method_wants_density_fitting` while the
+spelling still exists. `ccsd` and `ccsd(t)` are separate method types, so the
+triples survive the parse.
+
+Initial guess is `keywords.scf.guess`: `core`, `gwh`, `sac`, `sad`, or `auto`.
+`auto` resolves per backend - `sad` on the CPU path, `gwh` on cuEST - so the two
+can differ without either knowing what the other chose.
 
 ## Solvation Models
 
@@ -240,6 +257,13 @@ See `FORTRAN_STYLE.md` for the complete style guide. Key points:
 4. Register in method factory
 
 ### Add a new input keyword
+Check first whether it already exists. `keywords.scf.density_fitting`,
+`keywords.scf.unrestricted` and most of `correlation_config_t` and `cc_config_t`
+were already present and working when they were asked for.
+
+Keyword objects: `keywords.scf` for the reference, `keywords.correlation` for what
+every post-HF method shares, `keywords.cc` for what only an iterative one needs.
+
 1. Add the field to the relevant type in `mqc_config_types.f90`, with its default
 2. Add the key to its object's allow-list in `mqc_json_schema.f90` — the
    validator rejects anything it does not know, so a key added anywhere else
@@ -256,11 +280,23 @@ See `FORTRAN_STYLE.md` for the complete style guide. Key points:
 
 ## Validation Tests
 
-Located in `validation/` directory:
+Decks live under `validation/inputs/<hardware>/<engine>/<method>/`, with the
+geometries shared at `validation/inputs/sample_inputs/` and reached from a deck
+with `../../../`. The CPU suite is **generated** - edit
+`tools/cpu_validation/gen_cpu_validation.py` and rerun it; a deck added by hand
+under `cpu/mqc/` is deleted by the next regeneration.
+
+Examples, all under `validation/inputs/cpu/tblite/gfn1/`:
 - `h3o.json` - Unfragmented hydronium
 - `prism.json` - Water prism MBE(2)
 - `overlapping_gly3.json` - Glycine tripeptide GMBE(1)
 - `w20_isomer.json` - Water 20-mer MBE(2)
+
+The CPU ab initio suite is 176 generated cases under `cpu/mqc/`: RHF across H-Ar
+and eight basis sets, UHF, density fitting, MP2, RI-MP2, CCSD(T) and RI-CCSD(T),
+and one fragmented case. References are PySCF fed this repository's own basis
+JSON, not PySCF's internal tables - those differ in the eighth decimal on Pople
+sets, which looks exactly like a bug in whichever code you are checking.
 
 ## Output Format
 

--- a/README.md
+++ b/README.md
@@ -27,9 +27,14 @@ Additionally, users can opt to try the [vapaa](https://github.com/jeffhammond/va
 to ensure cross compiler portability. Please report any issues associated here and in vapaa.
 
 Metalquicha implements a naive backend for unfragmented and fragmented quantum chemistry
-calculations. Two chemistry engines are available:
+calculations. Three chemistry engines are available:
 
 - [tblite](https://github.com/tblite/tblite) for semi-empirical xTB (GFN1, GFN2), on the CPU
+- [libcint](https://github.com/sunqm/libcint) for Gaussian-basis ab initio on the
+  CPU — Hartree-Fock restricted and unrestricted, MP2, and CCSD(T), each
+  conventional or density-fitted. This one exists to be checked against as much as
+  to be run: it gives the GPU path a second, independent implementation to
+  disagree with, and every method in it is validated against PySCF.
 - [NVIDIA cuEST](https://developer.nvidia.com/cuda/cuda-x-libraries/cuest) for
   Hartree-Fock and Kohn-Sham DFT on the GPU — energies, analytic gradients and
   Hessians, for whole molecules and for every fragment of an MBE/GMBE expansion.
@@ -250,9 +255,11 @@ reference energies, and `energy_screened_mbe.py` shows a two-pass calculation
 that recomputes only the terms whose contribution exceeded a threshold.
 
 Which methods are available depends on the build: `gfn1`/`gfn2` need
-`MQC_ENABLE_TBLITE`, and `hf` on the CPU needs `MQC_ENABLE_LIBCINT`. Gradients
-come from xTB and cuEST; the CPU Hartree-Fock backend refuses them rather than
-returning something untested.
+`MQC_ENABLE_TBLITE`, while `MQC_ENABLE_LIBCINT` brings the CPU ab initio path —
+`hf`, `mp2`, `ccsd`, `ccsd(t)`, and the `ri-` spellings of the correlated ones.
+Gradients come from xTB and cuEST; the CPU backend refuses them rather than
+returning something untested, and refuses unrestricted coupled cluster on the same
+principle.
 
 Details, including density fitting and the current limitations, are in
 [the Python interface documentation](https://metalquicha.readthedocs.io/en/latest/python_interface.html).

--- a/mqc_docs/source/capabilities.rst
+++ b/mqc_docs/source/capabilities.rst
@@ -64,6 +64,25 @@ Semi-empirical quantum chemistry via the `tblite <https://github.com/tblite/tbli
 - **GFN2-xTB**: Latest parametrization, general-purpose, highest accuracy
 - **GFN1-xTB**: Earlier version, faster, good for large systems
 
+Ab Initio (CPU)
+---------------
+
+Gaussian-basis methods over `libcint <https://github.com/sunqm/libcint>`_, on the
+CPU. This path exists to be checked against as much as to be run: it is the second
+implementation the GPU backend is compared with, and everything below is validated
+against PySCF on the same geometries and the same basis data.
+
+- **Hartree-Fock**: restricted and unrestricted, with a direct, in-core or
+  density-fitted Fock build. Initial guesses are core, GWH, and superposition of
+  atomic densities or coefficients.
+- **MP2**: conventional and density-fitted (RI-MP2), with spin-component scaling
+  reported from separately-kept same- and opposite-spin components.
+- **Coupled cluster**: CCSD and CCSD(T), conventional and density-fitted, in the
+  spin-orbital basis over a restricted reference.
+
+Basis sets come from the Basis Set Exchange data shipped in ``basis_sets/``, and
+whether a set is Cartesian or spherical is taken from the file rather than assumed.
+
 Implicit Solvation
 ------------------
 
@@ -130,7 +149,8 @@ Energy Calculations
 -------------------
 
 - **Single-point energies**: Total electronic energy
-- **Component breakdown**: SCF, MP2 (future), coupled-cluster (future)
+- **Component breakdown**: SCF, MP2 same/opposite spin, coupled-cluster
+  singles/doubles/triples, kept separately so a total can be taken apart
 - **Output**: Hartrees, per-fragment energies, MBE contributions
 
 Gradient Calculations
@@ -374,9 +394,11 @@ Planned Features
 
 1. **Additional QC methods**:
 
-   - Hartree-Fock (via libint)
-   - DFT functionals (via libxc, libint)
-   - Post-HF methods (MP2, CCSD)
+   - DFT functionals on the CPU path (via libxc); DFT currently runs on the GPU
+     backend only
+   - Unrestricted coupled cluster, which needs its own alpha and beta transform
+     and is refused rather than approximated today
+   - F12 variants, and MCSCF: these parse but have no implementation
 
 2. **Advanced dynamics**:
 

--- a/mqc_docs/source/input_files.rst
+++ b/mqc_docs/source/input_files.rst
@@ -183,12 +183,32 @@ Specifies the quantum chemistry method:
      "aux_basis": "cc-pVDZ-RIFIT"
    }
 
-**Supported methods**:
+**Supported methods**. Spelling is case-insensitive, and an ``XTB-`` prefix is
+stripped before matching, so ``XTB-GFN2`` and ``gfn2`` are the same request.
 
-- ``XTB-GFN1``: GFN1-xTB semi-empirical method (default)
-- ``XTB-GFN2``: GFN2-xTB semi-empirical method
+Semi-empirical, through tblite:
 
-**Note**: Basis sets (``basis``, ``aux_basis``) are currently only used for future ab initio methods. XTB methods ignore these fields.
+- ``GFN1`` (also ``GFN1-xTB``, ``XTB-GFN1``)
+- ``GFN2`` (also ``GFN2-xTB``, ``XTB-GFN2``)
+
+Ab initio, on the CPU through libcint:
+
+- ``HF`` (also ``RHF``, ``UHF``, ``Hartree-Fock``) -- an odd electron count or a
+  multiplicity above one selects the unrestricted path whatever the spelling says
+- ``MP2``, and ``SCS-MP2`` / ``SOS-MP2`` for the spin-component-scaled variants
+- ``CCSD`` and ``CCSD(T)``
+- ``RI-`` or ``DF-`` on any correlated method asks for the density-fitted route:
+  ``RI-MP2``, ``RI-CCSD``, ``RI-CCSD(T)``
+
+**Basis sets.** ``basis`` is required by every ab initio method and ignored by the
+semi-empirical ones, which carry their own parameters. ``aux_basis`` is the
+auxiliary set for a density-fitted *reference*; the auxiliary set for a fitted
+*correlation* treatment is ``keywords.correlation.aux_basis``, which is separate
+because the two can legitimately differ.
+
+**Not yet reachable**: ``DFT``, ``MCSCF`` and the F12 variants parse but have no
+CPU implementation. ``RI-CCSD`` needs a restricted reference; unrestricted
+coupled cluster is refused rather than quietly run restricted.
 
 Driver Section
 --------------
@@ -215,12 +235,83 @@ SCF Options
    "keywords": {
      "scf": {
        "maxiter": 300,
-       "tolerance": 1e-6
+       "tolerance": 1e-6,
+       "guess": "auto",
+       "unrestricted": false,
+       "density_fitting": false,
+       "allow_crap_scf": false
      }
    }
 
 - ``maxiter``: Maximum SCF iterations (default: 300)
 - ``tolerance``: Convergence tolerance (default: 1e-6)
+- ``guess``: Initial orbital guess (default: ``auto``). One of:
+
+  - ``core`` -- the core Hamiltonian, ``F = H``. Cheapest and worst; on a
+    46-atom peptide cation it does not converge at all in 100 cycles.
+  - ``gwh`` -- generalized Wolfsberg-Helmholz, needing no atomic calculation.
+  - ``sad`` -- superposition of spherically averaged atomic densities. Each
+    element is solved once as a free atom and cached.
+  - ``sac`` -- superposition of the free atoms' own spin densities. Arrives with
+    its spatial symmetry already broken, which is what a radical wants and a
+    closed shell does not.
+  - ``auto`` -- let the backend choose, since the best starting point is a
+    property of the backend: the CPU path resolves it to ``sad`` and the GPU path
+    to ``gwh``, each having measured its own.
+
+- ``unrestricted``: Force the unrestricted path (default: false). An odd electron
+  count or a multiplicity above one forces it regardless.
+- ``density_fitting``: Fit J and K in the reference (default: false). Asked for
+  explicitly rather than inferred from ``aux_basis`` being present.
+- ``allow_crap_scf``: Accept a non-converged SCF instead of stopping (default:
+  false). Off because the energy of an SCF that ran out of iterations has the
+  right magnitude and nothing downstream can tell.
+
+Correlation Options
+^^^^^^^^^^^^^^^^^^^
+
+Shared by every post-Hartree-Fock method, and deliberately not under ``scf``: a
+density-fitted reference followed by a conventional correlation treatment is a
+combination someone will ask for, and one shared flag could not express it.
+
+.. code-block:: json
+
+   "correlation": {
+     "freeze_core": true,
+     "n_frozen_core": -1,
+     "density_fitting": false,
+     "aux_basis": "cc-pVDZ-RIFIT",
+     "scs": false
+   }
+
+- ``freeze_core``: Leave core orbitals uncorrelated (default: true)
+- ``n_frozen_core``: How many to freeze (default: -1, counted from the elements)
+- ``density_fitting``: Fit the correlation integrals (default: false, or true if
+  the method name carries an ``RI-``/``DF-`` prefix -- an explicit keyword wins)
+- ``aux_basis``: Auxiliary set for the fit; falls back to ``model.aux_basis``
+- ``scs``, ``scs_ss``, ``scs_os``: Spin-component scaling and its factors
+  (defaults 1/3 and 1.2, applied only when ``scs`` is on or the method name asks)
+
+Coupled Cluster Options
+^^^^^^^^^^^^^^^^^^^^^^^
+
+What only an iterative correlation method needs.
+
+.. code-block:: json
+
+   "cc": {
+     "maxiter": 100,
+     "tolerance": 1e-8,
+     "diis": true,
+     "diis_size": 8
+   }
+
+- ``maxiter``: Maximum amplitude iterations (default: 100)
+- ``tolerance``: Correlation energy convergence (default: 1e-8)
+- ``diis`` / ``diis_size``: Extrapolate the amplitudes (default: true, 8)
+- ``triples``: Override whether (T) runs. Ordinarily the method name settles it,
+  since ``ccsd`` and ``ccsd(t)`` are separate methods rather than one method with
+  a flag; set this only to contradict the name.
 
 Fragmentation Options
 ^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Everything the CPU ab initio path can do was undocumented. Before this, nothing in mqc_docs/, CLAUDE.md or the README mentioned `ccsd`, `keywords.cc`, the `sad` and `sac` guesses, or even `ri-mp2` -- zero occurrences of each. Two places were worse than silent:

  * input_files.rst listed GFN1 and GFN2 as the supported methods and said "Basis sets are currently only used for future ab initio methods";
  * capabilities.rst listed MP2 and coupled cluster under "Planned Features" and as "(future)" in the energy breakdown, and credited Hartree-Fock to libint rather than libcint.

Now documented, with defaults read out of `mqc_config_types.f90` rather than recalled: every method spelling the parser accepts and the `XTB-` prefix it strips; the full `keywords.scf` block including `guess`; and `keywords.correlation` and `keywords.cc` as separate objects, with why they are separate -- one holds what every post-HF method shares, the other what only an iterative one needs.

The guess list says what each is for rather than only naming it, including that `core` does not converge at all on a 46-atom peptide cation and that `auto` resolves per backend because the best starting point is a property of the backend.

The README claimed two chemistry engines and listed tblite and cuEST; libcint was missing entirely.

Also repaths the validation examples in CLAUDE.md, which pointed at the flat layout the previous commit replaced, and records that the CPU suite is generated so a deck added by hand under cpu/mqc/ does not silently disappear.

Kept out: what the CPU path refuses is written down next to what it does -- gradients, unrestricted coupled cluster, DFT -- because a documented refusal is the difference between a gap and a surprise.