### PR TITLE
Weight integral screening by the density it multiplies

### DIFF
--- a/backends/libcint/mqc_libcint_cphf.f90
+++ b/backends/libcint/mqc_libcint_cphf.f90
@@ -326,7 +326,14 @@ contains
       dtilde = dtilde + transpose(dtilde)
 
       if (direct) then
-         call build_fock_direct(mol, zero_h, dtilde, bounds, g, stats, error)
+         ! density_screen=.false. is not optional here. `dtilde` is the trial
+         ! rotation the CG solver drives towards zero, so the default
+         ! density-weighted screen would tighten as the solve converges and this
+         ! operator would stop being the fixed linear map the solver assumes --
+         ! the iteration then stalls short of tolerance. The plain Schwarz screen
+         ! depends on the basis alone and keeps the operator constant.
+         call build_fock_direct(mol, zero_h, dtilde, bounds, g, stats, error, &
+                                density_screen=.false.)
          if (error%has_error()) return
       else
          call build_fock(zero_h, eri, dtilde, g)

--- a/backends/libcint/mqc_libcint_direct.f90
+++ b/backends/libcint/mqc_libcint_direct.f90
@@ -41,6 +41,7 @@ module mqc_libcint_direct
    private
 
    public :: schwarz_bounds
+   public :: shell_density_max
    public :: build_fock_direct
    public :: build_fock_direct_many
    public :: build_fock_direct_nosym
@@ -59,7 +60,19 @@ module mqc_libcint_direct
       !! What a Fock build did, so screening can be reported rather than assumed
       integer(int64) :: quartets_total = 0     !! Unique quartets before screening
       integer(int64) :: quartets_computed = 0  !! Quartets actually handed to libcint
-      integer(int64) :: quartets_screened = 0  !! Skipped on the Schwarz bound
+      integer(int64) :: quartets_screened = 0  !! Skipped, either test
+      integer(int64) :: screened_schwarz = 0
+         !! Skipped because the integral itself is negligible. Depends on the
+         !! basis and the geometry only, so this number is the same at every
+         !! iteration of an SCF.
+      integer(int64) :: screened_density = 0
+         !! Skipped because the *contribution* is negligible although the
+         !! integral is not -- the extra reach the density weighting buys.
+         !!
+         !! Counted separately because it is the only honest way to measure that
+         !! weighting on a shared machine: run-to-run wall time on a contended
+         !! node varies by more than the effect, but these counts are exactly
+         !! reproducible.
    contains
       procedure :: screened_fraction => stats_screened_fraction
    end type direct_stats_t
@@ -128,6 +141,83 @@ contains
       deallocate (buf)
    end subroutine schwarz_bounds
 
+   subroutine shell_density_max(mol, density, dsh)
+      !! The largest |D| in each shell-pair block
+      !!
+      !! The Schwarz bound says how big an integral can be. It says nothing about
+      !! whether that integral matters, and by the middle of an SCF most of them
+      !! do not: a quartet multiplies six density elements, and if all six are
+      !! negligible the quartet contributes nothing however large it is.
+      !!
+      !! Blocked to shells rather than kept per function because the screening
+      !! decision is made per shell quartet -- one number per pair is all the test
+      !! can use, and it has to be the largest in the block or the bound would not
+      !! be one.
+      !!
+      !! Rebuilt every Fock build, unlike the Schwarz bounds: this one is a
+      !! property of the density and the density is what changes. It costs one
+      !! pass over an n-by-n matrix against a quartet loop that is the rest of the
+      !! iteration, so the cost does not show up.
+      type(libcint_molecule_t), intent(in) :: mol
+      real(dp), intent(in) :: density(:, :)
+      real(dp), allocatable, intent(out) :: dsh(:, :)
+
+      integer :: ish, jsh, oi, oj, di, dj
+
+      allocate (dsh(mol%nbas, mol%nbas))
+      dsh = 0.0_dp
+      do ish = 1, mol%nbas
+         oi = mol%shell_offset(ish)
+         di = shell_dim(mol%cartesian, ish - 1, mol%bas)
+         do jsh = 1, ish
+            oj = mol%shell_offset(jsh)
+            dj = shell_dim(mol%cartesian, jsh - 1, mol%bas)
+            dsh(ish, jsh) = maxval(abs(density(oi + 1:oi + di, oj + 1:oj + dj)))
+            dsh(jsh, ish) = dsh(ish, jsh)
+         end do
+      end do
+   end subroutine shell_density_max
+
+   pure function density_weight(dsh, s1, s2, s3, s4, jf, kq, deg) result(denmax)
+      !! Largest density contribution this quartet can make, per unit integral
+      !!
+      !! The six elements are the six the Fock updates read, and the weights are
+      !! the ones they are multiplied by, so `bound * denmax` is an upper bound on
+      !! the largest change any one Fock element can see from this quartet. That
+      !! is what the screening test should compare against a tolerance -- the
+      !! Schwarz bound alone compares the integral, which is not the quantity
+      !! anyone cares about being small.
+      !!
+      !! `deg` belongs in here. The permutational factor multiplies the
+      !! contribution, so leaving it out would make the bound smaller than the
+      !! thing it bounds and the test could discard a quartet that mattered.
+      !! Including it costs a little screening and buys rigour.
+      real(dp), intent(in) :: dsh(:, :)
+      integer, intent(in) :: s1, s2, s3, s4
+      real(dp), intent(in) :: jf, kq, deg
+      real(dp) :: denmax
+
+      denmax = deg*max(jf*dsh(s1, s2), jf*dsh(s3, s4), &
+                       kq*dsh(s1, s3), kq*dsh(s1, s4), &
+                       kq*dsh(s2, s3), kq*dsh(s2, s4))
+   end function density_weight
+
+   pure function pair_degeneracy(s1, s2, s3, s4) result(deg)
+      !! The eightfold permutational weight this quartet carries
+      !!
+      !! Shell equality, not function equality: a block with s1 == s2 already
+      !! contains both orderings of its function pair, so the permutation is
+      !! covered and must not be counted again. Getting it wrong produces a Fock
+      !! matrix wrong by a factor of two on its diagonal blocks only.
+      integer, intent(in) :: s1, s2, s3, s4
+      real(dp) :: deg
+
+      deg = 1.0_dp
+      if (s1 /= s2) deg = deg*2.0_dp
+      if (s3 /= s4) deg = deg*2.0_dp
+      if (.not. (s1 == s3 .and. s2 == s4)) deg = deg*2.0_dp
+   end function pair_degeneracy
+
    subroutine build_fock_direct(mol, h, density, bounds, fock, stats, error, screen_tol, &
                                 k_scale, j_scale, omega)
       !! F = H + J - K/2, without forming the integral tensor
