### PR TITLE
Kohn-Sham gradients, LDA

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -486,6 +486,13 @@ if(MQC_ENABLE_LIBCINT)
   # against translational invariance. Not a ctest case: it converges an SCF per
   # displaced coordinate, which is seconds rather than the milliseconds the unit
   # suite is meant to take.
+  add_executable(check_partition_deriv
+                 ${PROJECT_SOURCE_DIR}/validation/check_partition_deriv.f90)
+  target_include_directories(check_partition_deriv
+                             PRIVATE "${CMAKE_BINARY_DIR}/modules")
+  target_link_libraries(check_partition_deriv PRIVATE ${main_lib} cint_fortran
+                                                      cint)
+
   add_executable(check_df_deriv
                  ${PROJECT_SOURCE_DIR}/validation/check_df_deriv.f90)
   target_include_directories(check_df_deriv

--- a/backends/libcint/mqc_libcint_gradient.f90
+++ b/backends/libcint/mqc_libcint_gradient.f90
@@ -31,6 +31,9 @@ module mqc_libcint_gradient
    use mqc_libcint_integrals, only: libcint_molecule_t, shell_dim, atom_ao_blocks, &
                                     build_df_shell_table, three_centre, two_centre, &
                                     metric_inverse_sqrt
+   use mqc_libcint_ao, only: eval_ao_block, AO_POINT_BLOCK
+   use mqc_libcint_xc, only: xc_context_t, xc_grid_lda_quantities
+   use mqc_dft_partition, only: becke_partition_derivatives
    use pic_blas_interfaces, only: pic_gemm
    use libcint_fortran, only: libcint_1e_ipovlp_sph, libcint_1e_ipovlp_cart, &
                               libcint_1e_ipkin_sph, libcint_1e_ipkin_cart, &
@@ -60,7 +63,7 @@ contains
 
    subroutine libcint_scf_gradient(mol, density, density_beta, orbitals, orbitals_beta, &
                                    orbital_energies, orbital_energies_beta, &
-                                   n_occupied, n_occupied_beta, gradient, error, aux)
+                                   n_occupied, n_occupied_beta, gradient, error, aux, xc)
       !! dE/dR for a converged SCF, in Hartree/Bohr
       !!
       !! The beta arguments are what makes this one routine rather than two.
@@ -89,11 +92,17 @@ contains
       type(error_t), intent(inout) :: error
       type(libcint_molecule_t), intent(in), optional :: aux
          !! The auxiliary basis the SCF fitted with. Absent means exact ERIs.
+      type(xc_context_t), intent(inout), optional :: xc
+         !! The functional the SCF used. Absent means Hartree-Fock. Present adds
+         !! the exchange-correlation term and scales exact exchange by the
+         !! fraction the functional asks for -- zero for a pure functional, so
+         !! the Fock exchange derivative is not merely small but absent.
 
       real(dp), allocatable :: total_density(:, :), weighted(:, :)
       real(dp), allocatable :: s1(:, :, :), h1(:, :, :), kin(:, :, :)
       real(dp), allocatable :: vhf(:, :, :), vhf_beta(:, :, :)
       real(dp), allocatable :: vrinv(:, :, :), hcore_a(:, :, :)
+      real(dp) :: exx
       integer, allocatable :: offsets(:), counts(:)
       integer :: nao, iatom, comp, p0, p1
       logical :: unrestricted
@@ -101,6 +110,13 @@ contains
 
       unrestricted = present(density_beta)
       nao = mol%nao
