### PR TITLE
Density-fitted RHF gradients

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -486,6 +486,12 @@ if(MQC_ENABLE_LIBCINT)
   # against translational invariance. Not a ctest case: it converges an SCF per
   # displaced coordinate, which is seconds rather than the milliseconds the unit
   # suite is meant to take.
+  add_executable(check_df_deriv
+                 ${PROJECT_SOURCE_DIR}/validation/check_df_deriv.f90)
+  target_include_directories(check_df_deriv
+                             PRIVATE "${CMAKE_BINARY_DIR}/modules")
+  target_link_libraries(check_df_deriv PRIVATE ${main_lib} cint_fortran cint)
+
   add_executable(check_scf_gradient
                  ${PROJECT_SOURCE_DIR}/validation/check_scf_gradient.f90)
   target_include_directories(check_scf_gradient

--- a/backends/libcint/mqc_libcint_gradient.f90
+++ b/backends/libcint/mqc_libcint_gradient.f90
@@ -28,12 +28,18 @@ module mqc_libcint_gradient
    !! checking, and is checked in the tests.
    use pic_types, only: dp
    use mqc_error, only: error_t, ERROR_VALIDATION
-   use mqc_libcint_integrals, only: libcint_molecule_t, shell_dim, atom_ao_blocks
+   use mqc_libcint_integrals, only: libcint_molecule_t, shell_dim, atom_ao_blocks, &
+                                    build_df_shell_table, three_centre, two_centre, &
+                                    metric_inverse_sqrt
+   use pic_blas_interfaces, only: pic_gemm
    use libcint_fortran, only: libcint_1e_ipovlp_sph, libcint_1e_ipovlp_cart, &
                               libcint_1e_ipkin_sph, libcint_1e_ipkin_cart, &
                               libcint_1e_ipnuc_sph, libcint_1e_ipnuc_cart, &
                               libcint_1e_iprinv_sph, libcint_1e_iprinv_cart, &
                               libcint_2e_ip1_sph, libcint_2e_ip1_cart, &
+                              libcint_3c2e_ip1_sph, libcint_3c2e_ip1_cart, &
+                              libcint_3c2e_ip2_sph, libcint_3c2e_ip2_cart, &
+                              libcint_2c2e_ip1_sph, libcint_2c2e_ip1_cart, &
                               libcint_2e_ip1_sph_optimizer, libcint_2e_ip1_cart_optimizer, &
                               libcint_del_optimizer, LIBCINT_PTR_RINV_ORIG
    use, intrinsic :: iso_c_binding, only: c_ptr, c_null_ptr
@@ -42,6 +48,8 @@ module mqc_libcint_gradient
 
    public :: libcint_scf_gradient
    public :: nuclear_repulsion_gradient   !! Exposed for the tests
+   public :: three_centre_deriv           !! Exposed for the tests
+   public :: two_centre_deriv             !! Exposed for the tests
 
    ! Which one-electron derivative `one_electron_deriv` should build.
    integer, parameter :: DERIV_OVLP = 1
@@ -52,7 +60,7 @@ contains
 
    subroutine libcint_scf_gradient(mol, density, density_beta, orbitals, orbitals_beta, &
                                    orbital_energies, orbital_energies_beta, &
-                                   n_occupied, n_occupied_beta, gradient, error)
+                                   n_occupied, n_occupied_beta, gradient, error, aux)
       !! dE/dR for a converged SCF, in Hartree/Bohr
       !!
       !! The beta arguments are what makes this one routine rather than two.
@@ -60,6 +68,14 @@ contains
       !! density and exchange from each spin separately, which is the only
       !! place the two paths differ. Absent means closed shell, where the
       !! density already carries its factor of two.
+      !!
+      !! `aux` present means the SCF being differentiated fitted its J and K,
+      !! and only the two-electron term changes: a density-fitted SCF is still
+      !! variational, so the one-electron, Pulay and nuclear-repulsion terms
+      !! are the same integrals contracted with the same densities. Passing an
+      !! auxiliary basis that the SCF did not use would differentiate a
+      !! different energy, which nothing here can detect -- it is the caller's
+      !! job to pass the one it converged with.
       type(libcint_molecule_t), intent(in) :: mol
       real(dp), intent(in) :: density(:, :)          !! Alpha, or the total for RHF
       real(dp), intent(in), optional :: density_beta(:, :)
@@ -71,6 +87,8 @@ contains
       integer, intent(in), optional :: n_occupied_beta
       real(dp), allocatable, intent(out) :: gradient(:, :)   !! (3, natm)
       type(error_t), intent(inout) :: error
+      type(libcint_molecule_t), intent(in), optional :: aux
+         !! The auxiliary basis the SCF fitted with. Absent means exact ERIs.
 
       real(dp), allocatable :: total_density(:, :), weighted(:, :)
       real(dp), allocatable :: s1(:, :, :), h1(:, :, :), kin(:, :, :)
@@ -79,6 +97,7 @@ contains
       integer, allocatable :: offsets(:), counts(:)
       integer :: nao, iatom, comp, p0, p1
       logical :: unrestricted
+      logical :: fitted
 
       unrestricted = present(density_beta)
       nao = mol%nao
@@ -121,7 +140,23 @@ contains
       h1 = -(kin + h1)
       deallocate (kin)
 
-      if (unrestricted) then
+      ! The fitted two-electron gradient does not factor into a `vhf` matrix
+      ! the way the exact one does -- it contracts three- and two-centre
+      ! derivatives against densities of its own -- so it accumulates straight
+      ! into `gradient` here and the per-atom loop below skips its term.
+      fitted = present(aux)
+      if (fitted) then
+         if (unrestricted) then
+            call df_two_electron_gradient(mol, aux, total_density, orbitals, n_occupied, &
+                                          orbitals_beta=orbitals_beta, &
+                                          n_occupied_beta=n_occupied_beta, &
+                                          gradient=gradient, error=error)
+         else
+            call df_two_electron_gradient(mol, aux, total_density, orbitals, n_occupied, &
+                                          gradient=gradient, error=error)
+         end if
+         if (error%has_error()) return
+      else if (unrestricted) then
          call two_electron_deriv(mol, total_density, vhf, error, &
                                  exchange_density=density)
          if (error%has_error()) return
