### PR TITLE
Carry a converged small-basis density into a larger basis as a guess

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -476,6 +476,12 @@ if(MQC_ENABLE_LIBCINT)
   target_include_directories(check_direct PRIVATE "${CMAKE_BINARY_DIR}/modules")
   target_link_libraries(check_direct PRIVATE ${main_lib} cint_fortran cint)
 
+  add_executable(check_projection
+                 ${PROJECT_SOURCE_DIR}/validation/check_projection.f90)
+  target_include_directories(check_projection
+                             PRIVATE "${CMAKE_BINARY_DIR}/modules")
+  target_link_libraries(check_projection PRIVATE ${main_lib} cint_fortran cint)
+
   add_executable(check_libcint
                  ${PROJECT_SOURCE_DIR}/validation/check_libcint.f90)
   target_include_directories(check_libcint

--- a/backends/libcint/CMakeLists.txt
+++ b/backends/libcint/CMakeLists.txt
@@ -23,6 +23,7 @@ target_sources(
           mqc_libcint_dma.f90
           mqc_libcint_esp.f90
           mqc_libcint_screening.f90
+          mqc_libcint_projection.f90
           mqc_libcint_rhf.f90
           mqc_libcint_mp2.f90
           mqc_libcint_cc.f90

--- a/backends/libcint/mqc_libcint_atomic_guess.f90
+++ b/backends/libcint/mqc_libcint_atomic_guess.f90
@@ -55,7 +55,7 @@ module mqc_libcint_atomic_guess
    use pic_types, only: dp
    use mqc_error, only: error_t, ERROR_VALIDATION
    use mqc_libcint_integrals, only: libcint_molecule_t, atom_ao_blocks, subshell_layout
-   use mqc_libcint_rhf, only: rhf_result_t, run_libcint_uhf, &
+   use mqc_libcint_rhf, only: SCF_GUESS_PROJ, rhf_result_t, run_libcint_uhf, &
                               SCF_GUESS_CORE, SCF_GUESS_GWH, SCF_GUESS_SAC, SCF_GUESS_SAD
    implicit none
    private
@@ -179,10 +179,13 @@ contains
          kind = SCF_GUESS_SAC
       case ("sad")
          kind = SCF_GUESS_SAD
+      case ("basis_set_projection", "projection")
+         kind = SCF_GUESS_PROJ
       case default
          kind = SCF_GUESS_SAD
          call error%set(ERROR_VALIDATION, "unknown initial guess '"//trim(adjustl(text))// &
-                        "'; the CPU backend has core, gwh, sac and sad")
+                        "'; the CPU backend has core, gwh, sac, sad and "// &
+                        "basis_set_projection")
       end select
    end subroutine parse_guess_name
 
@@ -198,6 +201,8 @@ contains
          name = "gwh"
       case (SCF_GUESS_SAC)
          name = "sac"
+      case (SCF_GUESS_PROJ)
+         name = "basis_set_projection"
       case (SCF_GUESS_SAD)
          name = "sad"
       case default

--- a/backends/libcint/mqc_libcint_bridge.f90
+++ b/backends/libcint/mqc_libcint_bridge.f90
@@ -23,7 +23,8 @@ module mqc_libcint_bridge
    use mqc_cuest_iface, only: cuest_scf_settings_t
    use mqc_libcint_integrals, only: libcint_molecule_t, build_libcint_molecule
    use mqc_libcint_rhf, only: rhf_result_t, run_libcint_rhf, run_libcint_uhf, &
-                              SCF_GUESS_GWH, SCF_GUESS_SAC, SCF_GUESS_SAD
+                              SCF_GUESS_GWH, SCF_GUESS_SAC, SCF_GUESS_SAD, SCF_GUESS_PROJ
+   use mqc_libcint_projection, only: climb_basis_ladder
    use mqc_libcint_atomic_guess, only: build_atomic_guess, parse_guess_name, &
                                        guess_display_name
    use mqc_libcint_xc, only: xc_context_t, xc_context_create, xc_available
@@ -345,6 +346,31 @@ contains
          result%has_error = .true.
          call mol%destroy()
          return
+      end if
+
+      if (guess_kind == SCF_GUESS_PROJ) then
+         if (.not. allocated(settings%guess_steps)) then
+            call result%error%set(ERROR_VALIDATION, "guess 'basis_set_projection' needs "// &
+                                  "keywords.guess.subscf.steps; the schema normally "// &
+                                  "refuses a deck without them, so this settings object "// &
+                                  "was built by something other than the JSON reader")
+            result%has_error = .true.
+            call mol%destroy()
+            return
+         end if
+         call climb_basis_ladder(settings%guess_steps, fragment%element_numbers, symbols, &
+                                 fragment%coordinates, fragment%nelec, mol, guess_total, &
+                                 guess_error, verbose=settings%verbose)
+         if (guess_error%has_error()) then
+            ! The same reasoning the atomic guess uses: a guess that cannot be
+            ! built is a reason to start somewhere else, not to fail the
+            ! calculation. Loud, because the run is now doing something other
+            ! than what the deck asked for.
+            call logger%warning("basis projection guess: "//guess_error%get_message()// &
+                                " -- falling back to sad")
+            guess_kind = SCF_GUESS_SAD
+            if (allocated(guess_total)) deallocate (guess_total)
+         end if
       end if
 
       if (guess_kind == SCF_GUESS_SAC .or. guess_kind == SCF_GUESS_SAD) then

--- a/backends/libcint/mqc_libcint_projection.f90
+++ b/backends/libcint/mqc_libcint_projection.f90
@@ -1,0 +1,284 @@
+!! A converged small-basis density, carried into a larger basis as a starting point
+module mqc_libcint_projection
+   !! Converge the cheap basis first, then start the expensive one from it.
+   !!
+   !! For a system that converges badly, the cost is rarely the iterations in the
+   !! target basis -- it is that a core or GWH guess is far enough from the answer
+   !! that the iteration wanders. An STO-3G calculation on the same geometry costs
+   !! almost nothing and lands close to the right density, and that density can be
+   !! carried across.
+   !!
+   !! **What is projected is the occupied orbitals, not the density.** The obvious
+   !! thing is
+   !!
+   !!     D_B = S_BB^-1 S_BA D_A S_AB S_BB^-1
+   !!
+   !! which is one expression and wrong in a way that matters: the result is not
+   !! idempotent and its trace against S is not the electron count, so the first
+   !! Fock matrix is built from something that is not a density. Projecting the
+   !! occupied orbitals and re-orthonormalising them gives a D that is idempotent
+   !! and has exactly the right trace by construction, which is worth the extra
+   !! eigendecomposition of an n_occ-square matrix.
+   !!
+   !!     C~ = S_BB^-1 S_BA C_A(occ)      project
+   !!     M  = C~^T S_BB C~               overlap of the projected orbitals
+   !!     C  = C~ M^-1/2                  re-orthonormalise
+   !!     D  = 2 C C^T
+   !!
+   !! **The cross-basis overlap needs both bases in one molecule.** libcint
+   !! computes integrals over shells of the molecule it is given, so S_BA -- rows
+   !! in the target basis, columns in the small one -- does not exist for either
+   !! molecule alone. `merge_basis_sets` builds a third whose shell list is the
+   !! target's followed by the small one's over the same atoms, and the wanted
+   !! block is the off-diagonal corner of its overlap. This is what PySCF's
+   !! `intor_cross` does and for the same reason.
+   use pic_types, only: dp
+   use pic_blas_interfaces, only: pic_gemm
+   use pic_lapack_interfaces, only: pic_syev
+   use pic_logger, only: logger => global_logger
+   use pic_io, only: to_char
+   use mqc_error, only: error_t, ERROR_VALIDATION
+   use mqc_libcint_integrals, only: libcint_molecule_t, shell_dim
+   use libcint_fortran, only: LIBCINT_BAS_SLOTS, LIBCINT_PTR_EXP, &
+                              LIBCINT_PTR_COEFF, LIBCINT_PTR_ENV_START
+   implicit none
+   private
+
+   public :: merge_basis_sets
+   public :: cross_overlap
+   public :: project_occupied
+
+   !> Overlap eigenvalues below this are dropped when inverting.
+   !>
+   !> The same cutoff `build_orthogonalizer` uses, and for the same reason: a
+   !> near-dependent target basis has directions the small basis cannot inform,
+   !> and amplifying them by dividing through a tiny eigenvalue produces a guess
+   !> worse than the one it replaces.
+   real(dp), parameter :: OVERLAP_FLOOR = 1.0e-7_dp
+
+contains
+
+   subroutine merge_basis_sets(mol_target, mol_small, merged, error)
+      !! One molecule carrying both shell lists, target first
+      !!
+      !! Only the shells are concatenated. Both molecules describe the same atoms
+      !! at the same coordinates, and `molecule_build` writes those into `env`
+      !! before any basis data at offsets that depend on the atom count alone --
+      !! so the target's `atm` already points at coordinates that are correct for
+      !! the merged molecule, and the small basis contributes exponents and
+      !! coefficients only.
+      type(libcint_molecule_t), intent(in) :: mol_target, mol_small
+      type(libcint_molecule_t), intent(out) :: merged
+      type(error_t), intent(inout) :: error
+
+      integer :: coord_end, tail, shift, ish, ns, nt
+
+      if (mol_target%natm /= mol_small%natm) then
+         call error%set(ERROR_VALIDATION, "basis projection: the two bases describe "// &
+                        "different numbers of atoms")
+         return
+      end if
+      if (maxval(abs(mol_target%coords - mol_small%coords)) > 1.0e-10_dp) then
+         call error%set(ERROR_VALIDATION, "basis projection: the two bases are on "// &
+                        "different geometries")
+         return
+      end if
+      ! One angular form for the whole merged molecule, because libcint chooses it
+      ! per call rather than per shell -- the same constraint `cartesian` carries
+      ! for a single molecule, which here means the two bases have to agree.
+      if (mol_target%cartesian .neqv. mol_small%cartesian) then
+         call error%set(ERROR_VALIDATION, "basis projection: one basis is Cartesian "// &
+                        "and the other spherical; a merged molecule can only be one "// &
+                        "or the other")
+         return
+      end if
+
+      nt = mol_target%nbas
+      ns = mol_small%nbas
+      coord_end = LIBCINT_PTR_ENV_START + 3*mol_target%natm
+      tail = size(mol_small%env) - coord_end          !! small basis data only
+      shift = size(mol_target%env) - coord_end        !! where it lands in `merged`
+
+      merged%natm = mol_target%natm
+      merged%nbas = nt + ns
+      merged%cartesian = mol_target%cartesian
+      merged%atm = mol_target%atm
+      merged%charges = mol_target%charges
+      merged%coords = mol_target%coords
+
+      allocate (merged%env(size(mol_target%env) + tail))
+      merged%env(1:size(mol_target%env)) = mol_target%env
+      merged%env(size(mol_target%env) + 1:) = mol_small%env(coord_end + 1:)
+
+      allocate (merged%bas(LIBCINT_BAS_SLOTS, merged%nbas))
+      merged%bas(:, 1:nt) = mol_target%bas
+      merged%bas(:, nt + 1:) = mol_small%bas
+      do ish = nt + 1, merged%nbas
+         merged%bas(LIBCINT_PTR_EXP, ish) = merged%bas(LIBCINT_PTR_EXP, ish) + shift
+         merged%bas(LIBCINT_PTR_COEFF, ish) = merged%bas(LIBCINT_PTR_COEFF, ish) + shift
+      end do
+
+      allocate (merged%shell_offset(merged%nbas + 1))
+      merged%shell_offset(1) = 0
+      do ish = 1, merged%nbas
+         merged%shell_offset(ish + 1) = merged%shell_offset(ish) + &
+                                        shell_dim(merged%cartesian, ish - 1, merged%bas)
+      end do
+      merged%nao = merged%shell_offset(merged%nbas + 1)
+
+      if (merged%nao /= mol_target%nao + mol_small%nao) then
+         call error%set(ERROR_VALIDATION, "basis projection: the merged molecule has "// &
+                        to_char(merged%nao)//" functions where the two bases have "// &
+                        to_char(mol_target%nao + mol_small%nao)//" between them")
+         return
+      end if
+   end subroutine merge_basis_sets
+
+   subroutine cross_overlap(mol_target, mol_small, s_target, s_cross, error)
+      !! S_BB and S_BA in one pass over the merged molecule
+      !!
+      !! Both come out of the same matrix, so they are returned together: the
+      !! projection needs each of them and computing the merged overlap twice to
+      !! hand them back separately would be the only cost of pretending they were
+      !! independent.
+      type(libcint_molecule_t), intent(in) :: mol_target, mol_small
+      real(dp), allocatable, intent(out) :: s_target(:, :)   !! (n_B, n_B)
+      real(dp), allocatable, intent(out) :: s_cross(:, :)    !! (n_B, n_A)
+      type(error_t), intent(inout) :: error
+
+      type(libcint_molecule_t) :: merged
+      real(dp), allocatable :: s_all(:, :)
+      integer :: nb, na
+
+      call merge_basis_sets(mol_target, mol_small, merged, error)
+      if (error%has_error()) return
+
+      call merged%overlap(s_all)
+      nb = mol_target%nao
+      na = mol_small%nao
+      s_target = s_all(1:nb, 1:nb)
+      s_cross = s_all(1:nb, nb + 1:nb + na)
+   end subroutine cross_overlap
+
+   subroutine project_occupied(mol_target, mol_small, coeff_small, n_occ, density, error)
+      !! A target-basis density from the small basis's occupied orbitals
+      !!
+      !! The result is idempotent against S_BB and its trace against S_BB is
+      !! exactly 2*n_occ, both by construction rather than by luck -- which is
+      !! what makes it usable as a density rather than merely density-shaped.
+      type(libcint_molecule_t), intent(in) :: mol_target, mol_small
+      real(dp), intent(in) :: coeff_small(:, :)   !! (n_A, n_mo_A), occupied first
+      integer, intent(in) :: n_occ
+      real(dp), allocatable, intent(out) :: density(:, :)
+      type(error_t), intent(inout) :: error
+
+      real(dp), allocatable :: s_target(:, :), s_cross(:, :)
+      real(dp), allocatable :: rhs(:, :), proj(:, :), m(:, :), work(:, :)
+      real(dp), allocatable :: vec(:, :), val(:), half(:, :)
+      integer :: nb, i, kept
+
+      if (n_occ < 1) then
+         call error%set(ERROR_VALIDATION, "basis projection: no occupied orbitals to project")
+         return
+      end if
+      if (size(coeff_small, 2) < n_occ) then
+         call error%set(ERROR_VALIDATION, "basis projection: fewer orbitals than occupied ones")
+         return
+      end if
+
+      call cross_overlap(mol_target, mol_small, s_target, s_cross, error)
+      if (error%has_error()) return
+      nb = mol_target%nao
+
+      ! S_BA C_A(occ)
+      allocate (rhs(nb, n_occ))
+      call pic_gemm(s_cross, coeff_small(:, 1:n_occ), rhs)
+
+      ! S_BB^-1 applied through its eigendecomposition rather than a solve, so the
+      ! near-null directions of a nearly dependent target basis can be dropped
+      ! instead of divided by.
+      call invert_overlap(s_target, work, kept, error)
+      if (error%has_error()) return
+      if (kept < n_occ) then
+         call error%set(ERROR_VALIDATION, "basis projection: the target basis keeps only "// &
+                        to_char(kept)//" independent directions, fewer than the "// &
+                        to_char(n_occ)//" occupied orbitals being projected")
+         return
+      end if
+      allocate (proj(nb, n_occ))
+      call pic_gemm(work, rhs, proj)
+
+      ! M = C~^T S_BB C~, the overlap the projected orbitals have among themselves.
+      ! It is the identity only if the projection happened to be exact.
+      allocate (m(n_occ, n_occ))
+      deallocate (rhs)
+      allocate (rhs(nb, n_occ))
+      call pic_gemm(s_target, proj, rhs)
+      call pic_gemm(proj, rhs, m, transa="T")
+
+      ! C = C~ M^-1/2, by eigendecomposition. M is small -- occupied square -- and
+      ! positive definite unless the projection collapsed two orbitals onto one,
+      ! which the floor below catches.
+      allocate (vec(n_occ, n_occ), val(n_occ))
+      vec = m
+      call pic_syev(vec, val, jobz="V", uplo="U")
+      if (minval(val) <= OVERLAP_FLOOR) then
+         call error%set(ERROR_VALIDATION, "basis projection: the projected orbitals are "// &
+                        "linearly dependent; the small basis cannot represent this "// &
+                        "occupied space")
+         return
+      end if
+      ! M^-1/2 = V d^-1/2 V^T, so exactly one of the two factors carries the
+      ! eigenvalue scaling. Scaling `vec` in place and then multiplying it by
+      ! itself would put d^-1/2 in twice and produce M^-1 -- which is wrong in a
+      ! way the self-projection check cannot see, because there M is the identity
+      ! and every power of it is the same matrix.
+      allocate (half(n_occ, n_occ))
+      do i = 1, n_occ
+         half(:, i) = vec(:, i)/sqrt(val(i))
+      end do
+      deallocate (m)
+      allocate (m(n_occ, n_occ))
+      call pic_gemm(half, vec, m, transb="T")    !! M^-1/2
+
+      deallocate (rhs)
+      allocate (rhs(nb, n_occ))
+      call pic_gemm(proj, m, rhs)                !! C = C~ M^-1/2
+
+      allocate (density(nb, nb))
+      call pic_gemm(rhs, rhs, density, transb="T")
+      density = 2.0_dp*density
+   end subroutine project_occupied
+
+   subroutine invert_overlap(overlap, inverse, kept, error)
+      !! S^-1 with near-null directions dropped rather than amplified
+      real(dp), intent(in) :: overlap(:, :)
+      real(dp), allocatable, intent(out) :: inverse(:, :)
+      integer, intent(out) :: kept
+      type(error_t), intent(inout) :: error
+
+      real(dp), allocatable :: vec(:, :), val(:), scaled(:, :)
+      integer :: n, i
+
+      n = size(overlap, 1)
+      allocate (vec(n, n), val(n), scaled(n, n), inverse(n, n))
+      vec = overlap
+      call pic_syev(vec, val, jobz="V", uplo="U")
+
+      kept = 0
+      scaled = 0.0_dp
+      do i = 1, n
+         if (val(i) > OVERLAP_FLOOR) then
+            kept = kept + 1
+            scaled(:, i) = vec(:, i)/val(i)
+         end if
+      end do
+      if (kept == 0) then
+         call error%set(ERROR_VALIDATION, "basis projection: the target overlap has no "// &
+                        "eigenvalue above the linear-dependence floor")
+         return
+      end if
+      call pic_gemm(scaled, vec, inverse, transb="T")
+   end subroutine invert_overlap
+
+end module mqc_libcint_projection

--- a/backends/libcint/mqc_libcint_projection.f90
+++ b/backends/libcint/mqc_libcint_projection.f90
@@ -38,7 +38,9 @@ module mqc_libcint_projection
    use pic_logger, only: logger => global_logger
    use pic_io, only: to_char
    use mqc_error, only: error_t, ERROR_VALIDATION
-   use mqc_libcint_integrals, only: libcint_molecule_t, shell_dim
+   use mqc_config_types, only: guess_step_t
+   use mqc_libcint_integrals, only: libcint_molecule_t, shell_dim, build_libcint_molecule
+   use mqc_libcint_rhf, only: rhf_result_t, run_libcint_rhf, SCF_GUESS_SAD, SCF_GUESS_GWH
    use libcint_fortran, only: LIBCINT_BAS_SLOTS, LIBCINT_PTR_EXP, &
                               LIBCINT_PTR_COEFF, LIBCINT_PTR_ENV_START
    implicit none
@@ -47,6 +49,7 @@ module mqc_libcint_projection
    public :: merge_basis_sets
    public :: cross_overlap
    public :: project_occupied
+   public :: climb_basis_ladder
 
    !> Overlap eigenvalues below this are dropped when inverting.
    !>
@@ -57,6 +60,96 @@ module mqc_libcint_projection
    real(dp), parameter :: OVERLAP_FLOOR = 1.0e-7_dp
 
 contains
+
+   subroutine climb_basis_ladder(steps, atomic_numbers, symbols, coords, nelec, &
+                                 mol_target, density, error, verbose)
+      !! Converge each basis in turn, projecting forward, and return a density
+      !! in the target basis
+      !!
+      !! Each rung starts from the previous rung's density rather than from a
+      !! core guess, so the ladder gets cheaper as it climbs even though the
+      !! bases get larger: the first SCF is the only one starting from nothing.
+      !!
+      !! The target basis is not a rung. `mol_target` is already built by the
+      !! caller and the last projection lands in it, so a two-step ladder plus a
+      !! model basis is three SCFs, the last of which is the caller's.
+      type(guess_step_t), intent(in) :: steps(:)
+      integer, intent(in) :: atomic_numbers(:)
+      character(len=*), intent(in) :: symbols(:)
+      real(dp), intent(in) :: coords(:, :)
+      integer, intent(in) :: nelec
+      type(libcint_molecule_t), intent(in) :: mol_target
+      real(dp), allocatable, intent(out) :: density(:, :)
+      type(error_t), intent(inout) :: error
+      logical, intent(in), optional :: verbose
+
+      type(libcint_molecule_t), allocatable :: rungs(:)
+      type(rhf_result_t) :: scf
+      real(dp), allocatable :: carried(:, :)
+      integer :: i, n, n_occ
+      logical :: talk
+
+      talk = .false.
+      if (present(verbose)) talk = verbose
+      n = size(steps)
+      n_occ = nelec/2
+
+      if (mod(nelec, 2) /= 0) then
+         call error%set(ERROR_VALIDATION, "basis projection guess: the ladder converges "// &
+                        "closed-shell SCFs and this fragment has an odd electron count")
+         return
+      end if
+
+      ! Every rung is built up front. The last one is needed after its SCF to
+      ! project into the next, and a molecule that has been destroyed cannot be
+      ! asked for its overlap.
+      allocate (rungs(n))
+      do i = 1, n
+         call build_libcint_molecule(atomic_numbers, symbols, coords, steps(i)%basis, &
+                                     rungs(i), error)
+         if (error%has_error()) then
+            call error%set(ERROR_VALIDATION, "basis projection guess: rung "//to_char(i)// &
+                           " ("//trim(steps(i)%basis)//"): "//error%get_message())
+            return
+         end if
+      end do
+
+      do i = 1, n
+         if (i == 1) then
+            ! GWH rather than SAD for the bottom rung: SAD needs a density handed
+            ! to it and there is none yet, and this basis is small enough that
+            ! the difference between the two starting points costs an iteration
+            ! rather than a minute.
+            call run_libcint_rhf(rungs(i), nelec, steps(i)%maxiter, steps(i)%tolerance, &
+                                 steps(i)%tolerance, .false., scf, error, &
+                                 guess=SCF_GUESS_GWH)
+         else
+            call run_libcint_rhf(rungs(i), nelec, steps(i)%maxiter, steps(i)%tolerance, &
+                                 steps(i)%tolerance, .false., scf, error, &
+                                 guess=SCF_GUESS_SAD, guess_density=carried)
+         end if
+         if (error%has_error()) return
+         ! A rung that does not converge is not fatal. It is a starting point for
+         ! the next one, and a half-converged density from a smaller basis is
+         ! still closer to the answer than a core guess -- which is the whole
+         ! reason for climbing. Reported, because a ladder that never converges
+         ! anywhere is worth knowing about.
+         if (talk) then
+            call logger%info("  guess rung "//to_char(i)//": "//trim(steps(i)%basis)// &
+                             ", "//to_char(rungs(i)%nao)//" functions, "// &
+                             to_char(scf%iterations)//" iterations"// &
+                             merge("                ", " (not converged)", scf%converged))
+         end if
+
+         if (i < n) then
+            if (allocated(carried)) deallocate (carried)
+            call project_occupied(rungs(i + 1), rungs(i), scf%orbitals, n_occ, carried, error)
+         else
+            call project_occupied(mol_target, rungs(i), scf%orbitals, n_occ, density, error)
+         end if
+         if (error%has_error()) return
+      end do
+   end subroutine climb_basis_ladder
 
    subroutine merge_basis_sets(mol_target, mol_small, merged, error)
       !! One molecule carrying both shell lists, target first

--- a/backends/libcint/mqc_libcint_rhf.f90
+++ b/backends/libcint/mqc_libcint_rhf.f90
@@ -55,6 +55,7 @@ module mqc_libcint_rhf
    integer, parameter, public :: SCF_GUESS_GWH = 1    !! Generalized Wolfsberg-Helmholz
    integer, parameter, public :: SCF_GUESS_SAC = 2    !! Superposed atomic coefficients
    integer, parameter, public :: SCF_GUESS_SAD = 3    !! Superposed atomic densities
+   integer, parameter, public :: SCF_GUESS_PROJ = 4   !! Projected from a smaller basis
 
    !> The empirical scale on the GWH off-diagonal. 1.75 is the usual value and
    !> the one cuEST uses; the two backends have to start from the same matrix or
@@ -415,7 +416,7 @@ contains
          fock = h
       case (SCF_GUESS_GWH)
          call guess_fock(s, h, fock)
-      case (SCF_GUESS_SAC, SCF_GUESS_SAD)
+      case (SCF_GUESS_SAC, SCF_GUESS_SAD, SCF_GUESS_PROJ)
          if (.not. present(guess_density)) then
             call error%set(ERROR_VALIDATION, "RHF: an atomic guess was asked for but no "// &
                            "guess density was supplied")
@@ -671,7 +672,7 @@ contains
       case (SCF_GUESS_GWH)
          call guess_fock(s, h, fock_a)
          fock_b = fock_a
-      case (SCF_GUESS_SAC, SCF_GUESS_SAD)
+      case (SCF_GUESS_SAC, SCF_GUESS_SAD, SCF_GUESS_PROJ)
          if (.not. (present(guess_density_alpha) .and. present(guess_density_beta))) then
             call error%set(ERROR_VALIDATION, "UHF: an atomic guess was asked for but no "// &
                            "guess densities were supplied")

--- a/src/fragmentation/common/mqc_many_body_expansion.f90
+++ b/src/fragmentation/common/mqc_many_body_expansion.f90
@@ -246,7 +246,8 @@ contains
           this%resources%mpi_comms%node_comm%leader()) then
          ! Global coordinator (rank 0, node leader on node 0)
          call omp_set_num_threads(omp_get_max_threads())
-         call logger%verbose("Rank 0: Acting as global coordinator")
+         call logger%verbose("Rank 0: global coordinator, "// &
+                             to_char(omp_get_max_threads())//" thread(s)")
          call global_coordinator(this, json_data)
       else if (this%resources%mpi_comms%node_comm%leader()) then
          ! Node coordinator (node leader on other nodes)
@@ -255,9 +256,7 @@ contains
          call node_coordinator(this)
       else
          ! Worker
-         call omp_set_num_threads(1)
-         call logger%verbose("Rank "//to_char(this%resources%mpi_comms%world_comm%rank())// &
-                             ": Acting as worker")
+         call set_worker_threads(this, "worker")
          call node_worker(this)
       end if
    end subroutine mbe_run_distributed
@@ -328,7 +327,8 @@ contains
           this%resources%mpi_comms%node_comm%leader()) then
          ! Global coordinator (rank 0, node leader on node 0)
          call omp_set_num_threads(omp_get_max_threads())
-         call logger%verbose("Rank 0: Acting as GMBE PIE coordinator")
+         call logger%verbose("Rank 0: GMBE PIE coordinator, "// &
+                             to_char(omp_get_max_threads())//" thread(s)")
          call gmbe_pie_coordinator(this%resources, this%pie_atom_sets, this%pie_coefficients, &
                                    this%n_pie_terms, this%node_leader_ranks, this%num_nodes, &
                                    this%group_leader_ranks, this%group_ids, this%global_groups, &
@@ -357,12 +357,41 @@ contains
          end block
       else
          ! Worker
-         call omp_set_num_threads(1)
-         call logger%verbose("Rank "//to_char(this%resources%mpi_comms%world_comm%rank())// &
-                             ": Acting as worker")
+         call set_worker_threads(this, "worker")
          ! Note: node_worker works for both MBE and GMBE (fragment_type distinguishes)
          call node_worker(this)
       end if
    end subroutine gmbe_run_distributed
+
+   subroutine set_worker_threads(this, role)
+      !! Give a worker rank its threads, and say what it got
+      !!
+      !! This used to be an unconditional `omp_set_num_threads(1)`, which made
+      !! "one fragment per rank, several threads per rank" impossible: the ranks
+      !! that run the chemistry were clamped to one thread whatever the launcher
+      !! asked for, so raising OMP_NUM_THREADS did nothing and the cause was
+      !! nowhere near the command line.
+      !!
+      !! The clamp exists for tblite, which corrupts a result when threaded
+      !! rather than failing, so it is kept for exactly that -- and the ranks
+      !! running anything else now use the threads they were given. A libcint
+      !! Fock build threads its own quartet loop, which is where they go.
+      !!
+      !! Every rank reports its role and thread count because the failure this
+      !! replaces was invisible: nothing in the output distinguished "four
+      !! threads, no speedup" from "one thread all along".
+      use omp_lib, only: omp_set_num_threads, omp_get_max_threads
+      use mqc_method_types, only: needs_serial_execution
+      use pic_logger, only: logger => global_logger
+      use pic_io, only: to_char
+      class(many_body_expansion_t), intent(inout) :: this
+      character(len=*), intent(in) :: role
+
+      if (needs_serial_execution(this%method_config%method_type)) then
+         call omp_set_num_threads(1)
+      end if
+      call logger%verbose("Rank "//to_char(this%resources%mpi_comms%world_comm%rank())// &
+                          ": "//role//", "//to_char(omp_get_max_threads())//" thread(s)")
+   end subroutine set_worker_threads
 
 end module mqc_many_body_expansion

--- a/src/io/mqc_config_adapter.f90
+++ b/src/io/mqc_config_adapter.f90
@@ -230,8 +230,17 @@ contains
       if (mqc_config%cc_triples_set) then
          driver_config%method_config%cc%include_triples = mqc_config%cc_triples
       end if
+      ! `guess_type` is the current spelling and `scf_guess` the superseded one.
+      ! The schema has already refused a deck that sets both, so whichever is
+      ! allocated is the one the user meant.
       if (allocated(mqc_config%scf_guess)) then
          driver_config%method_config%scf%guess = mqc_config%scf_guess
+      end if
+      if (allocated(mqc_config%guess_type)) then
+         driver_config%method_config%scf%guess = mqc_config%guess_type
+      end if
+      if (allocated(mqc_config%guess_steps)) then
+         driver_config%method_config%scf%guess_steps = mqc_config%guess_steps
       end if
 
       ! Output control

--- a/src/io/mqc_config_types.f90
+++ b/src/io/mqc_config_types.f90
@@ -36,6 +36,7 @@ module mqc_config_types
    public :: molecule_t         !! One molecule of a multi-molecule input
    public :: input_fragment_t   !! One fragment definition, as written in the input
    public :: bond_t             !! Re-exported so consumers need only this module
+   public :: guess_step_t       !! One rung of a basis-set-projection ladder
 
    type :: input_fragment_t
       !! Input fragment definition with charge, multiplicity, and atom indices

--- a/src/io/mqc_config_types.f90
+++ b/src/io/mqc_config_types.f90
@@ -88,6 +88,20 @@ module mqc_config_types
       procedure :: destroy => molecule_destroy
    end type molecule_t
 
+   type :: guess_step_t
+      !! One rung of a basis-set-projection ladder
+      !!
+      !! Each rung converges an SCF in its own basis and hands the result to the
+      !! next as a starting density. The convergence settings are per rung
+      !! because the rungs are not doing the same job: an early one only has to
+      !! land in the right basin and can stop loosely, where the last one before
+      !! the target may as well be tight since it is cheap relative to what
+      !! follows.
+      character(len=:), allocatable :: basis
+      integer :: maxiter = 50
+      real(dp) :: tolerance = 1.0e-5_dp
+   end type guess_step_t
+
    type :: mqc_config_t
       !! Complete configuration from .mqc file
 
@@ -103,7 +117,20 @@ module mqc_config_types
       character(len=:), allocatable :: aux_basis
       character(len=:), allocatable :: functional
       character(len=:), allocatable :: scf_guess
-         !! Initial guess name from %scf
+         !! Initial guess name from `keywords.scf.guess`.
+         !!
+         !! Superseded by `keywords.guess.type`. Still read so existing decks
+         !! keep working, and setting both is an error rather than a precedence
+         !! rule: two keys naming one thing is confusing enough without the
+         !! answer depending on which one the reader happened to reach first.
+      character(len=:), allocatable :: guess_type
+         !! Initial guess name from `keywords.guess.type`, the current spelling.
+      type(guess_step_t), allocatable :: guess_steps(:)
+         !! The projection ladder, from `keywords.guess.subscf.steps`.
+         !!
+         !! One entry per preliminary SCF, in order. The target basis is
+         !! `model.basis` and is not repeated here, so three SCFs -- STO-3G, then
+         !! 6-31G, then cc-pVTZ -- is two steps and a model basis.
       logical :: scf_unrestricted = .false.
       logical :: allow_crap_scf = .false.
       logical :: scf_density_fitting = .false.

--- a/src/io/mqc_json_config_reader.f90
+++ b/src/io/mqc_json_config_reader.f90
@@ -33,6 +33,7 @@ module mqc_json_config_reader
    !! document before any of this. That separation is why the accessors below
    !! can stay as simple as they are: by the time they run, the deck is known
    !! to contain only keys this module knows about.
+   use pic_io, only: to_char
    use pic_types, only: dp
    use mqc_program_limits, only: MAX_ELEMENT_SYMBOL_LEN, MAX_MBE_LEVEL
    use mqc_geometry, only: geometry_type
@@ -194,6 +195,9 @@ contains
       call optional_real(json, "keywords.scf.tolerance", config%scf_tolerance)
       call optional_logical(json, "keywords.scf.unrestricted", config%scf_unrestricted)
       call optional_string(json, "keywords.scf.guess", config%scf_guess)
+      call optional_string(json, "keywords.guess.type", config%guess_type)
+      call read_guess_steps(json, config, error)
+      if (error%has_error()) return
       call optional_logical(json, "keywords.scf.allow_crap_scf", config%allow_crap_scf)
       call optional_logical(json, "keywords.scf.density_fitting", &
                             config%scf_density_fitting)
@@ -458,6 +462,41 @@ contains
          name = ""
       end select
    end function nmer_name
+
+   subroutine read_guess_steps(json, config, error)
+      !! The basis-set-projection ladder, one entry per preliminary SCF
+      !!
+      !! Order is the order written: the first step is the cheapest basis and the
+      !! last hands its density to the target one from `model.basis`, which is not
+      !! listed here. Three SCFs -- STO-3G, 6-31G, cc-pVTZ -- is two steps.
+      !!
+      !! The schema has already refused a `subscf` that does not belong to a
+      !! projection guess and a projection guess with no steps, so this only has
+      !! to read what is there.
+      type(json_file), intent(inout) :: json
+      type(mqc_config_t), intent(inout) :: config
+      type(error_t), intent(inout) :: error
+
+      character(len=:), allocatable :: prefix
+      integer :: n_steps, i
+      logical :: found
+
+      call json%info("keywords.guess.subscf.steps", found=found, n_children=n_steps)
+      if (.not. found .or. n_steps < 1) return
+
+      allocate (config%guess_steps(n_steps))
+      do i = 1, n_steps
+         prefix = "keywords.guess.subscf.steps("//trim(to_char(i))//")"
+         call optional_string(json, prefix//".basis", config%guess_steps(i)%basis)
+         if (.not. allocated(config%guess_steps(i)%basis)) then
+            call error%set(ERROR_VALIDATION, "guess step "//trim(to_char(i))// &
+                           " has no basis")
+            return
+         end if
+         call optional_int(json, prefix//".maxiter", config%guess_steps(i)%maxiter)
+         call optional_real(json, prefix//".tolerance", config%guess_steps(i)%tolerance)
+      end do
+   end subroutine read_guess_steps
 
    subroutine read_molecule(json, prefix, base_dir, charge, multiplicity, geom, &
                             nfrag, fragments, uniform, nbonds, nbroken, bonds, error)

--- a/src/io/mqc_json_schema.f90
+++ b/src/io/mqc_json_schema.f90
@@ -101,6 +101,10 @@ contains
       if (error%has_error()) return
       call check_grandchild_object(core, root, "keywords", "pcm", pcm_keys(), error)
       if (error%has_error()) return
+      call check_grandchild_object(core, root, "keywords", "guess", guess_keys(), error)
+      if (error%has_error()) return
+      call validate_guess_group(core, root, error)
+      if (error%has_error()) return
       call check_grandchild_object(core, root, "keywords", "cc", cc_keys(), error)
       if (error%has_error()) return
       call check_grandchild_object(core, root, "keywords", "hessian", hessian_keys(), error)
@@ -194,7 +198,30 @@ contains
       call allow(keys, "cc")
       call allow(keys, "dft")
       call allow(keys, "pcm")
+      call allow(keys, "guess")
    end function keywords_keys
+
+   function guess_keys() result(keys)
+      type(key_set_t) :: keys
+      call allow(keys, "type")
+      call allow(keys, "subscf")
+   end function guess_keys
+
+   function subscf_keys() result(keys)
+      !! Only meaningful under `type: basis_set_projection`, which
+      !! `validate_guess_group` enforces -- a `subscf` block beside any other
+      !! guess would be read, validated and then silently ignored.
+      type(key_set_t) :: keys
+      call allow(keys, "steps")
+   end function subscf_keys
+
+   function guess_step_keys() result(keys)
+      type(key_set_t) :: keys
+      call allow(keys, "basis")
+      call allow(keys, "maxiter")
+      call allow(keys, "tolerance")
+      call require(keys, "basis")
+   end function guess_step_keys
 
    function scf_keys() result(keys)
       type(key_set_t) :: keys
@@ -431,6 +458,88 @@ contains
       if (.not. found .or. .not. associated(child)) return
       call check_object(core, child, parent_name//"."//name, keys, error)
    end subroutine check_grandchild_object
+
+   subroutine validate_guess_group(core, root, error)
+      !! The three rules that make `keywords.guess` unambiguous
+      !!
+      !!   1. `keywords.scf.guess` and `keywords.guess.type` must not both be
+      !!      set. The second supersedes the first; refusing both rather than
+      !!      picking one keeps the deck's meaning independent of reader order.
+      !!   2. `subscf` is only meaningful under `basis_set_projection`. Beside
+      !!      any other guess it would be read, validated and then ignored, which
+      !!      is the failure mode this whole schema exists to prevent.
+      !!   3. `basis_set_projection` needs at least one step. A ladder with no
+      !!      rungs is the default guess wearing a longer name.
+      type(json_core), intent(inout) :: core
+      type(json_value), pointer, intent(in) :: root
+      type(error_t), intent(inout) :: error
+
+      type(json_value), pointer :: keywords, guess, scf, subscf, steps, step
+      character(len=:), allocatable :: gtype
+      logical :: found, has_scf_guess, is_projection
+      integer :: n_steps, i
+
+      call core%get(root, "keywords", keywords, found)
+      if (.not. found .or. .not. associated(keywords)) return
+      call core%get(keywords, "guess", guess, found)
+      if (.not. found .or. .not. associated(guess)) return
+
+      has_scf_guess = .false.
+      call core%get(keywords, "scf", scf, found)
+      if (found .and. associated(scf)) then
+         call core%get(scf, "guess", steps, has_scf_guess)
+      end if
+
+      call core%get(guess, "type", steps, found)
+      if (found .and. associated(steps)) then
+         call core%get(guess, "type", gtype)
+      end if
+
+      if (has_scf_guess .and. allocated(gtype)) then
+         call error%set(ERROR_VALIDATION, "keywords.scf.guess and keywords.guess.type "// &
+                        "both set the initial guess. Use keywords.guess.type; "// &
+                        "keywords.scf.guess is the older spelling and is superseded.")
+         return
+      end if
+
+      is_projection = .false.
+      if (allocated(gtype)) is_projection = trim(adjustl(gtype)) == "basis_set_projection"
+
+      call core%get(guess, "subscf", subscf, found)
+      if (found .and. associated(subscf)) then
+         if (.not. is_projection) then
+            call error%set(ERROR_VALIDATION, "keywords.guess.subscf only means something "// &
+                           "for type 'basis_set_projection'; beside any other guess it "// &
+                           "would be read and then ignored")
+            return
+         end if
+         call check_object(core, subscf, "keywords.guess.subscf", subscf_keys(), error)
+         if (error%has_error()) return
+         call core%get(subscf, "steps", steps, found)
+         if (found .and. associated(steps)) then
+            call core%info(steps, n_children=n_steps)
+            do i = 1, n_steps
+               call core%get_child(steps, i, step, found)
+               if (.not. found .or. .not. associated(step)) cycle
+               call check_object(core, step, "keywords.guess.subscf.steps", &
+                                 guess_step_keys(), error)
+               if (error%has_error()) return
+            end do
+         end if
+      end if
+
+      if (is_projection) then
+         n_steps = 0
+         call core%get(guess, "subscf.steps", steps, found)
+         if (found .and. associated(steps)) call core%info(steps, n_children=n_steps)
+         if (n_steps < 1) then
+            call error%set(ERROR_VALIDATION, "guess type 'basis_set_projection' needs "// &
+                           "keywords.guess.subscf.steps with at least one basis to "// &
+                           "converge before the target one")
+            return
+         end if
+      end if
+   end subroutine validate_guess_group
 
    subroutine check_cutoffs(core, root, error)
       !! Cutoff keys are n-mer names or decimal levels, so they get their own rule

--- a/src/methods/mqc_cuest_iface.f90
+++ b/src/methods/mqc_cuest_iface.f90
@@ -11,6 +11,7 @@ module mqc_cuest_iface
    !! which has a stub form fpm compiles and a real form CMake compiles -- lets
    !! the method files carry no preprocessor conditionals at all.
    use pic_types, only: dp
+   use mqc_config_types, only: guess_step_t
    use mqc_method_config, only: pcm_config_t
    implicit none
    private
@@ -73,8 +74,18 @@ module mqc_cuest_iface
          !! Pure (spherical) vs Cartesian angular functions
       logical :: verbose = .false.
          !! Print the SCF iteration table
-      character(len=16) :: guess = "auto"
-         !! Initial guess: 'core', 'gwh', 'sac', 'sad', or 'auto'
+      character(len=32) :: guess = "auto"
+         !! Initial guess: 'core', 'gwh', 'sac', 'sad', 'basis_set_projection',
+         !! or 'auto'
+      type(guess_step_t), allocatable :: guess_steps(:)
+         !! The basis ladder for 'basis_set_projection', one entry per
+         !! preliminary SCF in order. The target basis is `basis_set` and is not
+         !! repeated, so STO-3G then 6-31G then cc-pVTZ is two steps.
+         !!
+         !! Carried on the shared settings type because that is where every
+         !! other SCF setting lives, but only the libcint backend acts on it --
+         !! the projection is built from `libcint_molecule_t` and the cuEST path
+         !! refuses the guess rather than silently running a different one.
          !!
          !! 'auto' means the backend picks, because the best starting point
          !! is a property of the backend rather than of the request: the CPU

--- a/src/methods/mqc_method_config.f90
+++ b/src/methods/mqc_method_config.f90
@@ -4,6 +4,7 @@ module mqc_method_config
    !! Uses composition pattern: method_config_t contains nested config types
    !! for each method family. The factory reads from the appropriate nested type.
    use pic_types, only: int32, dp
+   use mqc_config_types, only: guess_step_t
    use mqc_method_types, only: METHOD_TYPE_UNKNOWN
    implicit none
    private
@@ -28,13 +29,18 @@ module mqc_method_config
          !! Use DIIS acceleration
       integer :: diis_size = 8
          !! Number of Fock matrices for DIIS
-      character(len=16) :: guess = "auto"
-         !! Initial guess: 'core', 'gwh', 'sac', 'sad', or 'auto'
+      character(len=32) :: guess = "auto"
+         !! Initial guess: 'core', 'gwh', 'sac', 'sad', 'basis_set_projection',
+         !! or 'auto'
          !!
          !! 'auto' means the backend picks, because the best starting point
          !! is a property of the backend rather than of the request: the CPU
          !! path resolves it to 'sad', and cuEST to 'gwh', each having
          !! measured its own. An explicit spelling always wins over both.
+      type(guess_step_t), allocatable :: guess_steps(:)
+         !! The basis ladder for 'basis_set_projection', one entry per
+         !! preliminary SCF in order. The target basis is the model's and is not
+         !! repeated here.
       logical :: allow_crap_scf = .false.
          !! Accept a non-converged SCF rather than stopping. See mqc_config_types.
       logical :: unrestricted = .false.

--- a/src/methods/mqc_method_dft.F90
+++ b/src/methods/mqc_method_dft.F90
@@ -15,6 +15,7 @@ module mqc_method_dft
    !! it is queried from cuEST's XC plan and handed to the DF plan, so a hybrid
    !! cannot end up with mismatched Coulomb and XC definitions.
    use pic_types, only: dp
+   use mqc_config_types, only: guess_step_t
    use mqc_method_config, only: pcm_config_t
    use mqc_method_base, only: qc_method_t
    use mqc_result_types, only: calculation_result_t
@@ -50,8 +51,12 @@ module mqc_method_dft
          !! Node-local MPI rank, for spreading ranks across a node's GPUs
       logical :: unrestricted = .false.
          !! Force UHF/UKS even for a closed shell
-      character(len=16) :: guess = "auto"
-         !! Initial guess: 'core', 'gwh', 'sac', 'sad', or 'auto'
+      character(len=32) :: guess = "auto"
+         !! Initial guess: 'core', 'gwh', 'sac', 'sad', 'basis_set_projection',
+         !! or 'auto'
+      type(guess_step_t), allocatable :: guess_steps(:)
+         !! The basis ladder for 'basis_set_projection', one entry per
+         !! preliminary SCF in order.
          !!
          !! 'auto' means the backend picks, because the best starting point
          !! is a property of the backend rather than of the request: the CPU
@@ -153,6 +158,7 @@ contains
       end if
       settings%unrestricted = this%options%unrestricted
       settings%guess = this%options%guess
+      if (allocated(this%options%guess_steps)) settings%guess_steps = this%options%guess_steps
       settings%max_iter = this%options%max_iter
       settings%energy_tol = this%options%energy_tol
       settings%density_tol = this%options%density_tol

--- a/src/methods/mqc_method_factory.F90
+++ b/src/methods/mqc_method_factory.F90
@@ -197,6 +197,7 @@ contains
       m%options%density_fitting = config%scf%density_fitting
       m%options%unrestricted = config%scf%unrestricted
       m%options%guess = config%scf%guess
+      if (allocated(config%scf%guess_steps)) m%options%guess_steps = config%scf%guess_steps
       m%options%max_iter = config%scf%max_iter
       m%options%allow_crap_scf = config%scf%allow_crap_scf
       m%options%conv_tol = config%scf%energy_convergence
@@ -219,6 +220,7 @@ contains
       ! SCF settings from shared config%scf
       m%options%unrestricted = config%scf%unrestricted
       m%options%guess = config%scf%guess
+      if (allocated(config%scf%guess_steps)) m%options%guess_steps = config%scf%guess_steps
       m%options%max_iter = config%scf%max_iter
       m%options%energy_tol = config%scf%energy_convergence
       m%options%density_tol = config%scf%density_convergence

--- a/src/methods/mqc_method_hf.F90
+++ b/src/methods/mqc_method_hf.F90
@@ -11,6 +11,7 @@ module mqc_method_hf
    !! placeholder number -- a silently wrong energy inside a many-body
    !! expansion is far worse than a failed fragment.
    use pic_types, only: dp
+   use mqc_config_types, only: guess_step_t
    use mqc_method_base, only: qc_method_t
    use mqc_result_types, only: calculation_result_t
    use mqc_physical_fragment, only: physical_fragment_t
@@ -58,8 +59,12 @@ module mqc_method_hf
          !! Node-local MPI rank, for spreading ranks across a node's GPUs
       logical :: unrestricted = .false.
          !! Force UHF/UKS even for a closed shell
-      character(len=16) :: guess = "auto"
-         !! Initial guess: 'core', 'gwh', 'sac', 'sad', or 'auto'
+      character(len=32) :: guess = "auto"
+         !! Initial guess: 'core', 'gwh', 'sac', 'sad', 'basis_set_projection',
+         !! or 'auto'
+      type(guess_step_t), allocatable :: guess_steps(:)
+         !! The basis ladder for 'basis_set_projection', one entry per
+         !! preliminary SCF in order.
          !!
          !! 'auto' means the backend picks, because the best starting point
          !! is a property of the backend rather than of the request: the CPU
@@ -140,6 +145,7 @@ contains
       end if
       settings%unrestricted = this%options%unrestricted
       settings%guess = this%options%guess
+      if (allocated(this%options%guess_steps)) settings%guess_steps = this%options%guess_steps
       settings%max_iter = this%options%max_iter
       settings%allow_crap_scf = this%options%allow_crap_scf
       settings%energy_tol = this%options%conv_tol

--- a/src/mqc_driver.f90
+++ b/src/mqc_driver.f90
@@ -8,6 +8,7 @@ module mqc_driver
    use pic_logger, only: logger => global_logger
    use pic_io, only: to_char
    use omp_lib, only: omp_get_max_threads, omp_set_num_threads
+   use mqc_method_types, only: needs_serial_execution
    use mqc_mbe_fragment_distribution_scheme, only: unfragmented_calculation, distributed_unfragmented_hessian
    use mqc_many_body_expansion, only: many_body_expansion_t, mbe_context_t, gmbe_context_t
    use mqc_method_config, only: method_config_t
@@ -41,23 +42,6 @@ module mqc_driver
    public :: run_multi_molecule_calculations  !! Multi-molecule calculation dispatcher
 
 contains
-
-   pure function needs_serial_execution(method_type) result(serial)
-      !! Whether this method has to be run on one thread
-      !!
-      !! An allow-list of the safe ones would be the tempting shape and the
-      !! wrong one: a method added later would default to "safe" and inherit a
-      !! silent data race. Naming the unsafe ones means a new method is clamped
-      !! until someone looks at it, which is the failure that costs an hour
-      !! rather than a week.
-      use mqc_method_types, only: METHOD_TYPE_GFN1, METHOD_TYPE_GFN2
-      integer, intent(in) :: method_type
-      logical :: serial
-
-      ! tblite. Threaded it corrupts a result rather than stopping, which is
-      ! why this is not merely a performance choice.
-      serial = (method_type == METHOD_TYPE_GFN1 .or. method_type == METHOD_TYPE_GFN2)
-   end function needs_serial_execution
 
    subroutine run_calculation(resources, config, sys_geom, bonds, result_out, all_ranks_write_json, &
                               supplied_terms, n_supplied_terms, write_output)

--- a/src/mqc_method_types.f90
+++ b/src/mqc_method_types.f90
@@ -7,6 +7,7 @@ module mqc_method_types
    implicit none
    private
 
+   public :: needs_serial_execution
    ! Public constants - Semi-empirical
    public :: METHOD_TYPE_GFN1, METHOD_TYPE_GFN2
    ! Public constants - SCF methods
@@ -57,6 +58,27 @@ module mqc_method_types
    integer(int32), parameter :: METHOD_TYPE_CCSD_T_F12 = 43  !! CCSD(T)-F12
 
 contains
+
+   pure function needs_serial_execution(method_type) result(serial)
+      !! Whether this method has to be run on one thread
+      !!
+      !! An allow-list of the safe ones would be the tempting shape and the
+      !! wrong one: a method added later would default to "safe" and inherit a
+      !! silent data race. Naming the unsafe ones means a new method is clamped
+      !! until someone looks at it, which is the failure that costs an hour
+      !! rather than a week.
+      !!
+      !! Lives here rather than in the driver because two places need it and one
+      !! of them -- the fragment workers -- is used *by* the driver, so it cannot
+      !! reach back. It used to be in the driver alone, and the worker path
+      !! clamped everything instead of asking.
+      integer, intent(in) :: method_type
+      logical :: serial
+
+      ! tblite. Threaded it corrupts a result rather than stopping, which is
+      ! why this is not merely a performance choice.
+      serial = (method_type == METHOD_TYPE_GFN1 .or. method_type == METHOD_TYPE_GFN2)
+   end function needs_serial_execution
 
    pure function method_type_from_string(method_str) result(method_type)
       !! Convert method type string to integer constant

--- a/validation/check_projection.f90
+++ b/validation/check_projection.f90
@@ -1,0 +1,164 @@
+program check_projection
+   !! Check the basis-set projection guess against what it has to be
+   !!
+   !! Three properties, and they are checkable without a reference implementation
+   !! because each is exact by construction rather than approximately right:
+   !!
+   !!   1. **Trace.** `Tr[D S_BB]` is the electron count. This is what the naive
+   !!      density projection gets wrong and is the reason the orbitals are
+   !!      projected instead.
+   !!   2. **Idempotency.** `D S D = 2 D` for a closed shell with `D = 2 C C^T`
+   !!      and `C^T S C = I`. A density that fails this is not a density.
+   !!   3. **Identity.** Projecting a basis onto *itself* must return the density
+   !!      it started from. This is the one that catches a wrong cross-overlap
+   !!      block, a mis-shifted `env` pointer or a transposed projection, none of
+   !!      which the first two would notice.
+   !!
+   !! Then the point of the exercise: does starting from the projected density
+   !! take fewer iterations than the default guess.
+   use pic_types, only: dp
+   use pic_blas_interfaces, only: pic_gemm
+   use pic_logger, only: logger => global_logger, info_level
+   use mqc_error, only: error_t
+   use mqc_libcint_integrals, only: libcint_molecule_t, build_libcint_molecule
+   use mqc_libcint_projection, only: project_occupied, cross_overlap
+   use mqc_libcint_rhf, only: rhf_result_t, run_libcint_rhf, SCF_GUESS_CORE, SCF_GUESS_SAD
+   implicit none
+
+   integer, parameter :: N_DIM = 3
+   integer :: n_bad
+
+   n_bad = 0
+   call logger%configure(info_level)
+
+   ! Water, which converges easily -- this case is about the projection being
+   ! right, not about it being needed.
+   call run_case("water", [character(len=2) :: "O", "H", "H"], &
+                 reshape([0.0_dp, 0.0_dp, 0.0_dp, &
+                          0.0_dp, -1.4308_dp, 1.1078_dp, &
+                          0.0_dp, 1.4308_dp, 1.1078_dp], [N_DIM, 3]), &
+                 [8, 1, 1], 10, "sto-3g", "6-31g", n_bad)
+
+   ! Two heavy atoms and a longer basis, so the cross-overlap has off-diagonal
+   ! structure a single atom would not exercise.
+   call run_case("ethene", [character(len=2) :: "C", "C", "H", "H", "H", "H"], &
+                 reshape([0.0_dp, 0.0_dp, 1.2637_dp, &
+                          0.0_dp, 0.0_dp, -1.2637_dp, &
+                          0.0_dp, 1.7554_dp, 2.3286_dp, &
+                          0.0_dp, -1.7554_dp, 2.3286_dp, &
+                          0.0_dp, 1.7554_dp, -2.3286_dp, &
+                          0.0_dp, -1.7554_dp, -2.3286_dp], [N_DIM, 6]), &
+                 [6, 6, 1, 1, 1, 1], 16, "sto-3g", "6-31g", n_bad)
+
+   if (n_bad == 0) then
+      write (*, "(a)") ""
+      write (*, "(a)") "projection guess is idempotent, normalised, and exact onto itself"
+   else
+      write (*, "(a,i0,a)") "", n_bad, " check(s) failed"
+      stop 1
+   end if
+
+contains
+
+   subroutine run_case(label, symbols, coords, charges, nelec, small, target_basis, n_bad)
+      character(len=*), intent(in) :: label, small, target_basis
+      character(len=2), intent(in) :: symbols(:)
+      real(dp), intent(in) :: coords(:, :)
+      integer, intent(in) :: charges(:)
+      integer, intent(in) :: nelec
+      integer, intent(inout) :: n_bad
+
+      type(libcint_molecule_t) :: mol_s, mol_t
+      type(rhf_result_t) :: scf_s, scf_t_proj, scf_t_core
+      type(error_t) :: error
+      real(dp), allocatable :: d_proj(:, :), s_t(:, :), s_x(:, :), d_self(:, :)
+      real(dp), allocatable :: ds(:, :), dsd(:, :)
+      real(dp) :: trace, worst_idem, worst_self
+      integer :: n_occ, i
+
+      n_occ = nelec/2
+      write (*, "(a)") ""
+      write (*, "(a,a,a,a,a,a)") "== ", label, ": ", small, " -> ", target_basis
+
+      call build_libcint_molecule(charges, symbols, coords, small, mol_s, error)
+      if (failed(error, "small molecule", n_bad)) return
+      call build_libcint_molecule(charges, symbols, coords, target_basis, mol_t, error)
+      if (failed(error, "target molecule", n_bad)) return
+
+      call run_libcint_rhf(mol_s, nelec, 100, 1.0e-9_dp, 1.0e-7_dp, .false., scf_s, error, &
+                           guess=SCF_GUESS_CORE)
+      if (failed(error, "small-basis SCF", n_bad)) return
+      write (*, "(a,i0,a,i0,a,f18.10)") "  ", mol_s%nao, " -> ", mol_t%nao, &
+         " functions,  small-basis E = ", scf_s%energy
+
+      ! ---- 3. identity: the same basis both sides must reproduce its density ----
+      call project_occupied(mol_s, mol_s, scf_s%orbitals, n_occ, d_self, error)
+      if (failed(error, "self-projection", n_bad)) return
+      worst_self = maxval(abs(d_self - scf_s%density))
+      call report("self-projection reproduces its own density", worst_self, 1.0e-10_dp, n_bad)
+
+      ! ---- the projection under test ----
+      call project_occupied(mol_t, mol_s, scf_s%orbitals, n_occ, d_proj, error)
+      if (failed(error, "projection", n_bad)) return
+      call cross_overlap(mol_t, mol_s, s_t, s_x, error)
+      if (failed(error, "cross overlap", n_bad)) return
+
+      ! ---- 1. trace ----
+      allocate (ds(mol_t%nao, mol_t%nao))
+      call pic_gemm(d_proj, s_t, ds)
+      trace = 0.0_dp
+      do i = 1, mol_t%nao
+         trace = trace + ds(i, i)
+      end do
+      call report("Tr[D S] is the electron count", abs(trace - real(nelec, dp)), &
+                  1.0e-10_dp, n_bad)
+
+      ! ---- 2. idempotency: D S D = 2 D ----
+      allocate (dsd(mol_t%nao, mol_t%nao))
+      call pic_gemm(ds, d_proj, dsd)
+      worst_idem = maxval(abs(dsd - 2.0_dp*d_proj))
+      call report("D S D = 2 D", worst_idem, 1.0e-10_dp, n_bad)
+
+      ! ---- what it is for ----
+      call run_libcint_rhf(mol_t, nelec, 100, 1.0e-9_dp, 1.0e-7_dp, .false., scf_t_core, &
+                           error, guess=SCF_GUESS_CORE)
+      if (failed(error, "target SCF from core", n_bad)) return
+      call run_libcint_rhf(mol_t, nelec, 100, 1.0e-9_dp, 1.0e-7_dp, .false., scf_t_proj, &
+                           error, guess=SCF_GUESS_SAD, guess_density=d_proj)
+      if (failed(error, "target SCF from projection", n_bad)) return
+
+      write (*, "(a,i0,a,f18.10)") "  from core guess:        ", scf_t_core%iterations, &
+         " iterations, E = ", scf_t_core%energy
+      write (*, "(a,i0,a,f18.10)") "  from projected density: ", scf_t_proj%iterations, &
+         " iterations, E = ", scf_t_proj%energy
+      call report("both starting points reach the same energy", &
+                  abs(scf_t_core%energy - scf_t_proj%energy), 1.0e-8_dp, n_bad)
+   end subroutine run_case
+
+   function failed(error, what, n_bad) result(bad)
+      type(error_t), intent(inout) :: error
+      character(len=*), intent(in) :: what
+      integer, intent(inout) :: n_bad
+      logical :: bad
+
+      bad = error%has_error()
+      if (bad) then
+         write (*, "(a,a,a,a)") "  FAIL ", what, ": ", error%get_message()
+         n_bad = n_bad + 1
+      end if
+   end function failed
+
+   subroutine report(what, deviation, tol, n_bad)
+      character(len=*), intent(in) :: what
+      real(dp), intent(in) :: deviation, tol
+      integer, intent(inout) :: n_bad
+
+      if (deviation <= tol) then
+         write (*, "(a,a,a,es10.3)") "  ok   ", what, "   ", deviation
+      else
+         write (*, "(a,a,a,es10.3,a,es10.3)") "  FAIL ", what, "   ", deviation, " > ", tol
+         n_bad = n_bad + 1
+      end if
+   end subroutine report
+
+end program check_projection


### PR DESCRIPTION
A converged density in a small basis is a far better starting point for a large
basis than any of the usual atomic guesses. This projects one into the other and
exposes it as a ladder, so a cc-pVQZ calculation can start from a converged
cc-pVDZ density instead of from superposed atoms.

The guess gains its own keyword group rather than more flags on `scf`, since a
ladder needs to name the bases it climbs. The ladder runs on the CPU path only;
the last commit lets a fragment worker use the threads it was given, which
otherwise limits what the ladder buys on fragmented runs.

Commits:
- `carry a converged small-basis density into a larger basis as a guess`
- `give the initial guess its own keyword group, with a ladder of bases`
- `run the basis ladder, on the CPU path only`
- `let a fragment worker use the threads it was given`

---

**Stack 1 of 2 — SCF / integral performance.** Last of four.

1. #173 `feat/cpu-integral-perf` → `main`
2. #174 `feat/density-weighted-screening` → `feat/cpu-integral-perf`
3. #175 `feat/incremental-fock` → `feat/density-weighted-screening`
4. **this PR** `feat/basis-projection-guess` → `feat/incremental-fock`

Please merge in order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)