+
+      ! Hartree-Fock keeps all of its exchange; a functional keeps the fraction
+      ! it declares. A range-separated one needs a second exchange derivative at
+      ! a screened omega, which this does not build, so it is refused below
+      ! rather than silently given its full-range part.
+      exx = 1.0_dp
+      if (present(xc)) exx = xc%exx_fraction
 
       if (size(density, 1) /= nao) then
          call error%set(ERROR_VALIDATION, &
@@ -157,14 +173,14 @@ contains
          end if
          if (error%has_error()) return
       else if (unrestricted) then
-         call two_electron_deriv(mol, total_density, vhf, error, &
+         call two_electron_deriv(mol, total_density, vhf, error, exx_fraction=exx, &
                                  exchange_density=density)
          if (error%has_error()) return
-         call two_electron_deriv(mol, total_density, vhf_beta, error, &
+         call two_electron_deriv(mol, total_density, vhf_beta, error, exx_fraction=exx, &
                                  exchange_density=density_beta)
          if (error%has_error()) return
       else
-         call two_electron_deriv(mol, total_density, vhf, error)
+         call two_electron_deriv(mol, total_density, vhf, error, exx_fraction=exx)
          if (error%has_error()) return
       end if
 
@@ -219,7 +235,244 @@ contains
          end do
       end do
 
+      ! Last, and on top of everything above: the exchange-correlation term is
+      ! an addition to the Hartree-Fock gradient, not a replacement for any part
+      ! of it.
+      if (present(xc)) then
+         if (xc%range_separated) then
+            call error%set(ERROR_VALIDATION, "the gradient of a range-separated "// &
+                           "functional needs a second exchange derivative at the "// &
+                           "screened omega, which this does not build")
+            return
+         end if
+         if (unrestricted) then
+            call xc_gradient(xc, mol, density, gradient, error, density_beta=density_beta)
+         else
+            ! The closed-shell density carries its factor of two, and
+            ! `xc_grid_lda_quantities` builds an unpolarised rho from it, which
+            ! is what the unpolarised functional expects.
+            call xc_gradient(xc, mol, total_density, gradient, error)
+         end if
+         if (error%has_error()) return
+      end if
+
    end subroutine libcint_scf_gradient
+
+   subroutine xc_gradient(ctx, mol, density, gradient, error, density_beta)
+      !! The exchange-correlation contribution to dE/dR, accumulated in place
+      !!
+      !! Three terms, and the last two are the ones a first attempt leaves out.
+      !!
+      !! **The basis functions move.** rho is built from functions centred on
+      !! atoms, so moving atom A changes rho wherever A's functions reach. This
+      !! is the term that looks like the Pulay term of the one-electron part and
+      !! is written the same way.
+      !!
+      !! **The grid points move.** The quadrature is atom-centred, so the points
+      !! belonging to A travel with it and the integrand is sampled at moved
+      !! positions. This contributes the same quantity as the first term but
+      !! summed over A's *points* rather than A's *functions* -- over every
+      !! basis function, not only the ones on A -- and with the opposite sign.
+      !!
+      !! **The partition weights move.** The Becke weight of every point depends
+      !! on every nuclear position, so moving A reweights the whole grid,
+      !! including points it does not own. This is the term whose absence leaves
+      !! a gradient that looks entirely plausible and misses finite differences
+      !! at about 1e-4, and it is also the term translational invariance is
+      !! sensitive to -- which is why that check is worth running on a DFT
+      !! gradient even though it is free.
+      !!
+      !! LDA only. `xc_grid_lda_quantities` refuses anything else, because a GGA
+      !! needs second derivatives of the basis functions and `eval_ao_block`
+      !! produces first.
+      type(xc_context_t), intent(inout) :: ctx
+      type(libcint_molecule_t), intent(in) :: mol
+      real(dp), intent(in) :: density(:, :)
+      real(dp), intent(inout) :: gradient(:, :)
+      type(error_t), intent(inout) :: error
+      real(dp), intent(in), optional :: density_beta(:, :)
+
+      real(dp), allocatable :: rho(:), exc(:), vrho(:)
+      real(dp), allocatable :: rho_beta(:), vrho_beta(:)
+      real(dp), allocatable :: ao(:, :), ao_grad(:, :, :)
+      real(dp), allocatable :: dchi(:, :), dchi_beta(:, :)
+      real(dp), allocatable :: dpart(:, :, :)
+      integer, allocatable :: offsets(:), counts(:)
+      real(dp) :: contrib(3)
+      real(dp) :: wv, scale
+      integer :: npts, nao, natm, g0, g1, nb, ig, gg, mu, comp, ia, own
+      logical :: unrestricted
+
+      if (.not. ctx%active) return
+
+      unrestricted = present(density_beta)
+      nao = mol%nao
+      natm = mol%natm
+      npts = ctx%grid%n_points
+
+      if (unrestricted) then
+         call xc_grid_lda_quantities(ctx, mol, density, rho, exc, vrho, error, &
+                                     density_beta=density_beta, rho_beta=rho_beta, &
+                                     vrho_beta=vrho_beta)
+      else
+         call xc_grid_lda_quantities(ctx, mol, density, rho, exc, vrho, error)
+      end if
+      if (error%has_error()) return
+
+      allocate (offsets(natm), counts(natm))
+      call atom_ao_blocks(mol, offsets, counts)
+
+      ! A closed-shell density already carries its factor of two, so the
+      ! derivative of rho with respect to a moving basis function is 2*D*chi
+      ! either way -- the two is the bra/ket pair, not the occupation.
+      scale = 2.0_dp
+
+      do g0 = 1, npts, AO_POINT_BLOCK
+         g1 = min(g0 + AO_POINT_BLOCK - 1, npts)
+         nb = g1 - g0 + 1
+
+         call eval_ao_block(mol, ctx%grid%coords(:, g0:g1), ao, error, grad=ao_grad)
+         if (error%has_error()) return
+
+         ! (D chi)_mu(g) = sum_nu D_mu,nu chi_nu(g), the partner every term
+         ! below contracts the basis-function gradient against.
+         if (allocated(dchi)) deallocate (dchi)
+         allocate (dchi(nb, nao))
+         call density_times_ao(ao, density, nb, nao, dchi)
+         if (unrestricted) then
+            if (allocated(dchi_beta)) deallocate (dchi_beta)
+            allocate (dchi_beta(nb, nao))
+            call density_times_ao(ao, density_beta, nb, nao, dchi_beta)
+         end if
+
+         do ig = 1, nb
+            gg = g0 + ig - 1
+            own = ctx%grid%atom(gg)
+
+            wv = ctx%grid%weights(gg)*vrho(gg)
+            call accumulate_channel(ao_grad, dchi, ig, nao, wv, scale, &
+                                    offsets, counts, natm, own, gradient)
+            if (unrestricted) then
+               wv = ctx%grid%weights(gg)*vrho_beta(gg)
+               call accumulate_channel(ao_grad, dchi_beta, ig, nao, wv, scale, &
+                                       offsets, counts, natm, own, gradient)
+            end if
+         end do
+
+         ! The partition-weight term. Differentiated blockwise for the same
+         ! reason the density is: the full (3, natm, npoints) array is large and
+         ! nothing needs it all at once.
+         if (allocated(dpart)) deallocate (dpart)
+         allocate (dpart(3, natm, nb))
+         call becke_partition_derivatives(ctx%grid%coords(:, g0:g1), mol%coords, &
+                                          ctx%grid%numbers, ctx%grid%atom(g0:g1), &
+                                          ctx%grid%scheme, ctx%grid%adjust, dpart, error)
+         if (error%has_error()) return
+
+         do ig = 1, nb
+            gg = g0 + ig - 1
+            contrib(1) = ctx%grid%quad_weights(gg)*exc(gg)
+            if (unrestricted) then
+               contrib(1) = contrib(1)*(rho(gg) + rho_beta(gg))
+            else
+               contrib(1) = contrib(1)*rho(gg)
+            end if
+            do ia = 1, natm
+               do comp = 1, 3
+                  gradient(comp, ia) = gradient(comp, ia) + contrib(1)*dpart(comp, ia, ig)
+               end do
+            end do
+
+            ! The partition weight of a point owned by A also changes because
+            ! the *point* moves with A, not only because A moves. That second
+            ! piece is what makes this term cancel the integrand's own
+            ! grid-motion contribution above -- together they are the integral
+            ! of grad(P f) over one atomic subgrid, which the quadrature
+            ! evaluates as very nearly zero because P f decays. Leaving it out
+            ! does not make the answer slightly worse: it leaves the
+            ! grid-motion term uncancelled, which on water is an error of 0.77
+            ! Hartree/Bohr against a gradient of 0.06.
+            !
+            ! It needs no new derivative. Displacing the point is the same as
+            ! displacing every nucleus the other way, so the gradient of the
+            ! partition with respect to the point is minus the sum over atoms
+            ! of what `becke_partition_derivatives` already returned.
+            own = ctx%grid%atom(gg)
+            do ia = 1, natm
+               do comp = 1, 3
+                  gradient(comp, own) = gradient(comp, own) &
+                                        - contrib(1)*dpart(comp, ia, ig)
+               end do
+            end do
+         end do
+      end do
+   end subroutine xc_gradient
+
+   subroutine density_times_ao(ao, density, nb, nao, dchi)
+      !! (D chi)_mu(g) = sum_nu D_mu,nu chi_nu(g)
+      real(dp), intent(in) :: ao(:, :)
+      real(dp), intent(in) :: density(:, :)
+      integer, intent(in) :: nb, nao
+      real(dp), intent(out) :: dchi(:, :)
+
+      integer :: ig, mu, nu
+      real(dp) :: acc
+
+      do mu = 1, nao
+         do ig = 1, nb
+            acc = 0.0_dp
+            do nu = 1, nao
+               acc = acc + density(mu, nu)*ao(ig, nu)
+            end do
+            dchi(ig, mu) = acc
+         end do
+      end do
+   end subroutine density_times_ao
+
+   subroutine accumulate_channel(ao_grad, dchi, ig, nao, wv, scale, &
+                                 offsets, counts, natm, own, gradient)
+      !! One spin channel's basis-function and grid-point terms at one point
+      !!
+      !! Both are the same contraction of `grad chi` against `D chi`. They
+      !! differ in which basis functions are summed and where the result lands:
+      !! the basis-function term takes only the functions on atom A and lands on
+      !! A, the grid-point term takes every function and lands on the atom that
+      !! owns the point. Their signs are opposite, which is what makes the two
+      !! cancel when every atom moves together.
+      real(dp), intent(in) :: ao_grad(:, :, :)
+      real(dp), intent(in) :: dchi(:, :)
+      integer, intent(in) :: ig, nao, natm, own
+      real(dp), intent(in) :: wv, scale
+      integer, intent(in) :: offsets(:), counts(:)
+      real(dp), intent(inout) :: gradient(:, :)
+
+      integer :: ia, mu, comp, p0, p1
+      real(dp) :: block_sum(3), total(3)
+
+      total = 0.0_dp
+      do ia = 1, natm
+         p0 = offsets(ia) + 1
+         p1 = offsets(ia) + counts(ia)
+         block_sum = 0.0_dp
+         do mu = p0, p1
+            do comp = 1, 3
+               block_sum(comp) = block_sum(comp) + ao_grad(ig, mu, comp)*dchi(ig, mu)
+            end do
+         end do
+         do comp = 1, 3
+            ! Moving atom A moves its functions; d chi / dR_A is minus the
+            ! gradient with respect to the electron coordinate.
+            gradient(comp, ia) = gradient(comp, ia) - scale*wv*block_sum(comp)
+            total(comp) = total(comp) + block_sum(comp)
+         end do
+      end do
+
+      ! The point travels with the atom that produced it, which is the same
+      ! contraction over every function and with the opposite sign.
+      do comp = 1, 3
+         gradient(comp, own) = gradient(comp, own) + scale*wv*total(comp)
+      end do
+   end subroutine accumulate_channel
 
    subroutine nuclear_repulsion_gradient(mol, gradient)
       !! dE_NN/dR, accumulated into `gradient`
@@ -399,7 +652,7 @@ contains
       end do
    end subroutine iprinv_deriv_at
 
-   subroutine two_electron_deriv(mol, density, vhf, error, exchange_density)
+   subroutine two_electron_deriv(mol, density, vhf, error, exchange_density, exx_fraction)
       !! `J - K/2` built from the differentiated ERIs, as (nao, nao, 3)
       !!
       !! `density` drives the Coulomb field and is the total density in both
@@ -422,6 +675,7 @@ contains
       real(dp), allocatable, intent(out) :: vhf(:, :, :)
       type(error_t), intent(inout) :: error
       real(dp), intent(in), optional :: exchange_density(:, :)
+      real(dp), intent(in), optional :: exx_fraction   !! Default one, for Hartree-Fock
 
       real(dp), allocatable :: buf(:), vj(:, :, :), vk(:, :, :)
       real(dp), allocatable :: vj_local(:, :, :), vk_local(:, :, :)
@@ -447,6 +701,8 @@ contains
          exchange_from = density
          k_scale = 0.5_dp
       end if
+
+      if (present(exx_fraction)) k_scale = k_scale*exx_fraction
 
       opt = c_null_ptr
       if (mol%cartesian) then

--- a/backends/libcint/mqc_libcint_xc.F90
+++ b/backends/libcint/mqc_libcint_xc.F90
@@ -57,6 +57,7 @@ module mqc_libcint_xc
    public :: xc_add_potential
    public :: xc_add_potential_uks
    public :: xc_available
+   public :: xc_grid_lda_quantities
 
    type :: xc_context_t
       !! A functional, a grid, and the fraction of exact exchange to keep
@@ -292,6 +293,124 @@ contains
       this%rs_omega = 0.0_dp
       this%rs_k_lr = 0.0_dp
    end subroutine xc_context_destroy
+
+   subroutine xc_grid_lda_quantities(ctx, mol, density, rho, exc, vrho, error, &
+                                     density_beta, rho_beta, vrho_beta)
+      !! rho, eps_xc and v_xc at every grid point, for an LDA functional
+      !!
+      !! The gradient needs these three on the grid rather than contracted into
+      !! a matrix: the exchange-correlation gradient has one term contracting
+      !! `vrho` against the moving basis functions and another contracting
+      !! `rho*exc` against the moving quadrature weights, and neither can be
+      !! recovered from the Fock-matrix contribution that `xc_add_potential`
+      !! returns.
+      !!
+      !! LDA only, and it refuses anything else rather than returning something
+      !! incomplete. A GGA needs `vsigma` and the density gradient as well, and
+      !! its gradient needs second derivatives of the basis functions, which
+      !! `eval_ao_block` does not produce.
+      type(xc_context_t), intent(inout) :: ctx
+      type(libcint_molecule_t), intent(in) :: mol
+      real(dp), intent(in) :: density(:, :)         !! Total density, or alpha
+      real(dp), allocatable, intent(out) :: rho(:)  !! Total density on the grid
+      real(dp), allocatable, intent(out) :: exc(:)  !! Energy per electron
+      real(dp), allocatable, intent(out) :: vrho(:)  !! dE_xc/drho, or the alpha part
+      type(error_t), intent(inout) :: error
+      real(dp), intent(in), optional :: density_beta(:, :)
+      real(dp), allocatable, intent(out), optional :: rho_beta(:)
+      real(dp), allocatable, intent(out), optional :: vrho_beta(:)
+
+      real(dp), allocatable :: ao(:, :), rho_blk(:), exc_i(:), vrho_i(:)
+      real(dp), allocatable :: rho_a_blk(:), rho_b_blk(:)
+      integer :: g0, g1, nb, i, ig, npts
+      logical :: unrestricted
+
+      unrestricted = present(density_beta)
+      npts = ctx%grid%n_points
+
+      allocate (rho(npts), exc(npts), vrho(npts))
+      rho = 0.0_dp
+      exc = 0.0_dp
+      vrho = 0.0_dp
+      if (unrestricted) then
+         allocate (rho_beta(npts), vrho_beta(npts))
+         rho_beta = 0.0_dp
+         vrho_beta = 0.0_dp
+      end if
+
+      if (.not. ctx%active) return
+      if (.not. xc_available()) then
+         call error%set(ERROR_VALIDATION, "no libxc in this build")
+         return
+      end if
+      if (ctx%any_gga .or. ctx%any_mgga) then
+         call error%set(ERROR_VALIDATION, "the exchange-correlation gradient is "// &
+                        "implemented for LDA functionals only; this one needs the "// &
+                        "density gradient")
+         return
+      end if
+      if (unrestricted .neqv. ctx%polarized) then
+         call error%set(ERROR_VALIDATION, "xc_grid_lda_quantities: the spin case does "// &
+                        "not match how this context was built")
+         return
+      end if
+
+#ifdef MQC_WITH_LIBXC
+      do g0 = 1, npts, AO_POINT_BLOCK
+         g1 = min(g0 + AO_POINT_BLOCK - 1, npts)
+         nb = g1 - g0 + 1
+
+         call eval_ao_block(mol, ctx%grid%coords(:, g0:g1), ao, error)
+         if (error%has_error()) return
+
+         if (allocated(exc_i)) deallocate (exc_i, vrho_i)
+
+         if (unrestricted) then
+            call eval_rho(ao, density, rho_a_blk)
+            call eval_rho(ao, density_beta, rho_b_blk)
+            ! libxc's polarised arrays are spin-interleaved.
+            if (allocated(rho_blk)) deallocate (rho_blk)
+            allocate (rho_blk(2*nb), exc_i(nb), vrho_i(2*nb))
+            do ig = 1, nb
+               rho_blk(2*ig - 1) = rho_a_blk(ig)
+               rho_blk(2*ig) = rho_b_blk(ig)
+            end do
+            do i = 1, ctx%n_func
+               exc_i = 0.0_dp
+               vrho_i = 0.0_dp
+               call xc_f03_lda_exc_vxc(ctx%func(i), int(nb, 8), rho_blk, exc_i, vrho_i)
+               do ig = 1, nb
+                  exc(g0 + ig - 1) = exc(g0 + ig - 1) + ctx%weight(i)*exc_i(ig)
+                  vrho(g0 + ig - 1) = vrho(g0 + ig - 1) + ctx%weight(i)*vrho_i(2*ig - 1)
+                  vrho_beta(g0 + ig - 1) = vrho_beta(g0 + ig - 1) &
+                                           + ctx%weight(i)*vrho_i(2*ig)
+               end do
+            end do
+            do ig = 1, nb
+               rho(g0 + ig - 1) = rho_a_blk(ig)
+               rho_beta(g0 + ig - 1) = rho_b_blk(ig)
+            end do
+         else
+            call eval_rho(ao, density, rho_blk)
+            allocate (exc_i(nb), vrho_i(nb))
+            do i = 1, ctx%n_func
+               exc_i = 0.0_dp
+               vrho_i = 0.0_dp
+               call xc_f03_lda_exc_vxc(ctx%func(i), int(nb, 8), rho_blk, exc_i, vrho_i)
+               do ig = 1, nb
+                  exc(g0 + ig - 1) = exc(g0 + ig - 1) + ctx%weight(i)*exc_i(ig)
+                  vrho(g0 + ig - 1) = vrho(g0 + ig - 1) + ctx%weight(i)*vrho_i(ig)
+               end do
+            end do
+            do ig = 1, nb
+               rho(g0 + ig - 1) = rho_blk(ig)
+            end do
+         end if
+      end do
+#else
+      call error%set(ERROR_VALIDATION, "no libxc in this build")
+#endif
+   end subroutine xc_grid_lda_quantities
 
    subroutine xc_add_potential(ctx, mol, density, v_xc, e_xc, n_elec, error)
       !! The exchange-correlation potential and energy for one density

--- a/src/methods/mqc_dft_grid.f90
+++ b/src/methods/mqc_dft_grid.f90
@@ -86,7 +86,22 @@ module mqc_dft_grid
       integer :: n_points = 0
       real(dp), allocatable :: coords(:, :)  !! (3, n_points), Bohr
       real(dp), allocatable :: weights(:)    !! (n_points), full volume weight
+      real(dp), allocatable :: quad_weights(:)
+         !! (n_points), the radial times angular weight *before* the Becke
+         !! partition multiplies it in. Kept because a gradient needs the
+         !! partition weight and the quadrature weight separately -- the
+         !! partition depends on where the nuclei are and the quadrature does
+         !! not, so only one of the two carries a derivative. Recovering it by
+         !! dividing `weights` by the partition would divide by zero exactly
+         !! where the partition underflows.
       integer, allocatable :: atom(:)        !! (n_points), owning atom
+      ! What the partition was built with. Recorded because a gradient has to
+      ! differentiate the same partition the energy integrated over, and a
+      ! caller reconstructing these from defaults would silently differentiate
+      ! a different one the moment the defaults changed.
+      integer :: scheme = PARTITION_BECKE
+      integer :: adjust = ADJUST_TREUTLER
+      integer, allocatable :: numbers(:)     !! (n_atoms), Z, for the partition radii
    contains
       procedure :: destroy => dft_grid_destroy
    end type dft_grid_t
@@ -235,6 +250,10 @@ contains
          if (allocated(sphere)) deallocate (sphere, w_ang)
       end do
 
+      grid%scheme = used_scheme
+      grid%adjust = used_adjust
+      allocate (grid%numbers(n_atoms), source=atomic_numbers)
+
       call apply_partition(grid, atom_coords, atomic_numbers, used_scheme, used_adjust, error)
    end subroutine build_dft_grid
 
@@ -268,6 +287,10 @@ contains
                                    grid%atom, scheme, adjust, cell, error)
       if (error%has_error()) return
 
+      ! Before, not after: this is the quadrature weight on its own.
+      if (allocated(grid%quad_weights)) deallocate (grid%quad_weights)
+      allocate (grid%quad_weights(grid%n_points), source=grid%weights)
+
       grid%weights = grid%weights*cell
    end subroutine apply_partition
 
@@ -278,6 +301,8 @@ contains
       this%n_points = 0
       if (allocated(this%coords)) deallocate (this%coords)
       if (allocated(this%weights)) deallocate (this%weights)
+      if (allocated(this%quad_weights)) deallocate (this%quad_weights)
+      if (allocated(this%numbers)) deallocate (this%numbers)
       if (allocated(this%atom)) deallocate (this%atom)
    end subroutine dft_grid_destroy
 

--- a/src/methods/mqc_dft_partition.f90
+++ b/src/methods/mqc_dft_partition.f90
@@ -39,6 +39,7 @@ module mqc_dft_partition
    public :: PARTITION_BECKE, PARTITION_STRATMANN
    public :: ADJUST_NONE, ADJUST_BECKE, ADJUST_TREUTLER
    public :: becke_partition_weights
+   public :: becke_partition_derivatives
    public :: partition_scheme_name
 
    !> Cutoff profile
@@ -177,6 +178,149 @@ contains
       end do
    end subroutine becke_partition_weights
 
+   subroutine becke_partition_derivatives(points, atom_coords, atomic_numbers, owner, &
+                                          scheme, adjust, dweights, error)
+      !! dP_k/dR_A at fixed grid points, as (3, n_atoms, n_points)
+      !!
+      !! The partition weight depends on every nuclear position, so moving any
+      !! atom changes the weight of every point -- including points owned by
+      !! other atoms. That is the whole content of the "grid response" term in
+      !! a DFT gradient, and omitting it leaves a gradient that looks entirely
+      !! reasonable and disagrees with finite differences at about 1e-4.
+      !!
+      !! **The grid points are held fixed here.** Points move with the atom that
+      !! owns them, but that motion is a separate contribution which the caller
+      !! adds; mixing the two into one routine would make neither checkable.
+      !!
+      !! The cell functions are differentiated by carrying the derivative
+      !! through the product alongside the value, rather than as a logarithmic
+      !! derivative summed at the end. The log form needs a division by each
+      !! cutoff factor, and those legitimately reach zero far from the molecule
+      !! -- where the value underflows to zero but the derivative does not, so
+      !! the quotient is 0/0 exactly where a guard would have to guess. Carrying
+      !! both costs an extra factor of the atom count and cannot divide by
+      !! anything.
+      real(dp), intent(in) :: points(:, :)       !! (3, n_points), Bohr
+      real(dp), intent(in) :: atom_coords(:, :)  !! (3, n_atoms), Bohr
+      integer, intent(in) :: atomic_numbers(:)   !! Z per atom, for the radii
+      integer, intent(in) :: owner(:)            !! Atom each point belongs to
+      integer, intent(in) :: scheme
+      integer, intent(in) :: adjust
+      real(dp), intent(out) :: dweights(:, :, :)  !! (3, n_atoms, n_points)
+      type(error_t), intent(inout) :: error
+
+      real(dp), allocatable :: shift(:, :), inv_distance(:, :)
+      real(dp), allocatable :: atom_r(:), unit_vec(:, :)
+      real(dp), allocatable :: cell(:), dcell(:, :, :)
+      real(dp) :: dtotal(3), rij(3), ds_i(3), ds_j(3), dmu_i(3), dmu_j(3)
+      real(dp) :: mu, nu, s, total, dnu_dmu, ds_dnu, invd
+      integer :: n_atoms, n_points, i, j, k, a
+
+      n_atoms = size(atom_coords, 2)
+      n_points = size(points, 2)
+      dweights = 0.0_dp
+
+      if (size(atomic_numbers) /= n_atoms) then
+         call error%set(ERROR_VALIDATION, &
+                        "partition derivatives: atomic_numbers does not match atom_coords")
+         return
+      end if
+      if (scheme /= PARTITION_BECKE .and. scheme /= PARTITION_STRATMANN) then
+         call error%set(ERROR_VALIDATION, "partition derivatives: unknown scheme")
+         return
+      end if
+
+      ! One atom owns everything and its weight is identically one, so it does
+      ! not change when the atom moves.
+      if (n_atoms == 1) return
+
+      allocate (shift(n_atoms, n_atoms), inv_distance(n_atoms, n_atoms))
+      allocate (atom_r(n_atoms), unit_vec(3, n_atoms))
+      allocate (cell(n_atoms), dcell(3, n_atoms, n_atoms))
+
+      call size_adjustment(atomic_numbers, adjust, shift)
+
+      inv_distance = 0.0_dp
+      do i = 1, n_atoms
+         do j = 1, n_atoms
+            if (i /= j) then
+               inv_distance(i, j) = 1.0_dp/norm2(atom_coords(:, i) - atom_coords(:, j))
+            end if
+         end do
+      end do
+
+      do k = 1, n_points
+         do i = 1, n_atoms
+            atom_r(i) = norm2(points(:, k) - atom_coords(:, i))
+            if (atom_r(i) > 0.0_dp) then
+               unit_vec(:, i) = (points(:, k) - atom_coords(:, i))/atom_r(i)
+            else
+               ! The point sits on the nucleus. |r - R| is not differentiable
+               ! there, and the quadrature never places a point exactly on one,
+               ! so this is a guard rather than a case.
+               unit_vec(:, i) = 0.0_dp
+            end if
+         end do
+
+         cell = 1.0_dp
+         dcell = 0.0_dp
+
+         do i = 1, n_atoms
+            do j = i + 1, n_atoms
+               invd = inv_distance(i, j)
+               rij = atom_coords(:, i) - atom_coords(:, j)
+
+               mu = (atom_r(i) - atom_r(j))*invd
+               nu = mu + shift(i, j)*(1.0_dp - mu*mu)
+
+               if (scheme == PARTITION_BECKE) then
+                  s = becke_cutoff(nu)
+                  ds_dnu = becke_cutoff_derivative(nu)
+               else
+                  s = stratmann_cutoff(nu)
+                  ds_dnu = stratmann_cutoff_derivative(nu)
+               end if
+
+               dnu_dmu = 1.0_dp - 2.0_dp*shift(i, j)*mu
+
+               ! mu depends on R_i and R_j only: through the distances from the
+               ! point, and through the internuclear distance in the denominator.
+               dmu_i = -unit_vec(:, i)*invd - (atom_r(i) - atom_r(j))*invd**3*rij
+               dmu_j = unit_vec(:, j)*invd + (atom_r(i) - atom_r(j))*invd**3*rij
+
+               ds_i = ds_dnu*dnu_dmu*dmu_i
+               ds_j = ds_dnu*dnu_dmu*dmu_j
+
+               ! Product rule, value and derivative together. Order matters:
+               ! the derivative uses the cell value from before this factor.
+               do a = 1, n_atoms
+                  dcell(:, a, i) = dcell(:, a, i)*s
+                  dcell(:, a, j) = dcell(:, a, j)*(1.0_dp - s)
+               end do
+               dcell(:, i, i) = dcell(:, i, i) + cell(i)*ds_i
+               dcell(:, j, i) = dcell(:, j, i) + cell(i)*ds_j
+               dcell(:, i, j) = dcell(:, i, j) - cell(j)*ds_i
+               dcell(:, j, j) = dcell(:, j, j) - cell(j)*ds_j
+
+               cell(i) = cell(i)*s
+               cell(j) = cell(j)*(1.0_dp - s)
+            end do
+         end do
+
+         total = sum(cell)
+         if (total <= 0.0_dp) cycle
+
+         do a = 1, n_atoms
+            dtotal = 0.0_dp
+            do i = 1, n_atoms
+               dtotal = dtotal + dcell(:, a, i)
+            end do
+            dweights(:, a, k) = (dcell(:, a, owner(k))*total &
+                                 - cell(owner(k))*dtotal)/(total*total)
+         end do
+      end do
+   end subroutine becke_partition_derivatives
+
    pure subroutine size_adjustment(atomic_numbers, adjust, shift)
       !! Pairwise shift applied to mu so unequal atoms get unequal cells
       integer, intent(in) :: atomic_numbers(:)
@@ -247,5 +391,40 @@ contains
          s = 0.5_dp*(1.0_dp - z)
       end if
    end function stratmann_cutoff
+
+   pure function becke_cutoff_derivative(nu) result(ds)
+      !! d/dnu of `becke_cutoff`
+      !!
+      !! Each iteration is p(x) = x(3 - x^2)/2 with p'(x) = 3(1 - x^2)/2, so the
+      !! chain rule over the three of them is the product of p' at the value
+      !! going into each.
+      real(dp), intent(in) :: nu
+      real(dp) :: ds
+      real(dp) :: f0, f1, f2
+
+      f0 = nu
+      f1 = 0.5_dp*f0*(3.0_dp - f0*f0)
+      f2 = 0.5_dp*f1*(3.0_dp - f1*f1)
+
+      ds = -0.5_dp*(1.5_dp*(1.0_dp - f2*f2)) &
+           *(1.5_dp*(1.0_dp - f1*f1)) &
+           *(1.5_dp*(1.0_dp - f0*f0))
+   end function becke_cutoff_derivative
+
+   pure function stratmann_cutoff_derivative(mu) result(ds)
+      !! d/dmu of `stratmann_cutoff`, zero where the cutoff is flat
+      real(dp), intent(in) :: mu
+      real(dp) :: ds
+      real(dp) :: z, z2
+
+      if (mu <= -STRATMANN_A .or. mu >= STRATMANN_A) then
+         ds = 0.0_dp
+      else
+         z = mu/STRATMANN_A
+         z2 = z*z
+         ds = -0.5_dp*(1.0_dp/16.0_dp) &
+              *(35.0_dp + z2*(-105.0_dp + z2*(105.0_dp - 35.0_dp*z2)))/STRATMANN_A
+      end if
+   end function stratmann_cutoff_derivative
 
 end module mqc_dft_partition

--- a/validation/check_partition_deriv.f90
+++ b/validation/check_partition_deriv.f90
@@ -1,0 +1,123 @@
+!! The Becke partition weight derivatives, on their own
+program check_partition_deriv
+   !! Checks `becke_partition_derivatives` against central differences of
+   !! `becke_partition_weights`, at fixed grid points.
+   !!
+   !! Checked here rather than only through the assembled DFT gradient, for the
+   !! reason the density-fitting derivative integrals were: a mistake in this
+   !! term produces a gradient of the right magnitude that disagrees with finite
+   !! differences for reasons that could be anywhere in the exchange-correlation
+   !! contribution. Differencing the partition function itself puts the error
+   !! where it happened.
+   !!
+   !! The partition is a smooth, purely geometric function of the nuclear
+   !! positions, so a central difference of it is good to about 1e-10 -- far
+   !! tighter than anything the assembled gradient can be checked to, which is
+   !! what makes this the sharper test of the two.
+   use pic_types, only: dp
+   use mqc_error, only: error_t
+   use mqc_dft_partition, only: becke_partition_weights, becke_partition_derivatives, &
+                                PARTITION_BECKE, PARTITION_STRATMANN, &
+                                ADJUST_NONE, ADJUST_TREUTLER
+   implicit none
+
+   integer :: n_bad
+
+   n_bad = 0
+
+   call one_case("water, Becke + Treutler", PARTITION_BECKE, ADJUST_TREUTLER, n_bad)
+   call one_case("water, Becke, no adjustment", PARTITION_BECKE, ADJUST_NONE, n_bad)
+   call one_case("water, Stratmann + Treutler", PARTITION_STRATMANN, ADJUST_TREUTLER, n_bad)
+
+   write (*, "(a)") ""
+   if (n_bad == 0) then
+      write (*, "(a)") "all partition derivative checks passed"
+   else
+      write (*, "(a,i0,a)") "FAILED: ", n_bad, " check(s)"
+      error stop 1
+   end if
+
+contains
+
+   subroutine one_case(label, scheme, adjust, n_bad)
+      character(len=*), intent(in) :: label
+      integer, intent(in) :: scheme, adjust
+      integer, intent(inout) :: n_bad
+
+      integer, parameter :: N_ATOMS = 3
+      integer, parameter :: N_POINTS = 7
+      real(dp), parameter :: STEP = 1.0e-5_dp
+
+      real(dp) :: coords(3, N_ATOMS), points(3, N_POINTS)
+      real(dp) :: shifted(3, N_ATOMS)
+      integer :: numbers(N_ATOMS), owner(N_POINTS)
+      real(dp) :: analytic(3, N_ATOMS, N_POINTS)
+      real(dp) :: w_plus(N_POINTS), w_minus(N_POINTS)
+      real(dp) :: numeric, worst, diff
+      integer :: ia, ic, k
+      type(error_t) :: error
+
+      numbers = [8, 1, 1]
+      coords = reshape([0.0_dp, 0.0_dp, 0.0_dp, &
+                        0.0_dp, -1.4308_dp, 1.1078_dp, &
+                        0.0_dp, 1.4308_dp, 1.1078_dp], [3, N_ATOMS])
+
+      ! Points scattered through the region where the partition actually
+      ! varies. A point far outside every cell has a weight of one or zero and
+      ! a derivative of zero, which would pass without testing anything.
+      points = reshape([0.3_dp, 0.2_dp, 0.4_dp, &
+                        0.0_dp, -0.7_dp, 0.6_dp, &
+                        0.1_dp, 0.9_dp, 0.5_dp, &
+                        -0.4_dp, 0.0_dp, 1.3_dp, &
+                        0.6_dp, -1.1_dp, 0.9_dp, &
+                        0.2_dp, 1.2_dp, 1.4_dp, &
+                        0.0_dp, 0.0_dp, 2.1_dp], [3, N_POINTS])
+      owner = [1, 2, 3, 1, 2, 3, 1]
+
+      call becke_partition_derivatives(points, coords, numbers, owner, scheme, adjust, &
+                                       analytic, error)
+      if (error%has_error()) then
+         write (*, "(a,a)") "FAIL: ", error%get_message()
+         n_bad = n_bad + 1
+         return
+      end if
+
+      worst = 0.0_dp
+      do ia = 1, N_ATOMS
+         do ic = 1, 3
+            shifted = coords
+            shifted(ic, ia) = coords(ic, ia) + STEP
+            call becke_partition_weights(points, shifted, numbers, owner, scheme, adjust, &
+                                         w_plus, error)
+            if (error%has_error()) then
+               write (*, "(a,a)") "FAIL: ", error%get_message()
+               n_bad = n_bad + 1
+               return
+            end if
+
+            shifted = coords
+            shifted(ic, ia) = coords(ic, ia) - STEP
+            call becke_partition_weights(points, shifted, numbers, owner, scheme, adjust, &
+                                         w_minus, error)
+            if (error%has_error()) then
+               write (*, "(a,a)") "FAIL: ", error%get_message()
+               n_bad = n_bad + 1
+               return
+            end if
+
+            do k = 1, N_POINTS
+               numeric = (w_plus(k) - w_minus(k))/(2.0_dp*STEP)
+               diff = abs(numeric - analytic(ic, ia, k))
+               worst = max(worst, diff)
+            end do
+         end do
+      end do
+
+      write (*, "(a,a,a,es12.4)") "== ", label, "   largest deviation: ", worst
+      if (worst > 1.0e-8_dp) then
+         write (*, "(a)") "  FAIL: the analytic partition derivative is wrong"
+         n_bad = n_bad + 1
+      end if
+   end subroutine one_case
+
+end program check_partition_deriv

--- a/validation/check_scf_gradient.f90
+++ b/validation/check_scf_gradient.f90
@@ -24,6 +24,7 @@ program check_scf_gradient
    use mqc_libcint_integrals, only: libcint_molecule_t, build_libcint_molecule
    use mqc_libcint_rhf, only: rhf_result_t, run_libcint_rhf, run_libcint_uhf
    use mqc_libcint_gradient, only: libcint_scf_gradient
+   use mqc_libcint_xc, only: xc_context_t, xc_context_create, xc_available
    implicit none
 
    integer, parameter :: N_DIM = 3
@@ -88,6 +89,35 @@ program check_scf_gradient
 
    call check_unrestricted_df_channels(n_bad)
 
+   ! Kohn-Sham. SVWN is Slater exchange with VWN correlation -- a pure local
+   ! functional, so the exchange-correlation gradient is exercised with no Fock
+   ! exchange derivative mixed into it. Skipped rather than failed on a build
+   ! without libxc, which is the default.
+   if (xc_available()) then
+      call check_case("H2O / sto-3g, SVWN (RKS)", [8, 1, 1], ["O", "H", "H"], &
+                      reshape([0.0_dp, 0.0_dp, 0.0_dp, &
+                               0.0_dp, -1.4308_dp, 1.1078_dp, &
+                               0.0_dp, 1.4308_dp, 1.1078_dp], [N_DIM, 3]), &
+                      "sto-3g", 10, 1, n_bad, functional="svwn")
+
+      call check_case("HCN / sto-3g, SVWN (RKS)", [1, 6, 7], ["H", "C", "N"], &
+                      reshape([0.0_dp, 0.0_dp, -2.0_dp, &
+                               0.0_dp, 0.0_dp, 0.0_dp, &
+                               0.0_dp, 0.0_dp, 2.2_dp], [N_DIM, 3]), &
+                      "sto-3g", 14, 1, n_bad, functional="svwn")
+
+      call check_case("CH3 doublet / sto-3g, SVWN (UKS)", [6, 1, 1, 1], &
+                      ["C", "H", "H", "H"], &
+                      reshape([0.0_dp, 0.0_dp, 0.0_dp, &
+                               2.05_dp, 0.0_dp, 0.0_dp, &
+                               -1.02_dp, 1.78_dp, 0.0_dp, &
+                               -1.02_dp, -1.78_dp, 0.3_dp], [N_DIM, 4]), &
+                      "sto-3g", 9, 2, n_bad, functional="svwn")
+   else
+      write (*, "(a)") ""
+      write (*, "(a)") "== Kohn-Sham cases skipped: this build has no libxc"
+   end if
+
    write (*, "(a)") ""
    if (n_bad == 0) then
       write (*, "(a)") "all gradient checks passed"
@@ -99,7 +129,7 @@ program check_scf_gradient
 contains
 
    subroutine check_case(label, numbers, symbols, coords, basis, nelec, multiplicity, &
-                         n_bad, aux_basis)
+                         n_bad, aux_basis, functional)
       character(len=*), intent(in) :: label
       integer, intent(in) :: numbers(:)
       character(len=*), intent(in) :: symbols(:)
@@ -109,6 +139,8 @@ contains
       integer, intent(inout) :: n_bad
       character(len=*), intent(in), optional :: aux_basis
          !! Present fits J and K, and differentiates the fitted energy
+      character(len=*), intent(in), optional :: functional
+         !! Present makes it Kohn-Sham, and adds the exchange-correlation term
 
       real(dp), allocatable :: analytic(:, :), numeric(:, :)
       real(dp) :: translation(3)
@@ -122,7 +154,7 @@ contains
       write (*, "(a,a)") "== ", label
 
       call gradient_at(numbers, symbols, coords, basis, nelec, multiplicity, &
-                       analytic, error, aux_basis)
+                       analytic, error, aux_basis, functional)
       if (error%has_error()) then
          write (*, "(a,a)") "FAIL: ", error%get_message()
          n_bad = n_bad + 1