@@ -169,13 +204,15 @@ contains
          ! the same number by the symmetry of the integrals, so it is counted
          ! rather than computed.
          do comp = 1, 3
-            if (unrestricted) then
-               gradient(comp, iatom) = gradient(comp, iatom) &
-                                       + 2.0_dp*sum(vhf(p0:p1, :, comp)*density(p0:p1, :)) &
-                                       + 2.0_dp*sum(vhf_beta(p0:p1, :, comp)*density_beta(p0:p1, :))
-            else
-               gradient(comp, iatom) = gradient(comp, iatom) &
-                                       + 2.0_dp*sum(vhf(p0:p1, :, comp)*total_density(p0:p1, :))
+            if (.not. fitted) then
+               if (unrestricted) then
+                  gradient(comp, iatom) = gradient(comp, iatom) &
+                                          + 2.0_dp*sum(vhf(p0:p1, :, comp)*density(p0:p1, :)) &
+                                          + 2.0_dp*sum(vhf_beta(p0:p1, :, comp)*density_beta(p0:p1, :))
+               else
+                  gradient(comp, iatom) = gradient(comp, iatom) &
+                                          + 2.0_dp*sum(vhf(p0:p1, :, comp)*total_density(p0:p1, :))
+               end if
             end if
             gradient(comp, iatom) = gradient(comp, iatom) &
                                     - 2.0_dp*sum(s1(p0:p1, :, comp)*weighted(p0:p1, :))
@@ -505,6 +542,349 @@ contains
       vhf = -(vj - k_scale*vk)
 
    end subroutine two_electron_deriv