@@ -162,6 +252,7 @@ contains
          !! the screening can only become conservative rather than wrong.
 
       real(dp), allocatable :: buf(:), g(:, :), g_local(:, :), d_half(:, :)
+      real(dp), allocatable :: dsh(:, :)
       real(dp), allocatable :: env_local(:)
       real(dp) :: jf
       type(c_ptr) :: opt
@@ -171,7 +262,8 @@ contains
       integer :: f1, f2, f3, f4, b1, b2, b3, b4, idx, ret, block_max, n
       integer :: ij, kl, npair, ipair
       integer, allocatable :: pair_i(:), pair_j(:), dims(:), offs(:)
-      integer(int64) :: n_total, n_computed, n_screened
+      integer(int64) :: n_total, n_computed, n_screened, n_schwarz, n_density
+      real(dp) :: schwarz
       real(dp) :: tol, deg, value, scaled
       real(dp) :: kq
 
@@ -222,6 +314,11 @@ contains
       ! large -- an error that still converges, to a badly wrong energy.
       d_half = 0.5_dp*density
 
+      ! Built from `d_half` rather than `density` because `d_half` is what the six
+      ! updates below actually multiply -- a bound has to be on the quantity that
+      ! is used, not on a factor of two away from it.
+      call shell_density_max(mol, d_half, dsh)
+
       ! The four exchange updates below carry a quarter each, so folding the
       ! exchange fraction in here scales all four at once at no per-quartet cost.
       kq = 0.25_dp
@@ -250,6 +347,8 @@ contains
       n_total = 0_int64
       n_computed = 0_int64
       n_screened = 0_int64
+      n_schwarz = 0_int64
+      n_density = 0_int64
 
       ! Threaded over bra pairs. libcint carries no mutable state across calls
       ! -- the 2e path has no static globals, and `opt` is written once here and
@@ -272,11 +371,12 @@ contains
       ! thousands of times the first, and a static split would leave most
       ! threads idle waiting for the tail.
       !$omp parallel default(none) &
-      !$omp    shared(mol, bounds, d_half, g, dims, offs, pair_i, pair_j, npair, tol, opt, n, block_max, kq, jf, env_local) &
+      !$omp    shared(mol, bounds, dsh, d_half, g, dims, offs, pair_i, pair_j, npair, tol, opt, n, &
+      !$omp           block_max, kq, jf, env_local) &
       !$omp    private(ij, kl, s1, s2, s3, s4, d1, d2, d3, d4, o1, o2, o3, o4, &
-      !$omp            shls, f1, f2, f3, f4, b1, b2, b3, b4, idx, ret, deg, value, scaled, &
+      !$omp            shls, f1, f2, f3, f4, b1, b2, b3, b4, idx, ret, deg, value, scaled, schwarz, &
       !$omp            buf, g_local) &
-      !$omp    reduction(+:n_total, n_computed, n_screened)
+      !$omp    reduction(+:n_total, n_computed, n_screened, n_schwarz, n_density)
       allocate (buf(block_max**4))
       allocate (g_local(n, n))
       g_local = 0.0_dp
@@ -300,8 +400,16 @@ contains
 
             n_total = n_total + 1_int64
 
-            if (bounds(s1, s2)*bounds(s3, s4) < tol) then
+            deg = pair_degeneracy(s1, s2, s3, s4)
+            schwarz = bounds(s1, s2)*bounds(s3, s4)
+            if (schwarz < tol) then
                n_screened = n_screened + 1_int64
+               n_schwarz = n_schwarz + 1_int64
+               cycle
+            end if
+            if (schwarz*density_weight(dsh, s1, s2, s3, s4, jf, kq, deg) < tol) then
+               n_screened = n_screened + 1_int64
+               n_density = n_density + 1_int64
                cycle
             end if
 
@@ -313,13 +421,6 @@ contains
                cycle
             end if
             n_computed = n_computed + 1_int64
-
-            ! Shell equality, not function equality: a block with s1 == s2
-            ! already contains both orderings of its function pair.
-            deg = 1.0_dp
-            if (s1 /= s2) deg = deg*2.0_dp
-            if (s3 /= s4) deg = deg*2.0_dp
-            if (.not. (s1 == s3 .and. s2 == s4)) deg = deg*2.0_dp
 
             do f4 = 1, d4
                b4 = o4 + f4
@@ -362,6 +463,8 @@ contains
       stats%quartets_total = n_total
       stats%quartets_computed = n_computed
       stats%quartets_screened = n_screened
+      stats%screened_schwarz = n_schwarz
+      stats%screened_density = n_density
 
       call libcint_del_optimizer(opt)
 
@@ -561,12 +664,7 @@ contains
             end if
             n_computed = n_computed + 1_int64
 
-            ! Shell equality, not function equality: a block with s1 == s2
-            ! already contains both orderings of its function pair.
-            deg = 1.0_dp
-            if (s1 /= s2) deg = deg*2.0_dp
-            if (s3 /= s4) deg = deg*2.0_dp
-            if (.not. (s1 == s3 .and. s2 == s4)) deg = deg*2.0_dp
+            deg = pair_degeneracy(s1, s2, s3, s4)
 
             do f4 = 1, d4
                b4 = o4 + f4