@@ -130,7 +162,7 @@ contains
       end if
 
       call numeric_gradient(numbers, symbols, coords, basis, nelec, multiplicity, &
-                            numeric, error, aux_basis)
+                            numeric, error, aux_basis, functional)
       if (error%has_error()) then
          write (*, "(a,a)") "FAIL (finite difference): ", error%get_message()
          n_bad = n_bad + 1
@@ -253,7 +285,7 @@ contains
    end subroutine check_unrestricted_df_channels
 
    subroutine gradient_at(numbers, symbols, coords, basis, nelec, multiplicity, &
-                          gradient, error, aux_basis)
+                          gradient, error, aux_basis, functional)
       !! Converge an SCF at this geometry and differentiate it
       integer, intent(in) :: numbers(:)
       character(len=*), intent(in) :: symbols(:)
@@ -263,15 +295,51 @@ contains
       real(dp), allocatable, intent(out) :: gradient(:, :)
       type(error_t), intent(inout) :: error
       character(len=*), intent(in), optional :: aux_basis
+      character(len=*), intent(in), optional :: functional
 
       type(libcint_molecule_t) :: mol, aux
       type(rhf_result_t) :: scf
+      type(xc_context_t) :: xc
 
       call build_libcint_molecule(numbers, symbols, coords, basis, mol, error)
       if (error%has_error()) return
       if (present(aux_basis)) then
          call build_libcint_molecule(numbers, symbols, coords, aux_basis, aux, error)
          if (error%has_error()) return