+
+   subroutine df_two_electron_gradient(orb, aux, total_density, orbitals, n_occupied, &
+                                       orbitals_beta, n_occupied_beta, gradient, error)
+      !! The two-electron gradient when J and K are density-fitted
+      !!
+      !! **What is being differentiated.** The fitted energy is
+      !!
+      !!    E_2e = (1/2) g^T J^-1 g  -  (exchange, below)
+      !!
+      !! with `g_P = sum_uv (P|uv) D_uv` and `J_PQ = (P|Q)`. Only the integrals
+      !! depend on the geometry -- the SCF is stationary in its orbitals, so
+      !! their derivatives are already accounted for by the Pulay term -- and
+      !! `d(J^-1)/dx = -J^-1 J^x J^-1` turns the Coulomb derivative into
+      !!
+      !!    rho^T g^x  -  (1/2) rho^T J^x rho,      rho = J^-1 g
+      !!
+      !! Exchange has the same two shapes over the fully transformed
+      !! `e^P_ij = sum_ul C_ui C_lj (ul|P)` and `f = J^-1 e`.
+      !!
+      !! **Everything collapses into two densities**, so the expensive
+      !! derivative integrals are each contracted once:
+      !!
+      !!    Gamma^P_uv = rho_P D_uv - sum_spin c_s Z^{s,P}_uv
+      !!    Omega_PQ   = -(1/2) rho_P rho_Q + sum_spin (c_s/2) sum_ij f^s_ij f^s_ij
+      !!
+      !! with `Z^{s,P}_uv = sum_ij C_ui f^{s,P}_ij C_vj`, and `c_s` the channel
+      !! weight: two for the single closed-shell channel, one for each of the
+      !! two unrestricted ones. That the ratio between the two terms is the
+      !! same either way is why one routine covers both.
+      !!
+      !! **The pseudo-inverse must be the SCF's.** `J^-1` is formed as
+      !! `J^-1/2 J^-1/2` from `metric_inverse_sqrt`, the same routine and the
+      !! same eigenvalue threshold `build_df_tensor` uses. A fitting set is
+      !! near-linearly-dependent by construction, so a `J^-1` that kept
+      !! different modes would be differentiating a slightly different energy
+      !! than the one that converged -- which shows up as a gradient that
+      !! disagrees with finite differences by a little, in a way that looks
+      !! like a factor being wrong somewhere.
+      type(libcint_molecule_t), intent(in) :: orb, aux
+      real(dp), intent(in) :: total_density(:, :)
+      real(dp), intent(in) :: orbitals(:, :)
+      integer, intent(in) :: n_occupied
+      real(dp), intent(in), optional :: orbitals_beta(:, :)
+      integer, intent(in), optional :: n_occupied_beta
+      real(dp), intent(inout) :: gradient(:, :)
+      type(error_t), intent(inout) :: error
+
+      real(dp), allocatable :: three(:, :), metric(:, :), half(:, :), jinv(:, :)
+      real(dp), allocatable :: g(:), rho(:)
+      real(dp), allocatable :: gamma(:, :, :), omega(:, :)
+      real(dp), allocatable :: ip1(:, :, :, :), ip2(:, :, :, :), d2c(:, :, :)
+      integer, allocatable :: orb_off(:), orb_cnt(:), aux_off(:), aux_cnt(:)
+      integer :: nao, naux, iatom, comp, p0, p1, q0, q1, ip
+      logical :: unrestricted
+
+      nao = orb%nao
+      naux = aux%nao
+      unrestricted = present(orbitals_beta)
+
+      ! The auxiliary basis sits on the same nuclei as the orbital one, and the
+      ! per-atom accumulation below indexes both by the same atom number. A
+      ! mismatch would silently attribute an auxiliary function's derivative to
+      ! the wrong nucleus, which translational invariance would catch but only
+      ! after the fact.
+      if (aux%natm /= orb%natm) then
+         call error%set(ERROR_VALIDATION, &
+                        "density-fitted gradient: the auxiliary basis is on a "// &
+                        "different set of atoms than the orbital basis")
+         return
+      end if
+
+      call three_centre(orb, aux, three)
+      call two_centre(aux, metric)
+      call metric_inverse_sqrt(metric, half, error)
+      if (error%has_error()) return
+
+      ! J^-1 from the square root, for the reason in the header.
+      allocate (jinv(naux, naux))
+      jinv = 0.0_dp
+      call pic_gemm(half, half, jinv)
+
+      allocate (g(naux), rho(naux))
+      do ip = 1, naux
+         g(ip) = sum(reshape(three(:, ip), [nao, nao])*total_density)
+      end do
+      rho = matmul(jinv, g)
+
+      allocate (gamma(nao, nao, naux), omega(naux, naux))
+      do ip = 1, naux
+         gamma(:, :, ip) = rho(ip)*total_density
+      end do
+      omega = -0.5_dp*outer(rho, rho)
+
+      if (unrestricted) then
+         call add_exchange_channel(three, jinv, orbitals, n_occupied, 1.0_dp, gamma, omega)
+         call add_exchange_channel(three, jinv, orbitals_beta, n_occupied_beta, 1.0_dp, &
+                                   gamma, omega)
+      else
+         call add_exchange_channel(three, jinv, orbitals, n_occupied, 2.0_dp, gamma, omega)
+      end if
+
+      deallocate (three, metric, half, jinv, g, rho)
+
+      call three_centre_deriv(orb, aux, 1, ip1)
+      call three_centre_deriv(orb, aux, 2, ip2)
+      call two_centre_deriv(aux, d2c)
+
+      allocate (orb_off(orb%natm), orb_cnt(orb%natm))
+      allocate (aux_off(aux%natm), aux_cnt(aux%natm))
+      call atom_ao_blocks(orb, orb_off, orb_cnt)
+      call atom_ao_blocks(aux, aux_off, aux_cnt)
+
+      do iatom = 1, orb%natm
+         p0 = orb_off(iatom) + 1
+         p1 = orb_off(iatom) + orb_cnt(iatom)
+         q0 = aux_off(iatom) + 1
+         q1 = aux_off(iatom) + aux_cnt(iatom)
+
+         do comp = 1, 3
+            ! Orbital indices. Twice: ip1 differentiates the first index only,
+            ! and the second index contributes the transpose -- which is the
+            ! same number because both (uv|P) and Gamma^P are symmetric in u
+            ! and v. Minus, because libcint's nabla is on the bra.
+            if (orb_cnt(iatom) > 0) then
+               gradient(comp, iatom) = gradient(comp, iatom) &
+                                       - 2.0_dp*sum(ip1(p0:p1, :, :, comp)*gamma(p0:p1, :, :))
+            end if
+
+            ! The auxiliary index. Once, because P appears once.
+            if (aux_cnt(iatom) > 0) then
+               gradient(comp, iatom) = gradient(comp, iatom) &
+                                       - sum(ip2(:, :, q0:q1, comp)*gamma(:, :, q0:q1))
+
+               ! The metric. Twice, for the same reason as the orbital pair:
+               ! (P|Q) is symmetric and so is Omega.
+               gradient(comp, iatom) = gradient(comp, iatom) &
+                                       - 2.0_dp*sum(d2c(q0:q1, :, comp)*omega(q0:q1, :))
+            end if
+         end do
+      end do
+
+   end subroutine df_two_electron_gradient
+
+   subroutine add_exchange_channel(three, jinv, orbitals, n_occ, weight, gamma, omega)
+      !! One spin channel's exchange contribution to Gamma and Omega
+      !!
+      !! `weight` is two for a closed shell, where the single channel carries
+      !! both spins, and one for each channel of an unrestricted reference. The
+      !! metric term takes half of it, which is the factor that makes the
+      !! restricted and unrestricted expressions agree when the two spins are
+      !! identical -- and the one worth checking by feeding a closed-shell
+      !! system through the unrestricted path.
+      real(dp), intent(in) :: three(:, :)     !! (nao*nao, naux)
+      real(dp), intent(in) :: jinv(:, :)      !! (naux, naux)
+      real(dp), intent(in) :: orbitals(:, :)
+      integer, intent(in) :: n_occ
+      real(dp), intent(in) :: weight
+      real(dp), intent(inout) :: gamma(:, :, :)   !! (nao, nao, naux)
+      real(dp), intent(inout) :: omega(:, :)      !! (naux, naux)
+
+      real(dp), allocatable :: c_occ(:, :), e(:, :, :), f(:, :, :)
+      real(dp), allocatable :: tmp(:, :), block(:, :), zp(:, :)
+      integer :: nao, naux, ip, iq
+
+      nao = size(orbitals, 1)
+      naux = size(jinv, 1)
+
+      if (n_occ <= 0) return
+
+      allocate (c_occ(nao, n_occ), source=orbitals(:, 1:n_occ))
+      allocate (e(n_occ, n_occ, naux), f(n_occ, n_occ, naux))
+      allocate (tmp(nao, n_occ), block(nao, nao), zp(nao, nao))
+
+      ! e^P_ij = C^T (uv|P) C, one auxiliary function at a time.
+      do ip = 1, naux
+         block = reshape(three(:, ip), [nao, nao])
+         tmp = 0.0_dp
+         call pic_gemm(block, c_occ, tmp)
+         e(:, :, ip) = 0.0_dp
+         call pic_gemm(c_occ, tmp, e(:, :, ip), transa="T")
+      end do
+
+      ! f = J^-1 e, over the auxiliary index for every occupied pair.
+      f = 0.0_dp
+      do ip = 1, naux
+         do iq = 1, naux
+            if (jinv(ip, iq) == 0.0_dp) cycle
+            f(:, :, ip) = f(:, :, ip) + jinv(ip, iq)*e(:, :, iq)
+         end do
+      end do
+
+      ! Z^P = C f^P C^T, back in the AO basis, subtracted from Gamma.
+      do ip = 1, naux
+         tmp = 0.0_dp
+         call pic_gemm(c_occ, f(:, :, ip), tmp)
+         zp = 0.0_dp
+         call pic_gemm(tmp, c_occ, zp, transb="T")
+         gamma(:, :, ip) = gamma(:, :, ip) - weight*zp
+      end do
+
+      ! The metric term, sum_ij f^P_ij f^Q_ij.
+      do iq = 1, naux
+         do ip = 1, naux
+            omega(ip, iq) = omega(ip, iq) &
+                            + 0.5_dp*weight*sum(f(:, :, ip)*f(:, :, iq))
+         end do
+      end do
+
+   end subroutine add_exchange_channel
+
+   pure function outer(a, b) result(m)
+      !! The outer product a b^T, which Fortran has no intrinsic for
+      real(dp), intent(in) :: a(:), b(:)
+      real(dp) :: m(size(a), size(b))
+
+      integer :: i
+
+      do i = 1, size(b)
+         m(:, i) = a*b(i)
+      end do
+   end function outer
+
+   subroutine three_centre_deriv(orb, aux, which, deriv)
+      !! d(mu nu | P) / dR, as (nao, nao, naux, 3)
+      !!
+      !! `which` selects whose centre is differentiated: 1 for the first
+      !! orbital index, through int3c2e_ip1, and 2 for the auxiliary one,
+      !! through int3c2e_ip2. The second orbital index has no entry point of
+      !! its own -- (mu nu|P) is symmetric in mu and nu, so its derivative is
+      !! the transpose of the first, which is why nothing here integrates for
+      !! it.
+      !!
+      !! No symmetry in the shell-pair loop, unlike the energy's `three_centre`
+      !! next door: ip1 differentiates mu and not nu, so the block for (ish,
+      !! jsh) is not the transpose of (jsh, ish).
+      type(libcint_molecule_t), intent(in) :: orb, aux
+      integer, intent(in) :: which
+      real(dp), allocatable, intent(out) :: deriv(:, :, :, :)
+
+      integer, allocatable :: bas(:, :)
+      real(dp), allocatable :: env(:), buf(:)
+      integer :: shls(4)
+      integer :: dummy, nbas_orb, nbas_aux
+      integer :: ish, jsh, ksh, di, dj, dk, io, jo, ko, i, j, k, comp, ret, idx, mx
+
+      nbas_orb = orb%nbas
+      nbas_aux = aux%nbas
+      call build_df_shell_table(orb, aux, bas, env, dummy)
+
+      allocate (deriv(orb%nao, orb%nao, aux%nao, 3))
+      deriv = 0.0_dp
+
+      mx = max(largest_shell(orb), largest_shell(aux))
+      allocate (buf(mx**3*3))
+
+      do ish = 1, nbas_orb
+         di = shell_dim(orb%cartesian, ish - 1, bas)
+         io = orb%shell_offset(ish)
+         do jsh = 1, nbas_orb
+            dj = shell_dim(orb%cartesian, jsh - 1, bas)
+            jo = orb%shell_offset(jsh)
+            do ksh = 1, nbas_aux
+               dk = shell_dim(orb%cartesian, nbas_orb + ksh - 1, bas)
+               ko = aux%shell_offset(ksh)
+               shls = [ish - 1, jsh - 1, nbas_orb + ksh - 1, dummy - 1]
+
+               if (orb%cartesian) then
+                  if (which == 1) then
+                     ret = libcint_3c2e_ip1_cart(buf, shls, orb%atm, orb%natm, bas, &
+                                                 dummy, env)
+                  else
+                     ret = libcint_3c2e_ip2_cart(buf, shls, orb%atm, orb%natm, bas, &
+                                                 dummy, env)
+                  end if
+               else
+                  if (which == 1) then
+                     ret = libcint_3c2e_ip1_sph(buf, shls, orb%atm, orb%natm, bas, &
+                                                dummy, env)
+                  else
+                     ret = libcint_3c2e_ip2_sph(buf, shls, orb%atm, orb%natm, bas, &
+                                                dummy, env)
+                  end if
+               end if
+               if (ret == 0) cycle
+
+               do comp = 1, 3
+                  do k = 1, dk
+                     do j = 1, dj
+                        do i = 1, di
+                           idx = i + di*(j - 1 + dj*(k - 1 + dk*(comp - 1)))
+                           deriv(io + i, jo + j, ko + k, comp) = buf(idx)
+                        end do
+                     end do
+                  end do
+               end do
+            end do
+         end do
+      end do
+   end subroutine three_centre_deriv
+
+   subroutine two_centre_deriv(aux, deriv)
+      !! d(P|Q) / dR with respect to P's centre, as (naux, naux, 3)
+      type(libcint_molecule_t), intent(in) :: aux
+      real(dp), allocatable, intent(out) :: deriv(:, :, :)
+
+      real(dp), allocatable :: buf(:)
+      integer :: shls(4)
+      integer :: ish, jsh, di, dj, io, jo, i, j, comp, ret, idx, mx
+
+      allocate (deriv(aux%nao, aux%nao, 3))
+      deriv = 0.0_dp
+
+      mx = largest_shell(aux)
+      allocate (buf(mx*mx*3))
+
+      do ish = 1, aux%nbas
+         di = shell_dim(aux%cartesian, ish - 1, aux%bas)
+         io = aux%shell_offset(ish)
+         do jsh = 1, aux%nbas
+            dj = shell_dim(aux%cartesian, jsh - 1, aux%bas)
+            jo = aux%shell_offset(jsh)
+            shls = [ish - 1, jsh - 1, 0, 0]
+
+            if (aux%cartesian) then
+               ret = libcint_2c2e_ip1_cart(buf, shls, aux%atm, aux%natm, aux%bas, &
+                                           aux%nbas, aux%env)
+            else
+               ret = libcint_2c2e_ip1_sph(buf, shls, aux%atm, aux%natm, aux%bas, &
+                                          aux%nbas, aux%env)
+            end if
+            if (ret == 0) cycle
+
+            do comp = 1, 3
+               do j = 1, dj
+                  do i = 1, di
+                     idx = i + di*(j - 1 + dj*(comp - 1))
+                     deriv(io + i, jo + j, comp) = buf(idx)
+                  end do
+               end do
+            end do
+         end do
+      end do
+   end subroutine two_centre_deriv
 
    pure function largest_shell(mol) result(n)
       !! Functions in the biggest shell, for sizing a scratch block