@@ -913,6 +1011,7 @@ contains
 
       real(dp), allocatable :: buf(:), ga(:, :), gb(:, :), ga_local(:, :), gb_local(:, :)
       real(dp), allocatable :: d_coul(:, :)
+      real(dp), allocatable :: dsh(:, :)
       real(dp), allocatable :: env_local(:)
       real(dp) :: kq, jf
       type(c_ptr) :: opt
@@ -922,7 +1021,8 @@ contains
       integer :: f1, f2, f3, f4, b1, b2, b3, b4, idx, ret, block_max, n
       integer :: ij, kl, npair, ipair
       integer, allocatable :: pair_i(:), pair_j(:), dims(:), offs(:)
-      integer(int64) :: n_total, n_computed, n_screened
+      integer(int64) :: n_total, n_computed, n_screened, n_schwarz, n_density
+      real(dp) :: schwarz
       real(dp) :: tol, deg, value, scaled
 
       n = mol%nao
@@ -985,6 +1085,12 @@ contains
       ! which is the same arithmetic one level out.
       d_coul = jf*0.5_dp*(d_alpha + d_beta)
 
+      ! Elementwise largest of the three matrices the updates read. Taking the
+      ! maximum rather than one of them keeps the bound a bound for every term:
+      ! the Coulomb updates read `d_coul` and the exchange updates read the two
+      ! spin densities, and any of the three can be the big one.
+      call shell_density_max(mol, max(abs(d_coul), abs(d_alpha), abs(d_beta)), dsh)
+
       ! A copy, because the range-separation parameter lives in `env` and the
       ! molecule is read-only here. See the closed-shell build for why the slot
       ! index carries a `+ 1`.
@@ -999,6 +1105,8 @@ contains
       n_total = 0_int64
       n_computed = 0_int64
       n_screened = 0_int64
+      n_schwarz = 0_int64
+      n_density = 0_int64
 
       ! Threaded over bra pairs. libcint carries no mutable state across calls
       ! -- the 2e path has no static globals, and `opt` is written once here and
@@ -1021,12 +1129,12 @@ contains
       ! thousands of times the first, and a static split would leave most
       ! threads idle waiting for the tail.
       !$omp parallel default(none) &
-      !$omp    shared(mol, bounds, d_coul, d_alpha, d_beta, ga, gb, dims, offs, pair_i, pair_j, &
+      !$omp    shared(mol, bounds, dsh, d_coul, d_alpha, d_beta, ga, gb, dims, offs, pair_i, pair_j, &
       !$omp            npair, tol, opt, n, block_max, kq, env_local) &
       !$omp    private(ij, kl, s1, s2, s3, s4, d1, d2, d3, d4, o1, o2, o3, o4, &
-      !$omp            shls, f1, f2, f3, f4, b1, b2, b3, b4, idx, ret, deg, value, scaled, &
+      !$omp            shls, f1, f2, f3, f4, b1, b2, b3, b4, idx, ret, deg, value, scaled, schwarz, &
       !$omp            buf, ga_local, gb_local) &
-      !$omp    reduction(+:n_total, n_computed, n_screened)
+      !$omp    reduction(+:n_total, n_computed, n_screened, n_schwarz, n_density)
       allocate (buf(block_max**4))
       allocate (ga_local(n, n), gb_local(n, n))
       ga_local = 0.0_dp
@@ -1051,8 +1159,19 @@ contains
 
             n_total = n_total + 1_int64
 
-            if (bounds(s1, s2)*bounds(s3, s4) < tol) then
+            ! One rather than `jf` for the Coulomb weight: this path folded `jf`
+            ! into `d_coul` before the loop, so `dsh` already carries it and
+            ! passing it again would square it.
+            deg = pair_degeneracy(s1, s2, s3, s4)
+            schwarz = bounds(s1, s2)*bounds(s3, s4)
+            if (schwarz < tol) then
                n_screened = n_screened + 1_int64
+               n_schwarz = n_schwarz + 1_int64
+               cycle
+            end if
+            if (schwarz*density_weight(dsh, s1, s2, s3, s4, 1.0_dp, kq, deg) < tol) then
+               n_screened = n_screened + 1_int64
+               n_density = n_density + 1_int64
                cycle
             end if
 
@@ -1064,13 +1183,6 @@ contains
                cycle
             end if
             n_computed = n_computed + 1_int64
-
-            ! Shell equality, not function equality: a block with s1 == s2
-            ! already contains both orderings of its function pair.
-            deg = 1.0_dp
-            if (s1 /= s2) deg = deg*2.0_dp
-            if (s3 /= s4) deg = deg*2.0_dp
-            if (.not. (s1 == s3 .and. s2 == s4)) deg = deg*2.0_dp
 
             do f4 = 1, d4
                b4 = o4 + f4
@@ -1121,6 +1233,8 @@ contains
       stats%quartets_total = n_total
       stats%quartets_computed = n_computed
       stats%quartets_screened = n_screened
+      stats%screened_schwarz = n_schwarz
+      stats%screened_density = n_density
 
       call libcint_del_optimizer(opt)
 

--- a/backends/libcint/mqc_libcint_direct.f90
+++ b/backends/libcint/mqc_libcint_direct.f90
@@ -276,7 +276,7 @@ contains
    end function pair_degeneracy
 
    subroutine build_fock_direct(mol, h, density, bounds, fock, stats, error, screen_tol, &
-                                k_scale, j_scale, omega)
+                                k_scale, j_scale, omega, density_screen)
       !! F = H + J - K/2, without forming the integral tensor
       type(libcint_molecule_t), intent(in) :: mol
       real(dp), intent(in) :: h(:, :)          !! Core Hamiltonian
@@ -307,6 +307,18 @@ contains
          !! here without being rebuilt: erf(omega r)/r <= 1/r pointwise, so an
          !! attenuated quartet is never larger than the bound screening it, and
          !! the screening can only become conservative rather than wrong.