+      end if
+
+      ! Kohn-Sham. Kept apart from the Hartree-Fock branches below rather than
+      ! threaded through them: the SCF and the gradient both need the same
+      ! context, and building it twice would integrate the energy on one grid
+      ! and differentiate it on another.
+      if (present(functional)) then
+         call xc_context_create(mol, functional, xc, error, &
+                                polarized=(multiplicity /= 1))
+         if (error%has_error()) return
+         if (multiplicity == 1) then
+            call run_libcint_rhf(mol, nelec, 200, 1.0e-12_dp, 1.0e-10_dp, .false., scf, &
+                                 error, xc=xc)
+            if (error%has_error()) return
+            call libcint_scf_gradient(mol, scf%density, &
+                                      orbitals=scf%orbitals, &
+                                      orbital_energies=scf%orbital_energies, &
+                                      n_occupied=scf%n_occupied, &
+                                      gradient=gradient, error=error, xc=xc)
+         else
+            call run_libcint_uhf(mol, nelec, multiplicity, 200, 1.0e-12_dp, 1.0e-10_dp, &
+                                 .false., scf, error, xc=xc)
+            if (error%has_error()) return
+            call libcint_scf_gradient(mol, scf%density, &
+                                      density_beta=scf%density_beta, &
+                                      orbitals=scf%orbitals, &
+                                      orbitals_beta=scf%orbitals_beta, &
+                                      orbital_energies=scf%orbital_energies, &
+                                      orbital_energies_beta=scf%orbital_energies_beta, &
+                                      n_occupied=scf%n_occupied, &
+                                      n_occupied_beta=scf%n_occupied_beta, &
+                                      gradient=gradient, error=error, xc=xc)
+         end if
+         return
       end if
 
       if (multiplicity == 1) then
