### PR TITLE
Fix flaky distributed-polarizability test: tie on the yy diagonal

### DIFF
--- a/test/test_mqc_libcint_cphf.f90
+++ b/test/test_mqc_libcint_cphf.f90
@@ -451,11 +451,26 @@ contains
       do i = 1, size(tensors, 3)
          total = total + tensors(:, :, i)
       end do
+
+      ! Per component the core can only lower a diagonal or leave it be, so assert
+      ! that none *grows*. Not a strict `total < alpha`: water's 1s is spherical
+      ! and, for this orientation, decoupled from y, so it contributes nothing to
+      ! alpha_yy and that diagonal returns equal to the total to the last bit. A
+      ! strict comparison there is deciding a one-ULP difference on the sign of the
+      ! summation error, which flips between toolchains -- the flake this once was.
       do k = 1, 3
-         call check(error, total(k, k) < alpha(k, k), &
-                    "excluding the core did not reduce the polarizability")
+         call check(error, total(k, k) <= alpha(k, k) + 1.0e-10_dp, &
+                    "excluding the core increased a diagonal polarizability")
          if (allocated(error)) return
       end do
+
+      ! The reduction still has to appear somewhere, or n_core did nothing. It
+      ! lands in the trace, which falls by the core's whole contribution -- about
+      ! 6e-4 here, far above the per-component rounding -- so assert that robustly.
+      call check(error, total(1, 1) + total(2, 2) + total(3, 3) < &
+                 alpha(1, 1) + alpha(2, 2) + alpha(3, 3), &
+                 "excluding the core did not reduce the total polarizability")
+      if (allocated(error)) return
       call check(error, abs(total(1, 2) - alpha(1, 2)) < 1.0e-4_dp, &
                  "excluding the core moved an off-diagonal component, but a "// &
                  "spherical core should contribute only to the diagonal")


### PR DESCRIPTION
## What

Fixes the intermittent `mqc_libcint_cphf → distributed_tensors_sum_to_the_total` failure ("excluding the core did not reduce the polarizability"). **Test-only change; no code touched.**

## Why it flakes

The test drops water's 1s core (`n_core=1`) and asserts each diagonal of the polarizability shrinks, with a strict, tolerance-free `total(k,k) < alpha(k,k)`. Measured values:

| diagonal | full `alpha` | core-excluded `total` | diff |
|---|---|---|---|
| xx | 3.27823137 | 3.27798355 | −2.48e-04 ✓ |
| **yy** | **4.195568346002e-02** | **4.195568346002e-02** | **+2.08e-17** ✗ |
| zz | 4.06081346 | 4.06047682 | −3.37e-04 ✓ |

The core lowers xx and zz by ~3e-4, but it's spherical and — for this orientation — decoupled from y, so it contributes **nothing** to `alpha_yy`. That diagonal returns equal to the total to the last bit; the difference is **one ULP** (2e-17 on 0.042). A strict `<` on a tie is decided by the sign of the rounding error, which is set by summation order and **flips between toolchains** — passing where it was written, failing under a different BLAS / thread count. It reproduces deterministically under gfortran-15 (every thread count 1/2/4/8); couldn't be reproduced upstream.

## The fix

Assert the physics, not the rounding:
- **Per component:** `<` → `<= alpha(k,k) + 1e-10` — the core can only lower a diagonal or leave it be, so this forbids a genuine *increase* (margin sits well above the 2e-17 tie, well below the 3e-4 real reductions) without adjudicating a tie.
- **Trace:** added a strict `Σ total(k,k) < Σ alpha(k,k)` — the reduction (~6e-4) lands robustly in the trace, so this still proves `n_core` actually did something.

## Verification

Built against current `main`. All 9 `mqc_libcint_cphf` subtests pass at `OMP_NUM_THREADS` = 1, 4, 8. `polarizability_matches_a_finite_field` continues to pass, confirming the polarizability itself was always correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)