+      logical, intent(in), optional :: density_screen
+         !! Weight the Schwarz bound by the density it multiplies before screening
+         !! (default true). An SCF wants it: a quartet whose six density elements
+         !! are all negligible contributes nothing however large its integral, so
+         !! dropping it is free accuracy. A CPHF response build must pass false.
+         !! Its `density` is a Krylov trial vector the solver drives towards zero,
+         !! so a screen keyed on the density's magnitude tightens as the solve
+         !! proceeds -- the operator stops being the same linear map from one
+         !! matvec to the next and the iteration cannot converge. False recovers
+         !! the plain Schwarz screen, which depends on the basis alone and leaves
+         !! the operator fixed. Bit-for-bit equal to `build_fock_direct_many` with
+         !! one density, which is the invariant the response path relies on.
 
       real(dp), allocatable :: buf(:), g(:, :), g_local(:, :), d_half(:, :)
       real(dp), allocatable :: dsh(:, :)
@@ -326,6 +338,7 @@ contains
       real(dp) :: schwarz
       real(dp) :: tol, deg, value, scaled
       real(dp) :: kq
+      logical :: weight_density
 
       n = mol%nao
       if (size(h, 1) /= n .or. size(density, 1) /= n .or. size(fock, 1) /= n) then
@@ -335,6 +348,9 @@ contains
 
       tol = DEFAULT_SCREEN_TOL
       if (present(screen_tol)) tol = screen_tol
+
+      weight_density = .true.
+      if (present(density_screen)) weight_density = density_screen
 
       ! Shell dimensions and offsets up front. Both are needed inside the
       ! parallel region, and looking them up there would mean every thread
@@ -377,8 +393,14 @@ contains
 
       ! Built from `d_half` rather than `density` because `d_half` is what the six
       ! updates below actually multiply -- a bound has to be on the quantity that
-      ! is used, not on a factor of two away from it.
-      call shell_density_max(mol, d_half, dsh)
+      ! is used, not on a factor of two away from it. Skipped when the caller has
+      ! opted out: `dsh` is then never read, so a zero-size placeholder keeps the
+      ! `shared` clause legal without paying for the pass over the density.
+      if (weight_density) then
+         call shell_density_max(mol, d_half, dsh)
+      else
+         allocate (dsh(0, 0))
+      end if
 
       ! The four exchange updates below carry a quarter each, so folding the
       ! exchange fraction in here scales all four at once at no per-quartet cost.
@@ -435,7 +457,7 @@ contains
       ! threads idle waiting for the tail.
       !$omp parallel default(none) &
       !$omp    shared(mol, bounds, dsh, d_half, g, dims, offs, pair_i, pair_j, order, npair, tol, opt, n, &
-      !$omp           block_max, kq, jf, env_local) &
+      !$omp           block_max, kq, jf, env_local, weight_density) &
       !$omp    private(itask, ij, kl, s1, s2, s3, s4, d1, d2, d3, d4, o1, o2, o3, o4, &
       !$omp            shls, f1, f2, f3, f4, b1, b2, b3, b4, idx, ret, deg, value, scaled, schwarz, &
       !$omp            buf, g_local, thread_clock, t_thread) &
@@ -474,14 +496,22 @@ contains
             ! whether the Schwarz bound alone would have been enough to reach it.
             deg = pair_degeneracy(s1, s2, s3, s4)
             schwarz = bounds(s1, s2)*bounds(s3, s4)
-            if (schwarz*density_weight(dsh, s1, s2, s3, s4, jf, kq, deg) < tol) then
-               n_screened = n_screened + 1_int64
-               if (schwarz < tol) then
-                  n_schwarz = n_schwarz + 1_int64
-               else
-                  n_density = n_density + 1_int64
+            if (weight_density) then
+               if (schwarz*density_weight(dsh, s1, s2, s3, s4, jf, kq, deg) < tol) then
+                  n_screened = n_screened + 1_int64
+                  if (schwarz < tol) then
+                     n_schwarz = n_schwarz + 1_int64
+                  else
+                     n_density = n_density + 1_int64
+                  end if
+                  cycle
                end if
-               cycle
+            else
+               if (schwarz < tol) then
+                  n_screened = n_screened + 1_int64
+                  n_schwarz = n_schwarz + 1_int64
+                  cycle
+               end if
             end if
 
             shls = [s1 - 1, s2 - 1, s3 - 1, s4 - 1]

--- a/backends/libcint/mqc_libcint_direct.f90
+++ b/backends/libcint/mqc_libcint_direct.f90
@@ -31,7 +31,8 @@ module mqc_libcint_direct
    !! equality, and why getting it wrong produces a Fock matrix that is wrong by
    !! a factor of two on its diagonal blocks only. `check_direct` compares
    !! against the in-core build elementwise, which catches exactly that.
-   use pic_types, only: dp, int64
+   use pic_types, only: dp, int64, int_index
+   use pic_sorting, only: sort_index
    use, intrinsic :: iso_c_binding, only: c_ptr, c_null_ptr
    use mqc_error, only: error_t, ERROR_VALIDATION
    use mqc_libcint_integrals, only: libcint_molecule_t, shell_dim, &
@@ -140,6 +141,47 @@ contains
 
       deallocate (buf)
    end subroutine schwarz_bounds