--- a/backends/libcint/mqc_libcint_integrals.f90
+++ b/backends/libcint/mqc_libcint_integrals.f90
@@ -71,6 +71,16 @@ module mqc_libcint_integrals
    ! Both follow from the packing order in `molecule_build`, so they belong
    ! beside it rather than being re-derived by whatever needs them.
    public :: atom_ao_blocks
+   public :: build_df_shell_table
+   ! The undifferentiated three- and two-centre integrals, and the metric's
+   ! inverse square root. Public because the gradient needs the same three
+   ! quantities the fitted Fock build does -- and, for the metric, needs them
+   ! from the *same* eigenvalue threshold: a gradient built on a pseudo-inverse
+   ! that kept different modes than the SCF's would not differentiate the
+   ! energy the SCF actually converged.
+   public :: three_centre
+   public :: two_centre
+   public :: metric_inverse_sqrt
    public :: subshell_layout
 
    type :: libcint_molecule_t
@@ -829,6 +839,54 @@ contains
       end do
    end subroutine two_centre
 
+   subroutine build_df_shell_table(orb, aux, bas, env, dummy)
+      !! Orbital and auxiliary shells in one table, as libcint needs them
+      !!
+      !! libcint addresses all four centres of a three-centre call by index
+      !! into a single shell table, so the two bases have to be concatenated
+      !! and the auxiliary env offsets shifted past the orbital env. The fourth
+      !! index names a dummy s shell of zero exponent, which is how libcint
+      !! spells "only three centres".
+      !!
+      !! Extracted so that the energy's `three_centre` and the gradient's
+      !! derivative equivalents build the same table. Two constructions of this
+      !! would agree until one of them was edited, and the failure would be a
+      !! fitted quantity differentiated in a basis it was not built in.
+      type(libcint_molecule_t), intent(in) :: orb, aux
+      integer, allocatable, intent(out) :: bas(:, :)
+      real(dp), allocatable, intent(out) :: env(:)
+      integer, intent(out) :: dummy   !! 1-based index of the dummy shell
+
+      integer :: nbas_orb, nbas_aux, n_env_orb, ish
+
+      nbas_orb = orb%nbas
+      nbas_aux = aux%nbas
+      n_env_orb = size(orb%env)
+
+      allocate (bas(LIBCINT_BAS_SLOTS, nbas_orb + nbas_aux + 1))
+      allocate (env(n_env_orb + size(aux%env) + 1))
+      bas = 0
+      env = 0.0_dp
+      env(1:n_env_orb) = orb%env
+      env(n_env_orb + 1:n_env_orb + size(aux%env)) = aux%env
+
+      bas(:, 1:nbas_orb) = orb%bas
+      bas(:, nbas_orb + 1:nbas_orb + nbas_aux) = aux%bas
+      do ish = 1, nbas_aux
+         bas(LIBCINT_PTR_EXP, nbas_orb + ish) = aux%bas(LIBCINT_PTR_EXP, ish) + n_env_orb
+         bas(LIBCINT_PTR_COEFF, nbas_orb + ish) = aux%bas(LIBCINT_PTR_COEFF, ish) + n_env_orb
+      end do
+
+      dummy = nbas_orb + nbas_aux + 1
+      bas(LIBCINT_ATOM_OF, dummy) = 0
+      bas(LIBCINT_ANG_OF, dummy) = 0
+      bas(LIBCINT_NPRIM_OF, dummy) = 1
+      bas(LIBCINT_NCTR_OF, dummy) = 1
+      bas(LIBCINT_PTR_EXP, dummy) = size(env) - 1
+      bas(LIBCINT_PTR_COEFF, dummy) = size(env) - 1
+      env(size(env)) = 0.0_dp
+   end subroutine build_df_shell_table
+
    subroutine three_centre(orb, aux, three)
       !! (mu nu | P), flattened to (nao*nao, naux)
       !!