@@ -310,7 +378,7 @@ contains
    end subroutine gradient_at
 
    subroutine energy_at(numbers, symbols, coords, basis, nelec, multiplicity, energy, &
-                        error, aux_basis)
+                        error, aux_basis, functional)
       !! One converged SCF energy, for the finite difference
       integer, intent(in) :: numbers(:)
       character(len=*), intent(in) :: symbols(:)
@@ -320,9 +388,11 @@ contains
       real(dp), intent(out) :: energy
       type(error_t), intent(inout) :: error
       character(len=*), intent(in), optional :: aux_basis
+      character(len=*), intent(in), optional :: functional
 
       type(libcint_molecule_t) :: mol, aux
       type(rhf_result_t) :: scf
+      type(xc_context_t) :: xc
 
       energy = 0.0_dp
       call build_libcint_molecule(numbers, symbols, coords, basis, mol, error)
@@ -332,7 +402,22 @@ contains
          if (error%has_error()) return
       end if
 
-      if (multiplicity == 1) then
+      if (present(functional)) then
+         ! The same grid the analytic gradient differentiates. `xc_context_create`
+         ! builds the grid from the geometry it is handed, so a displaced point
+         ! gets a displaced grid -- which is what makes the finite difference a
+         ! test of the grid response rather than of nothing.
+         call xc_context_create(mol, functional, xc, error, &
+                                polarized=(multiplicity /= 1))
+         if (error%has_error()) return
+         if (multiplicity == 1) then
+            call run_libcint_rhf(mol, nelec, 200, 1.0e-12_dp, 1.0e-10_dp, .false., scf, &
+                                 error, xc=xc)
+         else
+            call run_libcint_uhf(mol, nelec, multiplicity, 200, 1.0e-12_dp, 1.0e-10_dp, &
+                                 .false., scf, error, xc=xc)
+         end if
+      else if (multiplicity == 1) then
          if (present(aux_basis)) then
             call run_libcint_rhf(mol, nelec, 200, 1.0e-12_dp, 1.0e-10_dp, .false., scf, &
                                  error, aux=aux)