+
+   subroutine pair_work_order(pair_i, pair_j, dims, order)
+      !! Task indices sorted by descending cost
+      !!
+      !! Task `ij` runs `kl = 1..ij`, so its cost is the block size of pair `ij`
+      !! times the block sizes of every pair at or before it -- growing roughly
+      !! linearly in `ij`, but not monotonically, because a pair of two d shells
+      !! is thirty-six function pairs where two s shells are one.
+      !!
+      !! `schedule(dynamic)` hands tasks out in order, so ascending order
+      !! dispatches the most expensive task last and finishes with every other
+      !! thread idle behind it. Reversing fixes the trend but not the variation
+      !! within it; sorting on the actual cost fixes both, and `pic_sorting`'s
+      !! `sort_index` is an introsort that returns the permutation rather than
+      !! the sorted values, which is exactly the question being asked.
+      !!
+      !! The cost is the unscreened function-quartet count. Screening will remove
+      !! some of it unevenly, so this is an estimate -- but it is the estimate
+      !! available before the work is done, and the ordering only has to be
+      !! roughly right for the tail to disappear.
+      integer, intent(in) :: pair_i(:), pair_j(:), dims(:)
+      integer, allocatable, intent(out) :: order(:)
+
+      integer(int64), allocatable :: cost(:)
+      integer(int_index), allocatable :: perm(:)
+      integer(int64) :: cumulative, block
+      integer :: k, npair
+
+      npair = size(pair_i)
+      allocate (cost(npair), perm(npair), order(npair))
+
+      cumulative = 0_int64
+      do k = 1, npair
+         block = int(dims(pair_i(k)), int64)*int(dims(pair_j(k)), int64)
+         cumulative = cumulative + block
+         cost(k) = block*cumulative
+      end do
+
+      call sort_index(cost, perm, reverse=.true.)
+      order = int(perm)
+   end subroutine pair_work_order
 
    subroutine shell_density_max(mol, density, dsh)
       !! The largest |D| in each shell-pair block
@@ -261,7 +303,8 @@ contains
       integer :: shls(4)
       integer :: f1, f2, f3, f4, b1, b2, b3, b4, idx, ret, block_max, n
       integer :: ij, kl, npair, ipair
-      integer, allocatable :: pair_i(:), pair_j(:), dims(:), offs(:)
+      integer, allocatable :: pair_i(:), pair_j(:), dims(:), offs(:), order(:)
+      integer :: itask
       integer(int64) :: n_total, n_computed, n_screened, n_schwarz, n_density
       real(dp) :: schwarz
       real(dp) :: tol, deg, value, scaled
@@ -304,6 +347,7 @@ contains
             pair_j(ipair) = s2
          end do
       end do
+      call pair_work_order(pair_i, pair_j, dims, order)
 
       allocate (g(n, n), d_half(n, n))
       g = 0.0_dp
@@ -371,9 +415,9 @@ contains
       ! thousands of times the first, and a static split would leave most
       ! threads idle waiting for the tail.
       !$omp parallel default(none) &