@@ -845,7 +903,7 @@ contains
 
       integer, allocatable :: bas(:, :)
       real(dp), allocatable :: env(:), buf(:)
-      integer :: nbas_orb, nbas_aux, dummy, n_env_orb
+      integer :: nbas_orb, nbas_aux, dummy
       integer :: shls(4)
       integer :: ish, jsh, ksh, di, dj, dk, i, j, k, io, jo, ko, ret, idx
       integer :: npair, ipair
@@ -854,34 +912,7 @@ contains
 
       nbas_orb = orb%nbas
       nbas_aux = aux%nbas
-
-      ! Orbital shells, then auxiliary shells, then one dummy. The auxiliary
-      ! env offsets are shifted by the orbital env length because both live in
-      ! one array now.
-      n_env_orb = size(orb%env)
-      allocate (bas(LIBCINT_BAS_SLOTS, nbas_orb + nbas_aux + 1))
-      allocate (env(n_env_orb + size(aux%env) + 1))
-      bas = 0
-      env = 0.0_dp
-      env(1:n_env_orb) = orb%env
-      env(n_env_orb + 1:n_env_orb + size(aux%env)) = aux%env
-
-      bas(:, 1:nbas_orb) = orb%bas
-      bas(:, nbas_orb + 1:nbas_orb + nbas_aux) = aux%bas
-      do ish = 1, nbas_aux
-         bas(LIBCINT_PTR_EXP, nbas_orb + ish) = aux%bas(LIBCINT_PTR_EXP, ish) + n_env_orb
-         bas(LIBCINT_PTR_COEFF, nbas_orb + ish) = aux%bas(LIBCINT_PTR_COEFF, ish) + n_env_orb
-      end do
-
-      ! The dummy: one s shell, one primitive, exponent and coefficient zero.
-      dummy = nbas_orb + nbas_aux + 1
-      bas(LIBCINT_ATOM_OF, dummy) = 0
-      bas(LIBCINT_ANG_OF, dummy) = 0
-      bas(LIBCINT_NPRIM_OF, dummy) = 1
-      bas(LIBCINT_NCTR_OF, dummy) = 1
-      bas(LIBCINT_PTR_EXP, dummy) = size(env) - 1
-      bas(LIBCINT_PTR_COEFF, dummy) = size(env) - 1
-      env(size(env)) = 0.0_dp
+      call build_df_shell_table(orb, aux, bas, env, dummy)
 
       allocate (three(orb%nao*orb%nao, aux%nao))
       three = 0.0_dp