@@ -348,7 +433,7 @@ contains
    end subroutine energy_at
 
    subroutine numeric_gradient(numbers, symbols, coords, basis, nelec, multiplicity, &
-                               gradient, error, aux_basis)
+                               gradient, error, aux_basis, functional)
       !! Central differences on the SCF energy
       !!
       !! The step is a compromise the tolerance above is set from: too large
@@ -363,6 +448,7 @@ contains
       real(dp), allocatable, intent(out) :: gradient(:, :)
       type(error_t), intent(inout) :: error
       character(len=*), intent(in), optional :: aux_basis
+      character(len=*), intent(in), optional :: functional
 
       real(dp), parameter :: step = 0.002_dp
       real(dp), allocatable :: shifted(:, :)
@@ -379,13 +465,13 @@ contains
             shifted = coords
             shifted(ic, ia) = coords(ic, ia) + step
             call energy_at(numbers, symbols, shifted, basis, nelec, multiplicity, e_plus, &
-                           error, aux_basis)
+                           error, aux_basis, functional)
             if (error%has_error()) return
 
             shifted = coords
             shifted(ic, ia) = coords(ic, ia) - step
             call energy_at(numbers, symbols, shifted, basis, nelec, multiplicity, e_minus, &
-                           error, aux_basis)
+                           error, aux_basis, functional)
             if (error%has_error()) return
 
             gradient(ic, ia) = (e_plus - e_minus)/(2.0_dp*step)


### PR DESCRIPTION
Analytic Kohn-Sham gradients at the LDA rung. Beyond the Hartree-Fock terms this
needs the derivative of the exchange-correlation quadrature itself: the grid
weights move with the nuclei they are centred on, so the weight derivatives
contribute and omitting them leaves a gradient that looks plausible and is wrong.

Commit:
- `Kohn-Sham gradients on the CPU backend, LDA`

---

**Stack 2 of 2 — CPU analytic gradients.** Third of four.

1. #177 `feat/cpu-gradients` → `main`
2. #178 `feat/cpu-gradients-df` → `feat/cpu-gradients`
3. **this PR** `feat/cpu-gradients-dft` → `feat/cpu-gradients-df`
4. `feat/cpu-gradients-gga` → `feat/cpu-gradients-dft`

Please merge in order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)