-      !$omp    shared(mol, bounds, dsh, d_half, g, dims, offs, pair_i, pair_j, npair, tol, opt, n, &
+      !$omp    shared(mol, bounds, dsh, d_half, g, dims, offs, pair_i, pair_j, order, npair, tol, opt, n, &
       !$omp           block_max, kq, jf, env_local) &
-      !$omp    private(ij, kl, s1, s2, s3, s4, d1, d2, d3, d4, o1, o2, o3, o4, &
+      !$omp    private(itask, ij, kl, s1, s2, s3, s4, d1, d2, d3, d4, o1, o2, o3, o4, &
       !$omp            shls, f1, f2, f3, f4, b1, b2, b3, b4, idx, ret, deg, value, scaled, schwarz, &
       !$omp            buf, g_local) &
       !$omp    reduction(+:n_total, n_computed, n_screened, n_schwarz, n_density)
@@ -382,7 +426,8 @@ contains
       g_local = 0.0_dp
 
       !$omp do schedule(dynamic)
-      do ij = 1, npair
+      do itask = 1, npair
+         ij = order(itask)
          s1 = pair_i(ij)
          s2 = pair_j(ij)
          d1 = dims(s1)
@@ -400,16 +445,21 @@ contains
 
             n_total = n_total + 1_int64
 
+            ! One criterion, not two. The quantity that must be small is the
+            ! *contribution*, so that is what the test compares; screening on the
+            ! bare Schwarz bound as well would discard quartets whose weight
+            ! exceeds one -- `deg` reaches eight -- and those are exactly the ones
+            ! that matter most. The two counters only attribute the decision:
+            ! whether the Schwarz bound alone would have been enough to reach it.
             deg = pair_degeneracy(s1, s2, s3, s4)
             schwarz = bounds(s1, s2)*bounds(s3, s4)
-            if (schwarz < tol) then
-               n_screened = n_screened + 1_int64
-               n_schwarz = n_schwarz + 1_int64
-               cycle
-            end if
             if (schwarz*density_weight(dsh, s1, s2, s3, s4, jf, kq, deg) < tol) then
                n_screened = n_screened + 1_int64
-               n_density = n_density + 1_int64
+               if (schwarz < tol) then
+                  n_schwarz = n_schwarz + 1_int64
+               else
+                  n_density = n_density + 1_int64
+               end if
                cycle
             end if
 
@@ -534,7 +584,8 @@ contains
       integer :: shls(4)
       integer :: f1, f2, f3, f4, b1, b2, b3, b4, idx, ret, block_max, n, iset, n_set
       integer :: ij, kl, npair, ipair
-      integer, allocatable :: pair_i(:), pair_j(:), dims(:), offs(:)
+      integer, allocatable :: pair_i(:), pair_j(:), dims(:), offs(:), order(:)
+      integer :: itask
       integer(int64) :: n_total, n_computed, n_screened
       real(dp) :: tol, deg, value, scaled
 
@@ -581,6 +632,7 @@ contains
             pair_j(ipair) = s2
          end do
       end do
+      call pair_work_order(pair_i, pair_j, dims, order)
 
       allocate (g(n, n, n_set), d_half(n, n, n_set))
       g = 0.0_dp
@@ -621,9 +673,9 @@ contains
       ! thousands of times the first, and a static split would leave most
       ! threads idle waiting for the tail.
       !$omp parallel default(none) &
-      !$omp    shared(mol, bounds, d_half, g, dims, offs, pair_i, pair_j, npair, tol, opt, n, &
+      !$omp    shared(mol, bounds, d_half, g, dims, offs, pair_i, pair_j, order, npair, tol, opt, n, &
       !$omp           block_max, n_set) &
-      !$omp    private(ij, kl, s1, s2, s3, s4, d1, d2, d3, d4, o1, o2, o3, o4, &
+      !$omp    private(itask, ij, kl, s1, s2, s3, s4, d1, d2, d3, d4, o1, o2, o3, o4, &
       !$omp            shls, f1, f2, f3, f4, b1, b2, b3, b4, idx, ret, deg, value, scaled, &
       !$omp            buf, g_local, iset) &
       !$omp    reduction(+:n_total, n_computed, n_screened)
@@ -632,7 +684,8 @@ contains
       g_local = 0.0_dp
 
       !$omp do schedule(dynamic)
-      do ij = 1, npair
+      do itask = 1, npair
+         ij = order(itask)
          s1 = pair_i(ij)
          s2 = pair_j(ij)
          d1 = dims(s1)
@@ -787,7 +840,8 @@ contains
       integer :: shls(4)
       integer :: f1, f2, f3, f4, b1, b2, b3, b4, idx, ret, block_max, n, iset, n_set
       integer :: ij, kl, npair, ipair, i1, i2, i3, pp, qq, rr, ss, tmp
-      integer, allocatable :: pair_i(:), pair_j(:), dims(:), offs(:)
+      integer, allocatable :: pair_i(:), pair_j(:), dims(:), offs(:), order(:)
+      integer :: itask
       integer(int64) :: n_total, n_computed, n_screened
       real(dp) :: tol, value
       logical :: swap_bra, swap_ket, swap_pairs
@@ -825,6 +879,7 @@ contains
             pair_j(ipair) = s2
          end do
       end do
+      call pair_work_order(pair_i, pair_j, dims, order)
 
       allocate (g(n, n, n_set))
       g = 0.0_dp
@@ -838,9 +893,9 @@ contains
       n_screened = 0_int64
 
       !$omp parallel default(none) &
-      !$omp    shared(mol, bounds, densities, g, dims, offs, pair_i, pair_j, npair, tol, &
+      !$omp    shared(mol, bounds, densities, g, dims, offs, pair_i, pair_j, order, npair, tol, &
       !$omp           opt, n, block_max, n_set) &
-      !$omp    private(ij, kl, s1, s2, s3, s4, d1, d2, d3, d4, o1, o2, o3, o4, &
+      !$omp    private(itask, ij, kl, s1, s2, s3, s4, d1, d2, d3, d4, o1, o2, o3, o4, &
       !$omp            shls, f1, f2, f3, f4, b1, b2, b3, b4, idx, ret, value, &
       !$omp            buf, g_local, iset, i1, i2, i3, pp, qq, rr, ss, tmp, &
       !$omp            swap_bra, swap_ket, swap_pairs) &
@@ -850,7 +905,8 @@ contains
       g_local = 0.0_dp
 
       !$omp do schedule(dynamic)
-      do ij = 1, npair
+      do itask = 1, npair
+         ij = order(itask)
          s1 = pair_i(ij)
          s2 = pair_j(ij)
          d1 = dims(s1)
@@ -1020,7 +1076,8 @@ contains
       integer :: shls(4)
       integer :: f1, f2, f3, f4, b1, b2, b3, b4, idx, ret, block_max, n
       integer :: ij, kl, npair, ipair
-      integer, allocatable :: pair_i(:), pair_j(:), dims(:), offs(:)
+      integer, allocatable :: pair_i(:), pair_j(:), dims(:), offs(:), order(:)
+      integer :: itask
       integer(int64) :: n_total, n_computed, n_screened, n_schwarz, n_density
       real(dp) :: schwarz
       real(dp) :: tol, deg, value, scaled
@@ -1063,6 +1120,7 @@ contains
             pair_j(ipair) = s2
          end do
       end do
+      call pair_work_order(pair_i, pair_j, dims, order)
 
       allocate (ga(n, n), gb(n, n), d_coul(n, n))
       ga = 0.0_dp
@@ -1130,8 +1188,9 @@ contains
       ! threads idle waiting for the tail.
       !$omp parallel default(none) &
       !$omp    shared(mol, bounds, dsh, d_coul, d_alpha, d_beta, ga, gb, dims, offs, pair_i, pair_j, &
+      !$omp            order, &
       !$omp            npair, tol, opt, n, block_max, kq, env_local) &
-      !$omp    private(ij, kl, s1, s2, s3, s4, d1, d2, d3, d4, o1, o2, o3, o4, &
+      !$omp    private(itask, ij, kl, s1, s2, s3, s4, d1, d2, d3, d4, o1, o2, o3, o4, &
       !$omp            shls, f1, f2, f3, f4, b1, b2, b3, b4, idx, ret, deg, value, scaled, schwarz, &
       !$omp            buf, ga_local, gb_local) &
       !$omp    reduction(+:n_total, n_computed, n_screened, n_schwarz, n_density)
@@ -1141,7 +1200,8 @@ contains
       gb_local = 0.0_dp
 
       !$omp do schedule(dynamic)
-      do ij = 1, npair
+      do itask = 1, npair
+         ij = order(itask)
          s1 = pair_i(ij)
          s2 = pair_j(ij)
          d1 = dims(s1)
@@ -1162,16 +1222,21 @@ contains
             ! One rather than `jf` for the Coulomb weight: this path folded `jf`
             ! into `d_coul` before the loop, so `dsh` already carries it and
             ! passing it again would square it.
+            ! One criterion, not two. The quantity that must be small is the
+            ! *contribution*, so that is what the test compares; screening on the
+            ! bare Schwarz bound as well would discard quartets whose weight
+            ! exceeds one -- `deg` reaches eight -- and those are exactly the ones
+            ! that matter most. The two counters only attribute the decision:
+            ! whether the Schwarz bound alone would have been enough to reach it.
             deg = pair_degeneracy(s1, s2, s3, s4)
             schwarz = bounds(s1, s2)*bounds(s3, s4)
-            if (schwarz < tol) then
-               n_screened = n_screened + 1_int64
-               n_schwarz = n_schwarz + 1_int64
-               cycle
-            end if
             if (schwarz*density_weight(dsh, s1, s2, s3, s4, 1.0_dp, kq, deg) < tol) then
                n_screened = n_screened + 1_int64
-               n_density = n_density + 1_int64
+               if (schwarz < tol) then
+                  n_schwarz = n_schwarz + 1_int64
+               else
+                  n_density = n_density + 1_int64
+               end if
                cycle
             end if
 

--- a/backends/libcint/mqc_libcint_direct.f90
+++ b/backends/libcint/mqc_libcint_direct.f90
@@ -33,6 +33,7 @@ module mqc_libcint_direct
    !! against the in-core build elementwise, which catches exactly that.
    use pic_types, only: dp, int64, int_index
    use pic_sorting, only: sort_index
+   use pic_timer, only: timer_type
    use, intrinsic :: iso_c_binding, only: c_ptr, c_null_ptr
    use mqc_error, only: error_t, ERROR_VALIDATION
    use mqc_libcint_integrals, only: libcint_molecule_t, shell_dim, &
@@ -66,6 +67,13 @@ module mqc_libcint_direct
          !! Skipped because the integral itself is negligible. Depends on the
          !! basis and the geometry only, so this number is the same at every
          !! iteration of an SCF.
+      real(dp) :: thread_imbalance = 1.0_dp
+         !! Slowest thread's time on the quartet loop divided by the mean.
+         !!
+         !! One is perfect balance. This is what a work-ordering change has to
+         !! move, and it is measurable where wall time is not: it is a ratio
+         !! within a single run, so the contention that swamps a before/after
+         !! comparison on a shared node largely divides out.
       integer(int64) :: screened_density = 0
          !! Skipped because the *contribution* is negligible although the
          !! integral is not -- the extra reach the density weighting buys.
@@ -141,6 +149,13 @@ contains
 
       deallocate (buf)
    end subroutine schwarz_bounds
+
+   integer function omp_threads() result(n)
+      !! Threads that ran the last parallel region, or one without OpenMP
+!$    use omp_lib, only: omp_get_max_threads
+      n = 1
+!$    n = omp_get_max_threads()
+   end function omp_threads
 
    subroutine pair_work_order(pair_i, pair_j, dims, order)
       !! Task indices sorted by descending cost
@@ -305,6 +320,8 @@ contains
       integer :: ij, kl, npair, ipair
       integer, allocatable :: pair_i(:), pair_j(:), dims(:), offs(:), order(:)
       integer :: itask
+      type(timer_type) :: thread_clock
+      real(dp) :: t_thread, t_thread_max, t_thread_sum
       integer(int64) :: n_total, n_computed, n_screened, n_schwarz, n_density
       real(dp) :: schwarz
       real(dp) :: tol, deg, value, scaled
@@ -393,6 +410,8 @@ contains
       n_screened = 0_int64
       n_schwarz = 0_int64
       n_density = 0_int64
+      t_thread_max = 0.0_dp
+      t_thread_sum = 0.0_dp
 
       ! Threaded over bra pairs. libcint carries no mutable state across calls
       ! -- the 2e path has no static globals, and `opt` is written once here and
@@ -419,12 +438,14 @@ contains
       !$omp           block_max, kq, jf, env_local) &
       !$omp    private(itask, ij, kl, s1, s2, s3, s4, d1, d2, d3, d4, o1, o2, o3, o4, &
       !$omp            shls, f1, f2, f3, f4, b1, b2, b3, b4, idx, ret, deg, value, scaled, schwarz, &
-      !$omp            buf, g_local) &
-      !$omp    reduction(+:n_total, n_computed, n_screened, n_schwarz, n_density)
+      !$omp            buf, g_local, thread_clock, t_thread) &
+      !$omp    reduction(+:n_total, n_computed, n_screened, n_schwarz, n_density) &
+      !$omp    reduction(max:t_thread_max) reduction(+:t_thread_sum)
       allocate (buf(block_max**4))
       allocate (g_local(n, n))
       g_local = 0.0_dp
 
+      call thread_clock%start()
       !$omp do schedule(dynamic)
       do itask = 1, npair
          ij = order(itask)
@@ -501,7 +522,13 @@ contains
             end do
          end do
       end do
-      !$omp end do
+      !$omp end do nowait
+      ! `nowait`, so what is timed is this thread's share of the loop and not
+      ! the wait for the slowest one -- the wait is the thing being measured.
+      call thread_clock%stop()
+      t_thread = thread_clock%get_elapsed_time()
+      t_thread_max = max(t_thread_max, t_thread)
+      t_thread_sum = t_thread_sum + t_thread
 
       !$omp critical(mqc_direct_fock_accumulate)
       g = g + g_local
@@ -515,6 +542,9 @@ contains
       stats%quartets_screened = n_screened
       stats%screened_schwarz = n_schwarz
       stats%screened_density = n_density
+      if (t_thread_sum > 0.0_dp) then
+         stats%thread_imbalance = t_thread_max/(t_thread_sum/real(omp_threads(), dp))
+      end if
 
       call libcint_del_optimizer(opt)
 

--- a/backends/libcint/mqc_libcint_rhf.f90
+++ b/backends/libcint/mqc_libcint_rhf.f90
@@ -109,6 +109,42 @@ module mqc_libcint_rhf
 
 contains
 
+   subroutine screening_summary(verbose, stats)
+      !! How much of the quartet space each screening test removed
+      !!
+      !! From the last Fock build of the SCF, which is the converged one and so
+      !! the one whose density the screening will see for the rest of any
+      !! follow-on work.
+      !!
+      !! Split by cause because the two answer different questions. The Schwarz
+      !! count is a property of the basis and the geometry and does not move
+      !! between iterations; the density count is the extra reach that weighting
+      !! the bound by the density buys, and it is the only figure that a change
+      !! to the screening can move. Reported as counts rather than inferred from
+      !! wall time: on a shared node the run-to-run spread in seconds is larger
+      !! than the effect, and these are exactly reproducible.
+      logical, intent(in) :: verbose
+      type(direct_stats_t), intent(in) :: stats
+
+      character(len=LINE_LEN) :: line
+
+      if (.not. verbose) return
+      if (stats%quartets_total <= 0) return
+      call logger%performance("")
+      call logger%performance("  screening (last Fock build)")
+      write (line, "(a,i14)") "    unique quartets      ", stats%quartets_total
+      call logger%performance(trim(line))
+      write (line, "(a,i14,f9.1,a)") "    skipped, Schwarz     ", stats%screened_schwarz, &
+         100.0_dp*real(stats%screened_schwarz, dp)/real(stats%quartets_total, dp), " %"
+      call logger%performance(trim(line))
+      write (line, "(a,i14,f9.1,a)") "    skipped, density     ", stats%screened_density, &
+         100.0_dp*real(stats%screened_density, dp)/real(stats%quartets_total, dp), " %"
+      call logger%performance(trim(line))
+      write (line, "(a,i14,f9.1,a)") "    computed             ", stats%quartets_computed, &
+         100.0_dp*real(stats%quartets_computed, dp)/real(stats%quartets_total, dp), " %"
+      call logger%performance(trim(line))
+   end subroutine screening_summary
+
    subroutine scf_table_header(verbose)
       !! Column headings for the per-iteration table
       !!
@@ -235,6 +271,7 @@ contains
       real(dp) :: e_elec, e_old, de, drms
       integer :: n_ao, n_mo, n_occ, iter
       type(timing_report_t) :: clk
+      type(direct_stats_t) :: screening
       real(dp) :: t_fock_iter, t_rest_iter
 
       if (mod(nelec, 2) /= 0) then
@@ -359,7 +396,7 @@ contains
          ! back together and before extrapolation. A DIIS-mixed Fock is a
          ! convergence device, not a state anything is the energy of.
          call assemble_fock(mol, h, density, coeff, n_occ, bmat, eri, bounds, xc, &
-                            fock, e_elec, error, clk=clk)
+                            fock, e_elec, error, clk=clk, screening=screening)
          if (error%has_error()) return
          t_fock_iter = clk%seconds_of(STAGE_FOCK)
          call clk%lap(STAGE_FOCK)
@@ -416,6 +453,7 @@ contains
       call clk%lap(STAGE_FOCK)
       call clk%finish()
       call scf_table_footer(verbose, result%converged, result%iterations)
+      call screening_summary(verbose, screening)
       call clk%report("RHF", verbose)
    end subroutine run_libcint_rhf
 
@@ -686,7 +724,7 @@ contains
    end subroutine run_libcint_uhf
 
    subroutine assemble_fock(mol, h, density, coeff, n_occ, bmat, eri, bounds, xc, &
-                            fock, e_elec, error, clk)
+                            fock, e_elec, error, clk, screening)
       !! The Fock matrix for this density, and the electronic energy that belongs to it
       !!
       !! One place, because there used to be two: the iteration built its Fock
@@ -715,6 +753,11 @@ contains
          !! Present from the SCF loop, so the exchange-correlation quadrature is
          !! reported apart from the Coulomb/exchange build rather than inside it.
          !! Absent from the guess and gradient callers, which do not report.
+      type(direct_stats_t), intent(out), optional :: screening
+         !! How much of the quartet space each test removed. Reported rather than
+         !! discarded because wall time on a shared node varies by more than a
+         !! screening change does -- these counts are exactly reproducible, so
+         !! they are the measurement that can actually be trusted.
 
       type(direct_stats_t) :: stats
       real(dp), allocatable :: v_xc(:, :)
@@ -794,6 +837,8 @@ contains
          if (present(clk)) call clk%lap(STAGE_XC)
          deallocate (v_xc)
       end if
+
+      if (present(screening)) screening = stats
    end subroutine assemble_fock
 
    subroutine assemble_fock_uhf(mol, h, d_alpha, d_beta, eri, bounds, xc, &

--- a/backends/libcint/mqc_libcint_rhf.f90
+++ b/backends/libcint/mqc_libcint_rhf.f90
@@ -143,6 +143,11 @@ contains
       write (line, "(a,i14,f9.1,a)") "    computed             ", stats%quartets_computed, &
          100.0_dp*real(stats%quartets_computed, dp)/real(stats%quartets_total, dp), " %"
       call logger%performance(trim(line))
+      ! One is perfect balance. This is the figure a work-ordering change has to
+      ! move, and unlike wall time it is a ratio inside one run, so a contended
+      ! node largely divides out of it.
+      write (line, "(a,f14.4)") "    thread imbalance     ", stats%thread_imbalance
+      call logger%performance(trim(line))
    end subroutine screening_summary
 
    subroutine scf_table_header(verbose)


### PR DESCRIPTION
Screening decides which shell quartets are skipped in the Fock build. The Schwarz
bound alone bounds the *integral*, not the contribution, so it discards quartets
by a criterion that ignores how much density they would have been multiplied by.
Weighting the bound by that density screens on the quantity that actually
matters, and the scheduling change hands out the expensive shell pairs first so
threads do not finish at wildly different times.

Commits:
- `weight the Schwarz bound by the density it will multiply`
- `hand out the expensive shell pairs first, and screen on one criterion`
- `measure thread imbalance, and drop the case for a flat task space`

---

**Stack 1 of 2 — SCF / integral performance.** Second of four; based on #173.

1. #173 `feat/cpu-integral-perf` → `main`
2. **this PR** `feat/density-weighted-screening` → `feat/cpu-integral-perf`
3. `feat/incremental-fock` → `feat/density-weighted-screening`
4. `feat/basis-projection-guess` → `feat/incremental-fock`

Please merge in order. This branch previously carried #173's two commits as
cherry-picks; it has been rebased onto #173, which dropped the duplicates
(identical patch-ids), so the diff here is only the screening work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)