--- a/validation/check_df_deriv.f90
+++ b/validation/check_df_deriv.f90
@@ -1,0 +1,63 @@
+!! The density-fitting derivative integrals, before anything is built on them
+program check_df_deriv
+   !! Prints a few elements of d(mu nu|P)/dR and d(P|Q)/dR for comparison
+   !! against PySCF's int3c2e_ip1, int3c2e_ip2 and int2c2e_ip1.
+   !!
+   !! Checked at this level on purpose. An index or ordering mistake in a
+   !! three-centre derivative does not announce itself in the assembled
+   !! gradient -- it produces a number of the right magnitude that disagrees
+   !! with finite differences for reasons that could be anywhere in the
+   !! contraction. Comparing the integrals themselves puts the error where it
+   !! happened.
+   use pic_types, only: dp
+   use mqc_error, only: error_t
+   use mqc_libcint_integrals, only: libcint_molecule_t, build_libcint_molecule
+   use mqc_libcint_gradient, only: three_centre_deriv, two_centre_deriv
+   implicit none
+
+   integer, parameter :: N_DIM = 3
+   type(libcint_molecule_t) :: orb, aux
+   type(error_t) :: error
+   real(dp), allocatable :: ip1(:, :, :, :), ip2(:, :, :, :), ip2c(:, :, :)
+   integer :: i, j, k, c
+
+   call build_libcint_molecule([1, 1], ["H", "H"], &
+                               reshape([0.0_dp, 0.0_dp, -0.7_dp, &
+                                        0.0_dp, 0.0_dp, 0.7_dp], [N_DIM, 2]), &
+                               "sto-3g", orb, error)
+   if (error%has_error()) then
+      write (*, "(a,a)") "orbital basis failed: ", error%get_message()
+      error stop 1
+   end if
+   call build_libcint_molecule([1, 1], ["H", "H"], &
+                               reshape([0.0_dp, 0.0_dp, -0.7_dp, &
+                                        0.0_dp, 0.0_dp, 0.7_dp], [N_DIM, 2]), &
+                               "cc-pvdz-rifit", aux, error)
+   if (error%has_error()) then
+      write (*, "(a,a)") "auxiliary basis failed: ", error%get_message()
+      error stop 1
+   end if
+
+   write (*, "(a,i0,a,i0)") "nao = ", orb%nao, "   naux = ", aux%nao
+
+   call three_centre_deriv(orb, aux, 1, ip1)
+   call three_centre_deriv(orb, aux, 2, ip2)
+   call two_centre_deriv(aux, ip2c)
+
+   write (*, "(a)") "ip1 (mu,nu,P,comp) for mu,nu = 1,2 and P = 1..3"
+   do k = 1, min(3, aux%nao)
+      write (*, "(a,i0,a,3f18.12)") "   P=", k, "  ", (ip1(1, 2, k, c), c=1, 3)
+   end do
+   write (*, "(a)") "ip2 (mu,nu,P,comp) for mu,nu = 1,2 and P = 1..3"
+   do k = 1, min(3, aux%nao)
+      write (*, "(a,i0,a,3f18.12)") "   P=", k, "  ", (ip2(1, 2, k, c), c=1, 3)
+   end do
+   ! Q on the *other* atom. Both indices on one centre makes (P|Q)
+   ! independent of position, so its derivative is zero and the comparison
+   ! would pass without testing anything.
+   write (*, "(a,i0,a)") "2c2e_ip1 (P,Q,comp) for P=1, Q = ", aux%nao/2 + 1, "..+2"
+   do k = aux%nao/2 + 1, min(aux%nao/2 + 3, aux%nao)
+      write (*, "(a,i0,a,3f18.12)") "   Q=", k, "  ", (ip2c(1, k, c), c=1, 3)
+   end do
+
+end program check_df_deriv

--- a/validation/check_scf_gradient.f90
+++ b/validation/check_scf_gradient.f90
@@ -65,6 +65,29 @@ program check_scf_gradient
                             -1.02_dp, -1.78_dp, 0.3_dp], [N_DIM, 4]), &
                    "sto-3g", 9, 2, n_bad)
 
+   ! Density fitting. Only the two-electron term changes -- a fitted SCF is
+   ! still variational -- so these exercise the three-centre and metric
+   ! derivatives against the fitted energy they belong to.
+   call check_case("H2O / sto-3g + cc-pvdz-rifit (DF)", [8, 1, 1], ["O", "H", "H"], &
+                   reshape([0.0_dp, 0.0_dp, 0.0_dp, &
+                            0.0_dp, -1.4308_dp, 1.1078_dp, &
+                            0.0_dp, 1.4308_dp, 1.1078_dp], [N_DIM, 3]), &
+                   "sto-3g", 10, 1, n_bad, aux_basis="cc-pvdz-rifit")
+
+   call check_case("H2O / 6-31g + cc-pvdz-rifit (DF)", [8, 1, 1], ["O", "H", "H"], &
+                   reshape([0.0_dp, 0.0_dp, 0.0_dp, &
+                            0.0_dp, -1.4308_dp, 1.1078_dp, &
+                            0.0_dp, 1.4308_dp, 1.1078_dp], [N_DIM, 3]), &
+                   "6-31g", 10, 1, n_bad, aux_basis="cc-pvdz-rifit")
+
+   call check_case("HCN / sto-3g + cc-pvdz-rifit (DF)", [1, 6, 7], ["H", "C", "N"], &
+                   reshape([0.0_dp, 0.0_dp, -2.0_dp, &
+                            0.0_dp, 0.0_dp, 0.0_dp, &
+                            0.0_dp, 0.0_dp, 2.2_dp], [N_DIM, 3]), &
+                   "sto-3g", 14, 1, n_bad, aux_basis="cc-pvdz-rifit")
+
+   call check_unrestricted_df_channels(n_bad)
+
    write (*, "(a)") ""
    if (n_bad == 0) then
       write (*, "(a)") "all gradient checks passed"
@@ -75,7 +98,8 @@ program check_scf_gradient
 
 contains
 
-   subroutine check_case(label, numbers, symbols, coords, basis, nelec, multiplicity, n_bad)
+   subroutine check_case(label, numbers, symbols, coords, basis, nelec, multiplicity, &
+                         n_bad, aux_basis)
       character(len=*), intent(in) :: label
       integer, intent(in) :: numbers(:)
       character(len=*), intent(in) :: symbols(:)
@@ -83,6 +107,8 @@ contains
       character(len=*), intent(in) :: basis
       integer, intent(in) :: nelec, multiplicity
       integer, intent(inout) :: n_bad
+      character(len=*), intent(in), optional :: aux_basis
+         !! Present fits J and K, and differentiates the fitted energy
 
       real(dp), allocatable :: analytic(:, :), numeric(:, :)
       real(dp) :: translation(3)
@@ -96,7 +122,7 @@ contains
       write (*, "(a,a)") "== ", label
 
       call gradient_at(numbers, symbols, coords, basis, nelec, multiplicity, &
-                       analytic, error)
+                       analytic, error, aux_basis)
       if (error%has_error()) then
          write (*, "(a,a)") "FAIL: ", error%get_message()
          n_bad = n_bad + 1
@@ -104,7 +130,7 @@ contains
       end if
 
       call numeric_gradient(numbers, symbols, coords, basis, nelec, multiplicity, &
-                            numeric, error)
+                            numeric, error, aux_basis)
       if (error%has_error()) then
          write (*, "(a,a)") "FAIL (finite difference): ", error%get_message()
          n_bad = n_bad + 1
@@ -133,8 +159,101 @@ contains
       end if
    end subroutine check_case
 
+   subroutine check_unrestricted_df_channels(n_bad)
+      !! The unrestricted density-fitted branch, on a closed shell
+      !!
+      !! mqc has no unrestricted density-fitted SCF -- `run_libcint_uhf` says
+      !! so itself -- so there is no open-shell fitted energy to differentiate
+      !! and no finite difference to check the unrestricted branch against.
+      !!
+      !! What can still be checked is the part that is easy to get wrong: the
+      !! channel weights. Feed a closed-shell system through the unrestricted
+      !! path as two identical half-filled spin channels, and the result must
+      !! equal the restricted one exactly. The restricted expression carries a
+      !! factor of two on the exchange density and one on the metric term; the
+      !! unrestricted one carries one and a half per channel. If either is
+      !! wrong the two disagree, and this is the only thing that would notice.
+      integer, intent(inout) :: n_bad
+
+      integer, parameter :: numbers(3) = [8, 1, 1]
+      character(len=1), parameter :: symbols(3) = ["O", "H", "H"]
+      real(dp) :: coords(N_DIM, 3)
+      type(libcint_molecule_t) :: mol, aux
+      type(rhf_result_t) :: scf
+      type(error_t) :: error
+      real(dp), allocatable :: restricted(:, :), unrestricted(:, :)
+      real(dp), allocatable :: half_density(:, :)
+      real(dp) :: worst
+
+      coords = reshape([0.0_dp, 0.0_dp, 0.0_dp, &
+                        0.0_dp, -1.4308_dp, 1.1078_dp, &
+                        0.0_dp, 1.4308_dp, 1.1078_dp], [N_DIM, 3])
+
+      write (*, "(a)") ""
+      write (*, "(a)") "== unrestricted DF branch against the restricted one (H2O / sto-3g)"
+
+      call build_libcint_molecule(numbers, symbols, coords, "sto-3g", mol, error)
+      if (error%has_error()) then
+         write (*, "(a,a)") "FAIL: ", error%get_message()
+         n_bad = n_bad + 1
+         return
+      end if
+      call build_libcint_molecule(numbers, symbols, coords, "cc-pvdz-rifit", aux, error)
+      if (error%has_error()) then
+         write (*, "(a,a)") "FAIL: ", error%get_message()
+         n_bad = n_bad + 1
+         return
+      end if
+
+      call run_libcint_rhf(mol, 10, 200, 1.0e-12_dp, 1.0e-10_dp, .false., scf, error, aux=aux)
+      if (error%has_error()) then
+         write (*, "(a,a)") "FAIL: ", error%get_message()
+         n_bad = n_bad + 1
+         return
+      end if
+
+      call libcint_scf_gradient(mol, scf%density, &
+                                orbitals=scf%orbitals, &
+                                orbital_energies=scf%orbital_energies, &
+                                n_occupied=scf%n_occupied, &
+                                gradient=restricted, error=error, aux=aux)
+      if (error%has_error()) then
+         write (*, "(a,a)") "FAIL: ", error%get_message()
+         n_bad = n_bad + 1
+         return
+      end if
+
+      ! One electron per spin orbital rather than two, the same orbitals in
+      ! both channels: physically the same closed shell, expressed the way an
+      ! unrestricted reference would.
+      allocate (half_density(mol%nao, mol%nao))
+      half_density = 0.5_dp*scf%density
+
+      call libcint_scf_gradient(mol, half_density, &
+                                density_beta=half_density, &
+                                orbitals=scf%orbitals, &
+                                orbitals_beta=scf%orbitals, &
+                                orbital_energies=scf%orbital_energies, &
+                                orbital_energies_beta=scf%orbital_energies, &
+                                n_occupied=scf%n_occupied, &
+                                n_occupied_beta=scf%n_occupied, &
+                                gradient=unrestricted, error=error, aux=aux)
+      if (error%has_error()) then
+         write (*, "(a,a)") "FAIL: ", error%get_message()
+         n_bad = n_bad + 1
+         return
+      end if
+
+      worst = maxval(abs(restricted - unrestricted))
+      write (*, "(a,es12.4)") "  largest difference between the two paths: ", worst
+      if (worst > 1.0e-11_dp) then
+         write (*, "(a)") "  FAIL: the unrestricted channel weights do not reproduce the restricted result"
+         n_bad = n_bad + 1
+      end if
+   end subroutine check_unrestricted_df_channels
+
    subroutine gradient_at(numbers, symbols, coords, basis, nelec, multiplicity, &
-                          gradient, error)
+                          gradient, error, aux_basis)
       !! Converge an SCF at this geometry and differentiate it
       integer, intent(in) :: numbers(:)
       character(len=*), intent(in) :: symbols(:)
@@ -143,14 +262,30 @@ contains
       integer, intent(in) :: nelec, multiplicity
       real(dp), allocatable, intent(out) :: gradient(:, :)
       type(error_t), intent(inout) :: error
+      character(len=*), intent(in), optional :: aux_basis
 
-      type(libcint_molecule_t) :: mol
+      type(libcint_molecule_t) :: mol, aux
       type(rhf_result_t) :: scf
 
       call build_libcint_molecule(numbers, symbols, coords, basis, mol, error)
       if (error%has_error()) return
+      if (present(aux_basis)) then
+         call build_libcint_molecule(numbers, symbols, coords, aux_basis, aux, error)
+         if (error%has_error()) return
+      end if
 
       if (multiplicity == 1) then
+         if (present(aux_basis)) then
+            call run_libcint_rhf(mol, nelec, 200, 1.0e-12_dp, 1.0e-10_dp, .false., scf, &
+                                 error, aux=aux)
+            if (error%has_error()) return
+            call libcint_scf_gradient(mol, scf%density, &
+                                      orbitals=scf%orbitals, &
+                                      orbital_energies=scf%orbital_energies, &
+                                      n_occupied=scf%n_occupied, &
+                                      gradient=gradient, error=error, aux=aux)
+            return
+         end if
          call run_libcint_rhf(mol, nelec, 200, 1.0e-12_dp, 1.0e-10_dp, .false., scf, error)
          if (error%has_error()) return
          call libcint_scf_gradient(mol, scf%density, &
@@ -174,7 +309,8 @@ contains
       end if
    end subroutine gradient_at
 
-   subroutine energy_at(numbers, symbols, coords, basis, nelec, multiplicity, energy, error)
+   subroutine energy_at(numbers, symbols, coords, basis, nelec, multiplicity, energy, &
+                        error, aux_basis)
       !! One converged SCF energy, for the finite difference
       integer, intent(in) :: numbers(:)
       character(len=*), intent(in) :: symbols(:)
@@ -183,16 +319,26 @@ contains
       integer, intent(in) :: nelec, multiplicity
       real(dp), intent(out) :: energy
       type(error_t), intent(inout) :: error
+      character(len=*), intent(in), optional :: aux_basis
 
-      type(libcint_molecule_t) :: mol
+      type(libcint_molecule_t) :: mol, aux
       type(rhf_result_t) :: scf
 
       energy = 0.0_dp
       call build_libcint_molecule(numbers, symbols, coords, basis, mol, error)
       if (error%has_error()) return
+      if (present(aux_basis)) then
+         call build_libcint_molecule(numbers, symbols, coords, aux_basis, aux, error)
+         if (error%has_error()) return
+      end if
 
       if (multiplicity == 1) then
-         call run_libcint_rhf(mol, nelec, 200, 1.0e-12_dp, 1.0e-10_dp, .false., scf, error)
+         if (present(aux_basis)) then
+            call run_libcint_rhf(mol, nelec, 200, 1.0e-12_dp, 1.0e-10_dp, .false., scf, &
+                                 error, aux=aux)
+         else
+            call run_libcint_rhf(mol, nelec, 200, 1.0e-12_dp, 1.0e-10_dp, .false., scf, error)
+         end if
       else
          call run_libcint_uhf(mol, nelec, multiplicity, 200, 1.0e-12_dp, 1.0e-10_dp, &
                               .false., scf, error)
@@ -202,7 +348,7 @@ contains
    end subroutine energy_at
 
    subroutine numeric_gradient(numbers, symbols, coords, basis, nelec, multiplicity, &
-                               gradient, error)
+                               gradient, error, aux_basis)
       !! Central differences on the SCF energy
       !!
       !! The step is a compromise the tolerance above is set from: too large
@@ -216,6 +362,7 @@ contains
       integer, intent(in) :: nelec, multiplicity
       real(dp), allocatable, intent(out) :: gradient(:, :)
       type(error_t), intent(inout) :: error
+      character(len=*), intent(in), optional :: aux_basis
 
       real(dp), parameter :: step = 0.002_dp
       real(dp), allocatable :: shifted(:, :)
@@ -231,12 +378,14 @@ contains
          do ic = 1, 3
             shifted = coords
             shifted(ic, ia) = coords(ic, ia) + step
-            call energy_at(numbers, symbols, shifted, basis, nelec, multiplicity, e_plus, error)
+            call energy_at(numbers, symbols, shifted, basis, nelec, multiplicity, e_plus, &
+                           error, aux_basis)
             if (error%has_error()) return
 
             shifted = coords
             shifted(ic, ia) = coords(ic, ia) - step
-            call energy_at(numbers, symbols, shifted, basis, nelec, multiplicity, e_minus, error)
+            call energy_at(numbers, symbols, shifted, basis, nelec, multiplicity, e_minus, &
+                           error, aux_basis)
             if (error%has_error()) return
 
             gradient(ic, ia) = (e_plus - e_minus)/(2.0_dp*step)


### PR DESCRIPTION
Extends the analytic gradient to the density-fitted RHF path, so a DF calculation
no longer has to fall back to finite differences for its forces. The three-centre
and two-centre derivative terms both contribute, and the fitting coefficients
have to be differentiated along with the integrals.

Commit:
- `density-fitted RHF gradients on the CPU backend`

---

**Stack 2 of 2 — CPU analytic gradients.** Second of four.

1. #177 `feat/cpu-gradients` → `main`
2. **this PR** `feat/cpu-gradients-df` → `feat/cpu-gradients`
3. `feat/cpu-gradients-dft` → `feat/cpu-gradients-df`
4. `feat/cpu-gradients-gga` → `feat/cpu-gradients-dft`

Please merge in order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)