### PR TITLE
validation 

### DIFF
--- a/backends/libcint/mqc_libcint_bridge.f90
+++ b/backends/libcint/mqc_libcint_bridge.f90
@@ -28,6 +28,7 @@ module mqc_libcint_bridge
    use mqc_libcint_atomic_guess, only: build_atomic_guess, parse_guess_name, &
                                        guess_display_name
    use mqc_libcint_xc, only: xc_context_t, xc_context_create, xc_available
+   use mqc_libcint_gradient, only: libcint_scf_gradient
    use mqc_libcint_mp2, only: mp2_result_t, run_libcint_mp2, run_libcint_ri_mp2
    use mqc_libcint_cc, only: cc_result_t, run_libcint_ccsd
    use mqc_program_limits, only: MAX_LINE_LENGTH
@@ -170,32 +171,47 @@ contains
       type(calculation_result_t), intent(inout) :: result
       logical, intent(in), optional :: want_gradient
 
-      type(libcint_molecule_t) :: mol, aux, corr_aux
+      ! `aux` and `xc` are targets because the gradient takes both as optional
+      ! arguments, and a disassociated pointer is how "this SCF fitted nothing"
+      ! and "this SCF had no functional" are said without four spellings of the
+      ! same call.
+      type(libcint_molecule_t) :: mol, corr_aux
+      type(libcint_molecule_t), target :: aux
+      type(libcint_molecule_t), pointer :: aux_arg
       type(rhf_result_t) :: scf
       type(error_t) :: error
       character(len=MAX_ELEMENT_SYMBOL_LEN), allocatable :: symbols(:)
       integer :: iatom, diis_size, guess_kind
-      logical :: unrestricted
+      logical :: unrestricted, do_gradient
       ! Left unallocated for the guesses that need no free-atom solutions. An
       ! unallocated allocatable passed to an optional dummy is an absent
       ! argument, so the SCF calls below need no branching on which guess ran.
       real(dp), allocatable :: guess_a(:, :), guess_b(:, :), guess_total(:, :)
       type(error_t) :: guess_error
-      type(xc_context_t) :: xc
+      type(xc_context_t), target :: xc
+      type(xc_context_t), pointer :: xc_arg
       logical :: kohn_sham
 
       character(len=MAX_LINE_LENGTH) :: line
 
-      if (present(want_gradient)) then
-         if (want_gradient) then
-            ! libcint has the derivative entry points -- ip1 and ipovlp -- so
-            ! this is a gap rather than a wall, but an untested gradient is
-            ! worse than an absent one.
-            call result%error%set(ERROR_VALIDATION, "the CPU backend has no gradients "// &
-                                  "yet; run an energy, or build with cuEST")
-            result%has_error = .true.
-            return
-         end if
+      do_gradient = .false.
+      if (present(want_gradient)) do_gradient = want_gradient
+
+      ! What is differentiated here is the SCF energy, and nothing above it. A
+      ! correlated method asked for alongside a gradient would get the
+      ! reference gradient reported against a correlated energy -- of the right
+      ! magnitude, and wrong by the whole relaxation, with nothing in the
+      ! output to say which of the two numbers the other belongs to. The
+      ! functional-side gaps (range separation, meta-GGA) are refused inside
+      ! the gradient itself, where the functional is known.
+      if (do_gradient .and. (settings%run_mp2 .or. settings%run_cc)) then
+         call result%error%set(ERROR_VALIDATION, "the CPU gradient differentiates the "// &
+                               "SCF energy: MP2 and coupled cluster gradients need a "// &
+                               "relaxed density and a response solve, which are not "// &
+                               "written yet. Run the gradient at the reference level, "// &
+                               "or the correlated method as an energy.")
+         result%has_error = .true.
+         return
       end if
 
       ! Same rule the GPU backend applies, so a deck does not change meaning
@@ -438,7 +454,8 @@ contains
                               settings%density_tol, settings%verbose, scf, error, &
                               aux=aux, diis_vectors=diis_size, guess=guess_kind, &
                               guess_density=guess_total, xc=xc)
-         call aux%destroy()
+         ! Kept alive: the gradient below has to be told the same auxiliary
+         ! basis this SCF fitted with. Released once past it.
       else if (unrestricted) then
          call run_libcint_uhf(mol, fragment%nelec, fragment%multiplicity, settings%max_iter, &
                               settings%energy_tol, settings%density_tol, settings%verbose, &
@@ -453,6 +470,7 @@ contains
       if (error%has_error()) then
          call result%error%set(ERROR_VALIDATION, error%get_message())
          result%has_error = .true.
+         call aux%destroy()
          call mol%destroy()
          return
       end if
@@ -470,12 +488,56 @@ contains
          call result%error%set(ERROR_VALIDATION, "SCF not converged in "// &
                                to_text(scf%iterations)//" cycles")
          result%has_error = .true.
+         call aux%destroy()
          call mol%destroy()
          return
       end if
 
       result%energy%scf = scf%energy
       result%has_energy = .true.
+
+      ! ---- dE/dR, analytically ----------------------------------------------
+      !
+      ! Differentiating the energy that was just converged, which is why the
+      ! auxiliary basis handed over is the one the SCF fitted with rather than
+      ! whatever the deck names: a fitted energy differentiated as an exact one
+      ! is a gradient of a function nobody computed.
+      if (do_gradient) then
+         aux_arg => null()
+         xc_arg => null()
+         if (settings%density_fitting) aux_arg => aux
+         if (kohn_sham) xc_arg => xc
+
+         if (unrestricted) then
+            call libcint_scf_gradient(mol, scf%density, density_beta=scf%density_beta, &
+                                      orbitals=scf%orbitals, orbitals_beta=scf%orbitals_beta, &
+                                      orbital_energies=scf%orbital_energies, &
+                                      orbital_energies_beta=scf%orbital_energies_beta, &
+                                      n_occupied=scf%n_occupied, &
+                                      n_occupied_beta=scf%n_occupied_beta, &
+                                      gradient=result%gradient, error=error, &
+                                      aux=aux_arg, xc=xc_arg)
+         else
+            call libcint_scf_gradient(mol, scf%density, orbitals=scf%orbitals, &
+                                      orbital_energies=scf%orbital_energies, &
+                                      n_occupied=scf%n_occupied, &
+                                      gradient=result%gradient, error=error, &
+                                      aux=aux_arg, xc=xc_arg)
+         end if
+         if (error%has_error()) then
+            call result%error%set(ERROR_VALIDATION, "gradient: "//error%get_message())
+            result%has_error = .true.
+            if (kohn_sham) call xc%destroy()
+            call aux%destroy()
+            call mol%destroy()
+            return
+         end if
+         result%has_gradient = .true.
+         if (settings%verbose) then
+            write (*, "(a,f20.12)") "  |gradient|     ", sqrt(sum(result%gradient**2))
+         end if
+      end if
+      call aux%destroy()
 
       if (settings%run_mp2) then
          block

--- a/mqc_docs/source/json_output.rst
+++ b/mqc_docs/source/json_output.rst
@@ -47,6 +47,12 @@ Several fields appear across multiple output types:
    * - ``total_energy``
      - float
      - Total electronic energy in Hartree
+   * - ``gradient``
+     - array
+     - Nuclear gradient, one ``[x, y, z]`` triple per atom in input order (Hartree/Bohr)
+   * - ``gradient_units``
+     - string
+     - Units the components are written in; always ``hartree/bohr``
    * - ``gradient_norm``
      - float
      - Euclidean norm of the nuclear gradient (Hartree/Bohr)
@@ -77,6 +83,12 @@ Schema
          "magnitude_debye": 1.923456789012
        },
        "gradient_norm": 0.012345678901,
+       "gradient_units": "hartree/bohr",
+       "gradient": [
+         [0.0, 0.0, -0.067617391054],
+         [0.0, -0.016791268486, 0.033808695649],
+         [0.0, 0.016791268169, 0.033808695405]
+       ],
        "hessian_frobenius_norm": 1.234567890123
      }
    }
@@ -88,8 +100,17 @@ All fields are optional depending on the calculation type:
 
 - ``total_energy``: Present for Energy, Gradient, and Hessian calculations
 - ``dipole``: Present when dipole moments are computed
-- ``gradient_norm``: Present for Gradient and Hessian calculations
+- ``gradient``, ``gradient_units``, ``gradient_norm``: Present for Gradient and
+  Hessian calculations
 - ``hessian_frobenius_norm``: Present for Hessian calculations
+
+The components are what a validation case compares. A norm cannot tell a
+correct gradient from one with a sign error, a swapped pair of atoms, or a
+wrong component that happens to preserve the magnitude, so
+``validation/run_validation.py`` reads ``gradient`` and compares element by
+element against ``expected_gradient`` in the manifest -- and reports the
+translational residual, :math:`\sum_A \partial E/\partial R_A`, which should
+vanish, while it is there.
 
 MBE Detailed Breakdown
 ======================

--- a/mqc_docs/source/validation.rst
+++ b/mqc_docs/source/validation.rst
@@ -634,6 +634,40 @@ The ``validation_tests.json`` file has the following structure:
 - ``expected_energy``: Expected total energy (for single molecule tests)
 - ``expected_energies``: Dictionary of expected energies (for multi-molecule tests)
 - ``type``: Test type (``unfragmented``, ``fragmented``, or ``multi_molecule``)
+- ``expected_gradient``: Expected nuclear gradient, one ``[x, y, z]`` triple per
+  atom in Hartree/Bohr, compared component by component
+- ``gradient_tolerance``: Bound on each gradient component (default ``1.0e-7``)
+- ``check_translation``: Fail the case when :math:`\sum_A \partial E/\partial R_A`
+  exceeds ``translation_tolerance`` (default ``1.0e-8``). Off by default, where
+  a non-zero residual is only reported
+
+Gradients
+---------
+
+A gradient case pins every component rather than ``expected_gradient_norm``,
+which is still read and still passes but cannot distinguish a correct gradient
+from one with a sign error, a swapped pair of atoms, or a wrong component that
+preserves the magnitude.
+
+The translational residual is free -- it needs no reference value -- and is
+printed for any case whose output carries gradient components. Treat it as a
+smoke test rather than a criterion: it is structurally blind to
+exchange-correlation terms, because a rigid translation leaves the Becke
+partition unchanged, and it has passed at 2e-15 over an exchange-correlation
+gradient term wrong by 0.77 Hartree/Bohr.
+
+Set the SCF convergence tighter than usual in a gradient deck. The gradient is
+a derivative of the converged energy, so an unconverged density shows up in it
+linearly rather than quadratically: the CPU gradient cases stop the SCF at
+``1e-11``, and at the suite default of ``1e-8`` they sat ~1e-7 from PySCF for
+that reason alone.
+
+The CPU gradient cases are generated, not hand-written -- see
+``tools/cpu_validation/gen_cpu_validation.py``, whose ``GRADIENT_CASES`` table
+adds one case per code path. Their references come from PySCF with
+``grid_response = True``, which is not its default: without it PySCF omits the
+derivative of the quadrature weights while metalquicha includes it, and the two
+disagree by ~1e-4 with nothing wrong on either side.
 
 Contributing New Tests
 ======================

--- a/python/examples/backends.py
+++ b/python/examples/backends.py
@@ -58,7 +58,15 @@ HF_DIMER_STO3G = -149.922856255009
 #: against, and a tighter tolerance would be false precision.
 XTB_WATER = -5.070544
 
+#: PySCF RHF/sto-3g nuclear gradient norm on the WATER geometry, in
+#: Hartree/Bohr, from the same basis JSON this program reads. The CPU backend
+#: refused gradients when this file was written and now computes them, so what
+#: was a check that it refused cleanly is now a check that it is right --
+#: the property the refusal was standing in for.
+HF_WATER_STO3G_GRAD_NORM = 0.086151389909
+
 TOL_HF = 1.0e-6      # against PySCF
+TOL_GRAD = 1.0e-6    # against PySCF, on the gradient norm
 TOL_XTB = 1.0e-4     # against ourselves; loose on purpose
 TOL_CLOSURE = 1.0e-8 # MBE(2) against the supermolecule; exact, so tight
 
@@ -96,32 +104,42 @@ def standalone_hf_df():
 
 
 def gradient_support():
-    """Gradients work through tblite and are refused by libcint.
+    """Both backends produce a gradient, and the CPU one produces the right one.
 
-    Not a limitation being papered over -- the CPU backend says so and stops,
-    which is the right behaviour for a derivative nobody has tested. What this
-    checks is that it stays a clean refusal rather than becoming a wrong
-    number, and that asking xTB for the same thing still works.
+    This used to assert that libcint *refused*, which was correct when no CPU
+    derivative existed: a clean refusal beats a wrong number. Now that the
+    gradients are implemented the refusal is gone, and checking merely that
+    something came back would drop the guard without replacing it. So the
+    number itself is checked, against PySCF on the same geometry and the same
+    basis data -- which is what the refusal was protecting all along.
+
+    Returns (cpu_norm, cpu_ok, xtb_ok). `cpu_norm` is None if the run produced
+    no gradient at all, which is a failure now rather than the expected result.
     """
     system = mqc.System(**WATER)
     system.set_monomers([[0, 1, 2]])
 
-    refused = False
+    # write_to_file=True because the norm travels in the output document, the
+    # same route `gap_ev` takes.
+    cpu_norm = None
     try:
-        mqc.MBE(system, level=0, method="hf", basis="sto-3g", driver="gradient").run(
-            label="py_grad_hf", write_to_file=False)
-    except mqc.MQCError as exc:
-        refused = "gradient" in str(exc).lower()
+        result = mqc.MBE(system, level=0, method="hf", basis="sto-3g",
+                         driver="gradient").run(label="py_grad_hf", write_to_file=True)
+        cpu_norm = result.gradient_norm
+    except mqc.MQCError:
+        cpu_norm = None
+    cpu_ok = (cpu_norm is not None
+              and abs(cpu_norm - HF_WATER_STO3G_GRAD_NORM) <= TOL_GRAD)
 
-    worked = False
+    xtb_ok = False
     try:
         mqc.MBE(system, level=0, method="gfn2", driver="gradient").run(
             label="py_grad_xtb", write_to_file=False)
-        worked = True
+        xtb_ok = True
     except mqc.MQCError:
-        worked = False
+        xtb_ok = False
 
-    return refused, worked
+    return cpu_norm, cpu_ok, xtb_ok
 
 
 def fragmented_xtb():
@@ -194,11 +212,20 @@ def main(argv):
             if not ok:
                 failures.append(f"{name}: {energy} vs {expected}, diff {delta:.2e} > {tol:.1e}")
 
-        refused, worked = gradient_support()
-        print(f"  {'gradients':<18} libcint refuses: {refused}   tblite provides: {worked}")
-        if not refused:
-            failures.append("the CPU backend must refuse gradients, not return one")
-        if not worked:
+        cpu_norm, cpu_ok, xtb_ok = gradient_support()
+        shown = f"{cpu_norm:.9f}" if cpu_norm is not None else "none"
+        delta = (abs(cpu_norm - HF_WATER_STO3G_GRAD_NORM)
+                 if cpu_norm is not None else float("inf"))
+        print(f"  {'gradient hf':<18} {shown:>18}   ref "
+              f"{HF_WATER_STO3G_GRAD_NORM:>18.9f} (PySCF)   diff {delta:.2e}   "
+              f"{'ok' if cpu_ok else 'FAIL'}")
+        print(f"  {'gradient xtb':<18} {'provided' if xtb_ok else 'MISSING':>18}")
+        if cpu_norm is None:
+            failures.append("the CPU backend returned no gradient at all")
+        elif not cpu_ok:
+            failures.append(f"CPU gradient norm {cpu_norm} vs "
+                            f"{HF_WATER_STO3G_GRAD_NORM}, diff {delta:.2e} > {TOL_GRAD:.1e}")
+        if not xtb_ok:
             failures.append("tblite must still provide gradients")
 
     if failures:

--- a/python/mqc/__init__.py
+++ b/python/mqc/__init__.py
@@ -333,6 +333,19 @@ class Result:
             return None
         return document.get("homo_lumo_gap_ev")
 
+    @property
+    def gradient_norm(self):
+        """Norm of the nuclear gradient in Hartree/Bohr, or None.
+
+        Only a run that asked for one and wrote its output has this. The JSON
+        carries the norm rather than the full array, which is enough to tell a
+        correct gradient from a wrong one without moving 3N numbers through it.
+        """
+        document = self._output_document()
+        if not document:
+            return None
+        return document.get("gradient_norm")
+
     def _output_document(self):
         if not self.wrote:
             return None

--- a/src/io/mqc_json_writer.f90
+++ b/src/io/mqc_json_writer.f90
@@ -19,6 +19,37 @@ module mqc_json_writer
 
 contains
 
+   subroutine add_gradient(json, parent, gradient)
+      !! Nuclear gradient, as the norm and as the components it came from
+      !!
+      !! The norm alone cannot separate a correct gradient from one with a sign
+      !! error, a swapped pair of atoms, or a wrong component that happens to
+      !! preserve the magnitude, so validation compares the components. Written
+      !! in Hartree/Bohr, the internal unit -- unlike the optimization
+      !! trajectory, which converts to Angstrom because a viewer expects it.
+      type(json_core), intent(inout) :: json
+      type(json_value), pointer, intent(in) :: parent
+      real(dp), intent(in) :: gradient(:, :)  !! (3, natoms)
+
+      type(json_value), pointer :: grad_arr, atom_arr
+      integer :: iatom, icomp
+
+      call json%add(parent, "gradient_norm", sqrt(sum(gradient**2)))
+      call json%add(parent, "gradient_units", "hartree/bohr")
+
+      ! One [x, y, z] triple per atom, in input order.
+      call json%create_array(grad_arr, "gradient")
+      call json%add(parent, grad_arr)
+      do iatom = 1, size(gradient, 2)
+         call json%create_array(atom_arr, "")
+         call json%add(grad_arr, atom_arr)
+         do icomp = 1, size(gradient, 1)
+            call json%add(atom_arr, "", gradient(icomp, iatom))
+         end do
+      end do
+
+   end subroutine add_gradient
+
    subroutine write_json_output(output_data)
       !! THE single entry point for all JSON output
       !!
@@ -104,7 +135,7 @@ contains
       end if
 
       if (data%has_gradient .and. allocated(data%gradient)) then
-         call json%add(main_obj, "gradient_norm", sqrt(sum(data%gradient**2)))
+         call add_gradient(json, main_obj, data%gradient)
       end if
       if (data%has_hessian .and. allocated(data%hessian)) then
          call json%add(main_obj, "hessian_frobenius_norm", sqrt(sum(data%hessian**2)))
@@ -224,7 +255,7 @@ contains
       end if
 
       if (data%has_gradient .and. allocated(data%gradient)) then
-         call json%add(main_obj, "gradient_norm", sqrt(sum(data%gradient**2)))
+         call add_gradient(json, main_obj, data%gradient)
       end if
 
       if (data%has_hessian .and. allocated(data%hessian)) then
@@ -274,7 +305,7 @@ contains
       call json%add(main_obj, "total_energy", data%total_energy)
 
       if (data%has_gradient .and. allocated(data%gradient)) then
-         call json%add(main_obj, "gradient_norm", sqrt(sum(data%gradient**2)))
+         call add_gradient(json, main_obj, data%gradient)
       end if
       if (data%has_hessian .and. allocated(data%hessian)) then
          call json%add(main_obj, "hessian_frobenius_norm", sqrt(sum(data%hessian**2)))
@@ -352,7 +383,7 @@ contains
       character(len=256) :: output_file, basename
       real(dp) :: pV_cal, H_vib_cal, H_rot_cal, H_trans_cal, H_total_cal
       real(dp) :: Cv_total, S_total, S_total_J, H_int_cal, Cv_int, S_int, S_int_J, Cp_trans
-      real(dp) :: grad_norm, hess_norm
+      real(dp) :: hess_norm
 
       output_file = get_output_json_filename()
       basename = get_basename()
@@ -395,8 +426,7 @@ contains
 
       ! Gradient and Hessian norms
       if (data%has_gradient .and. allocated(data%gradient)) then
-         grad_norm = sqrt(sum(data%gradient**2))
-         call json%add(main_obj, "gradient_norm", grad_norm)
+         call add_gradient(json, main_obj, data%gradient)
       end if
       if (data%has_hessian .and. allocated(data%hessian)) then
          hess_norm = sqrt(sum(data%hessian**2))

--- a/test/test_mqc_method_placeholders.f90
+++ b/test/test_mqc_method_placeholders.f90
@@ -1,4 +1,20 @@
+!! What the method objects promise, now that most of them are not placeholders
+!!
+!! Hartree-Fock and Kohn-Sham are real calculations on this path: analytic
+!! gradients and finite-difference Hessians both exist for them. Only MCSCF is
+!! still a stub, and its tests below are the only ones that assert stub
+!! behaviour. The file keeps its name because the target does.
+!!
+!! **The contract every test here shares** is not that a particular number comes
+!! back. It is that exactly one of "produced a result" and "reported an error"
+!! is true. Which one depends on the build and the machine -- these fragments
+!! carry no basis set, and the test environment has no `basis_sets/` in its
+!! working directory -- so asserting success would make the suite a test of the
+!! environment. Asserting the exclusive-or tests the thing that must hold
+!! everywhere: nothing is ever invented, and nothing that succeeded is ever
+!! reported as failed.
 module test_mqc_method_placeholders
+   use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
    use testdrive, only: new_unittest, unittest_type, error_type, check
    use mqc_method_hf, only: hf_method_t, hf_options_t
    use mqc_method_dft, only: dft_method_t, dft_options_t
@@ -88,14 +104,22 @@ contains
       call create_test_fragment(fragment)
       call method%calc_gradient(fragment, result)
 
-      ! Analytic HF gradients are not implemented yet. The contract is that
-      ! this is reported, not that a zero gradient is handed back as if real.
-      call check(error, result%has_error, &
-                 "HF gradients are unimplemented and must report an error")
+      ! The analytic HF gradient is implemented. What this asserts is the
+      ! contract around it rather than its value, which
+      ! `validation/check_scf_gradient` covers against PySCF and finite
+      ! differences: one of a gradient and an error, never both, never neither,
+      ! and never a zero gradient passed off as real.
+      call check(error, result%has_error .neqv. result%has_gradient, &
+                 "HF must either produce a gradient or report an error, not both "// &
+                 "or neither")
       if (allocated(error)) return
 
-      call check(error,.not. result%has_gradient, &
-                 "An unimplemented HF gradient must not claim to have one")
+      if (result%has_error) then
+         call check(error, len_trim(result%error%get_message()) > 0, &
+                    "A failed HF gradient must carry a diagnostic message")
+      else
+         call check_gradient_shape(error, result, fragment%n_atoms, "HF")
+      end if
 
       call fragment%destroy()
    end subroutine test_hf_gradient
@@ -109,8 +133,19 @@ contains
       call create_test_fragment(fragment)
       call method%calc_hessian(fragment, result)
 
-      call check(error,.not. result%has_hessian, &
-                 "HF Hessian placeholder should report not implemented")
+      ! Built by finite differences of the analytic gradient, so it exists
+      ! wherever that does.
+      call check(error, result%has_error .neqv. result%has_hessian, &
+                 "HF must either produce a Hessian or report an error, not both "// &
+                 "or neither")
+      if (allocated(error)) return
+
+      if (result%has_error) then
+         call check(error, len_trim(result%error%get_message()) > 0, &
+                    "A failed HF Hessian must carry a diagnostic message")
+      else
+         call check_hessian_shape(error, result, fragment%n_atoms, "HF")
+      end if
 
       call fragment%destroy()
    end subroutine test_hf_hessian
@@ -163,14 +198,20 @@ contains
 
       call method%calc_gradient(fragment, result)
 
-      ! Analytic DFT gradients are not implemented; the contract is that this
-      ! is reported rather than a zero gradient being passed off as real.
-      call check(error, result%has_error, &
-                 "DFT gradients are unimplemented and must report an error")
+      ! Implemented through hybrid GGA. Meta-GGAs and range-separated hybrids
+      ! are refused rather than approximated, which is an error and so is
+      ! covered by the same exclusive-or.
+      call check(error, result%has_error .neqv. result%has_gradient, &
+                 "DFT must either produce a gradient or report an error, not both "// &
+                 "or neither")
       if (allocated(error)) return
 
-      call check(error,.not. result%has_gradient, &
-                 "An unimplemented DFT gradient must not claim to have one")
+      if (result%has_error) then
+         call check(error, len_trim(result%error%get_message()) > 0, &
+                    "A failed DFT gradient must carry a diagnostic message")
+      else
+         call check_gradient_shape(error, result, fragment%n_atoms, "DFT")
+      end if
 
       call fragment%destroy()
    end subroutine test_dft_gradient
@@ -186,16 +227,66 @@ contains
 
       call method%calc_hessian(fragment, result)
 
-      ! Analytic DFT Hessians are not implemented; report, never fabricate.
-      call check(error, result%has_error, &
-                 "DFT Hessians are unimplemented and must report an error")
+      call check(error, result%has_error .neqv. result%has_hessian, &
+                 "DFT must either produce a Hessian or report an error, not both "// &
+                 "or neither")
       if (allocated(error)) return
 
-      call check(error,.not. result%has_hessian, &
-                 "An unimplemented DFT Hessian must not claim to have one")
+      if (result%has_error) then
+         call check(error, len_trim(result%error%get_message()) > 0, &
+                    "A failed DFT Hessian must carry a diagnostic message")
+      else
+         call check_hessian_shape(error, result, fragment%n_atoms, "DFT")
+      end if
 
       call fragment%destroy()
    end subroutine test_dft_hessian
+
+   subroutine check_gradient_shape(error, result, n_atoms, label)
+      !! A gradient that claims to exist has to be one
+      !!
+      !! Shape and finiteness rather than value. An unallocated array behind a
+      !! true `has_gradient`, or a NaN in it, is the failure this catches -- and
+      !! it is exactly what a zero-initialised placeholder would *not* have been
+      !! caught doing by the old assertion, which only asked whether the flag
+      !! was false.
+      type(error_type), allocatable, intent(out) :: error
+      type(calculation_result_t), intent(in) :: result
+      integer, intent(in) :: n_atoms
+      character(len=*), intent(in) :: label
+
+      call check(error, allocated(result%gradient), &
+                 label//" claims a gradient but did not allocate one")
+      if (allocated(error)) return
+
+      call check(error, size(result%gradient, 1) == 3 .and. &
+                 size(result%gradient, 2) == n_atoms, &
+                 label//" gradient is not (3, n_atoms)")
+      if (allocated(error)) return
+
+      call check(error, all(ieee_is_finite(result%gradient)), &
+                 label//" gradient contains a non-finite element")
+   end subroutine check_gradient_shape
+
+   subroutine check_hessian_shape(error, result, n_atoms, label)
+      !! The same, for the second derivatives
+      type(error_type), allocatable, intent(out) :: error
+      type(calculation_result_t), intent(in) :: result
+      integer, intent(in) :: n_atoms
+      character(len=*), intent(in) :: label
+
+      call check(error, allocated(result%hessian), &
+                 label//" claims a Hessian but did not allocate one")
+      if (allocated(error)) return
+
+      call check(error, size(result%hessian, 1) == 3*n_atoms .and. &
+                 size(result%hessian, 2) == 3*n_atoms, &
+                 label//" Hessian is not (3 n_atoms, 3 n_atoms)")
+      if (allocated(error)) return
+
+      call check(error, all(ieee_is_finite(result%hessian)), &
+                 label//" Hessian contains a non-finite element")
+   end subroutine check_hessian_shape
 
    subroutine test_mcscf_no_active(error)
       type(error_type), allocatable, intent(out) :: error

--- a/tools/cpu_validation/gen_cpu_validation.py
+++ b/tools/cpu_validation/gen_cpu_validation.py
@@ -384,6 +384,66 @@ FRAGMENTED_CASES = [
     ("w2dimer", "cc-pvdz", "mp2", 2, [[0, 1, 2], [3, 4, 5]]),
 ]
 
+# Analytic nuclear gradients, as (molecule, basis, aux, functional, multiplicity).
+# An empty aux means exact ERIs, an empty functional means Hartree-Fock.
+#
+# These are the only cases in the suite whose reference is a vector, and they
+# exist because a total energy says nothing about a derivative: both times an
+# exchange-correlation gradient term was wrong during development, the
+# converged energy still matched PySCF to all ten printed digits. The manifest
+# carries every component, not `gradient_norm` -- a norm cannot separate a sign
+# error, a swapped pair of atoms, or a wrong component that preserves the
+# magnitude.
+#
+# One case per code path rather than a sweep: exact ERIs restricted and
+# unrestricted, density fitting, and each rung of the functional ladder that is
+# implemented. Meta-GGA and range-separated hybrids are absent because their
+# gradients are refused rather than approximated -- tau and the screened
+# exchange derivative are not written -- so a case here would be pinning a
+# refusal.
+GRADIENT_CASES = [
+    ("water", "sto-3g", "", "", 1),
+    ("ch4", "6-31g**", "", "", 1),       # Cartesian d functions
+    ("nh3", "cc-pvdz", "", "", 1),
+    ("ch3", "cc-pvdz", "", "", 2),       # unrestricted
+    ("water", "cc-pvdz", "cc-pvdz-rifit", "", 1),   # density fitted
+    ("water", "cc-pvdz", "", "svwn", 1),            # LDA
+    ("water", "cc-pvdz", "", "pbe", 1),             # GGA
+    ("water", "cc-pvdz", "", "b3lyp", 1),           # hybrid GGA
+    ("ch3", "cc-pvdz", "", "pbe", 2),               # unrestricted GGA
+]
+
+# The same gradient through the many-body expansion, as
+# (molecule, basis, fragments). Its reference is the supermolecule and that is
+# exact rather than tolerated: over two fragments the expansion collapses term
+# by term, E_1 + E_2 + (E_12 - E_1 - E_2) = E_12, and differentiating a term-by-term
+# identity leaves it one. So the fragmented gradient has to reproduce the
+# supermolecular one to machine precision, and the case covers what no
+# unfragmented one does -- per-fragment gradients surviving assembly, and the
+# MPI distribution the runner gives a fragmented case.
+GRADIENT_FRAGMENTED_CASES = [
+    ("w2dimer", "cc-pvdz", [[0, 1, 2], [3, 4, 5]]),
+]
+
+# Ten times looser than the unfragmented cases, and not because the expansion
+# is approximate here -- it is exact. Three SCFs are converged independently
+# and each contributes its own stopping residue, and the assembly subtracts the
+# monomer gradients from the dimer one, so what cancels in the energy does not
+# cancel in the residues. Measured 1.5e-8 with the SCF stopped at 1e-11 and
+# 6.8e-9 at 1e-13, which is the shape of a convergence floor rather than a term
+# that is wrong.
+GRADIENT_FRAGMENTED_TOLERANCE = 1.0e-7
+
+# Looser than the energy tolerance, and for a reason rather than to make the
+# cases pass: the reference is another program's assembly of the same terms in
+# another order, and the exchange-correlation ones are quadratures. Measured
+# agreement over these nine cases is 4e-12 to 3e-9 without a functional and
+# 7e-10 to 7e-9 with one, so each bound keeps a factor of a few in hand. That
+# is enough: a term going missing is a 1e-3 event, not a 1e-8 one.
+GRADIENT_TOLERANCE = 1.0e-8
+GRADIENT_DFT_TOLERANCE = 1.0e-7
+GRADIENT_GRID_LEVEL = 3
+
 DF_CASES = [
     ("water", "cc-pvdz", "cc-pvdz-rifit"),
     ("water", "def2-svp", "def2-universal-jkfit"),
@@ -776,6 +836,55 @@ def pyscf_ri_cc(atoms, basis, aux, method, frozen):
     return float(escf + ecorr), mol.nao
 
 
+def pyscf_gradient(atoms, basis, aux="", functional="", multiplicity=1,
+                   level=GRADIENT_GRID_LEVEL):
+    """Reference energy and analytic nuclear gradient, in Hartree/Bohr.
+
+    Two things here are not defaults and both matter. The gradient modules have
+    to be imported by name -- `mf.Gradients()` raises NotImplementedError
+    otherwise, which reads like the method having no gradient rather than a
+    missing import. And `grid_response` is switched on for the functionals:
+    PySCF leaves out the derivative of the quadrature weights by default, while
+    metalquicha includes it, so the two disagree by ~1e-4 with nothing wrong on
+    either side. That term is also the one that hides best -- translational
+    invariance is blind to it, because a rigid translation leaves the Becke
+    partition unchanged.
+    """
+    from pyscf import df, dft, gto, scf
+    from pyscf.grad import rhf as _rhf_grad, rks as _rks_grad  # noqa: F401
+    from pyscf.grad import uhf as _uhf_grad, uks as _uks_grad  # noqa: F401
+
+    mol = gto.Mole()
+    mol.atom = [(s, (x, y, z)) for s, x, y, z in atoms]
+    mol.unit = "Angstrom"
+    symbols = {a[0] for a in atoms}
+    mol.basis = {s: bse_to_pyscf(basis, s) for s in symbols}
+    mol.charge = 0
+    mol.spin = multiplicity - 1
+    mol.cart = molecule_form(basis, symbols) == CARTESIAN
+    mol.verbose = 0
+    mol.build()
+
+    unrestricted = multiplicity != 1
+    if functional:
+        mf = dft.UKS(mol) if unrestricted else dft.RKS(mol)
+        mf.xc = functional
+        mf.grids.level = level
+    else:
+        mf = scf.UHF(mol) if unrestricted else scf.RHF(mol)
+    if aux:
+        mf = df.density_fit(mf, auxbasis={s: bse_to_pyscf(aux, s) for s in symbols})
+    mf.conv_tol = 1e-12
+    energy = mf.kernel()
+    if not mf.converged:
+        raise SystemExit(f"PySCF did not converge for {basis} {functional}")
+
+    grad = mf.Gradients()
+    if functional:
+        grad.grid_response = True
+    return float(energy), grad.kernel().tolist(), mol.nao
+
+
 def pyscf_rhf(atoms, basis, aux="", multiplicity=1):
     from pyscf import df, gto, scf
 
@@ -876,6 +985,82 @@ def main():
             "type": "unfragmented",
         })
         print(f"{mol.label:6s} {basis:12s} df={aux:22s} E={energy:.12f}", flush=True)
+
+    for name, basis, aux, functional, mult in GRADIENT_CASES:
+        mol = MOLECULES[name]
+        energy, gradient, nao = pyscf_gradient(mol.atoms, basis, aux=aux,
+                                               functional=functional, multiplicity=mult)
+        tag = normalize_basis_name(basis)
+        if functional:
+            tag += "_" + functional.replace("-", "")
+        if aux:
+            tag += "_df"
+        deck = deck_for(f"{CPU_MQC}/gradient", f"cpu_{name}_{tag}_grad")
+        written.add(str((VALIDATION / deck).relative_to(INPUTS)))
+        if not args.dry_run:
+            d = deck_json(xyz_for(mol), basis, aux=aux, multiplicity=mult,
+                          method="dft" if functional else "hf")
+            if functional:
+                d["model"]["functional"] = functional
+                d["keywords"]["dft"] = {"grid_level": GRADIENT_GRID_LEVEL}
+            # Tighter than the suite default, because a gradient is a
+            # derivative of the converged energy and an unconverged density
+            # shows up in it linearly rather than quadratically. At the default
+            # 1e-8 these cases sat ~1e-7 from PySCF -- which is the SCF
+            # stopping point, not the gradient.
+            d["keywords"]["scf"]["tolerance"] = 1e-11
+            d["driver"] = "Gradient"
+            _write_deck(VALIDATION / deck, json.dumps(d, indent=4) + "\n")
+        theory = functional.upper() if functional else ("UHF" if mult != 1 else "RHF")
+        label = f"{theory} gradient {mol.label} {basis}"
+        if aux:
+            label += f" density fitted with {aux}"
+        tests.append({
+            "name": label + " (CPU)",
+            "input": deck,
+            "expected_energy": round(energy, 12),
+            "expected_gradient": [[round(c, 12) for c in atom] for atom in gradient],
+            "gradient_tolerance": GRADIENT_DFT_TOLERANCE if functional else GRADIENT_TOLERANCE,
+            # Exact here, and worth failing on: every term in these gradients is
+            # translationally invariant, so a residual is a real defect even
+            # though the converse does not hold.
+            "check_translation": True,
+            "type": "unfragmented",
+        })
+        norm = math.sqrt(sum(c*c for atom in gradient for c in atom))
+        print(f"{mol.label:6s} {basis:12s} {theory:8s} grad |g|={norm:.10f} "
+              f"nao={nao:4d} E={energy:.12f}", flush=True)
+
+    for name, basis, fragments in GRADIENT_FRAGMENTED_CASES:
+        mol = MOLECULES[name]
+        energy, gradient, nao = pyscf_gradient(mol.atoms, basis)
+        deck = deck_for(f"{CPU_MQC}/gradient",
+                        f"cpu_{name}_{normalize_basis_name(basis)}_grad_mbe{len(fragments)}")
+        written.add(str((VALIDATION / deck).relative_to(INPUTS)))
+        if not args.dry_run:
+            d = deck_json(xyz_for(mol), basis)
+            d["molecules"][0]["fragments"] = fragments
+            d["molecules"][0]["fragment_charges"] = [0]*len(fragments)
+            d["molecules"][0]["fragment_multiplicities"] = [1]*len(fragments)
+            d["keywords"]["fragmentation"] = {
+                "method": "MBE", "level": len(fragments),
+                "allow_overlapping_fragments": False, "embedding": "none",
+            }
+            d["keywords"]["scf"]["tolerance"] = 1e-11
+            d["driver"] = "Gradient"
+            _write_deck(VALIDATION / deck, json.dumps(d, indent=4) + "\n")
+        tests.append({
+            "name": f"MBE({len(fragments)}) RHF gradient {mol.label} {basis} (CPU)",
+            "input": deck,
+            "expected_energy": round(energy, 12),
+            "expected_gradient": [[round(c, 12) for c in atom] for atom in gradient],
+            "gradient_tolerance": GRADIENT_FRAGMENTED_TOLERANCE,
+            "check_translation": True,
+            "type": "fragmented",
+        })
+        norm = math.sqrt(sum(c*c for atom in gradient for c in atom))
+        print(f"{mol.label:6s} {basis:12s} {'RHF':8s} grad MBE({len(fragments)}) "
+              f"|g|={norm:.10f} nao={nao:4d} E={energy:.12f}", flush=True)
 
     for name, basis, mult in OPEN_SHELL:
         mol = MOLECULES[name]

--- a/validation/check_scf_gradient.f90
+++ b/validation/check_scf_gradient.f90
@@ -25,10 +25,31 @@ program check_scf_gradient
    use mqc_libcint_rhf, only: rhf_result_t, run_libcint_rhf, run_libcint_uhf
    use mqc_libcint_gradient, only: libcint_scf_gradient
    use mqc_libcint_xc, only: xc_context_t, xc_context_create, xc_available
+   use omp_lib, only: omp_set_num_threads, omp_get_max_threads
+   use, intrinsic :: iso_fortran_env, only: output_unit
    implicit none
 
    integer, parameter :: N_DIM = 3
+   integer, parameter :: BENCH_THREADS = 4
+      !! Every molecule here is three or four atoms in a minimal basis, where
+      !! the threaded gradient contraction is nearly all overhead: measured on
+      !! water/sto-3g, forty threads bought a 1.4x wall speedup for 47x the CPU
+      !! time. Four keeps most of that and leaves the machine usable, which
+      !! matters because this suite runs for minutes on a shared box.
    integer :: n_bad
+   character(len=128) :: filter
+   integer :: filter_len, arg_status
+
+   call omp_set_num_threads(min(BENCH_THREADS, omp_get_max_threads()))
+
+   ! One optional argument: a substring of the case label. Without it every
+   ! case runs, which is what CI wants; with it, one case runs, which is what
+   ! anyone developing a new gradient wants. The whole suite is a few hundred
+   ! converged SCFs -- re-running all of it to test one new case is the reason
+   ! iterating on the GGA term was slow.
+   filter = ""
+   call get_command_argument(1, filter, length=filter_len, status=arg_status)
+   if (arg_status /= 0) filter = ""
 
    n_bad = 0
 
@@ -198,6 +219,10 @@ contains
 
       natm = size(numbers)
 
+      if (len_trim(filter) > 0) then
+         if (index(label, trim(filter)) == 0) return
+      end if
+
       write (*, "(a)") ""
       write (*, "(a,a)") "== ", label
 
@@ -237,6 +262,11 @@ contains
          write (*, "(a)") "  FAIL: not translationally invariant"
          n_bad = n_bad + 1
       end if
+
+      ! gfortran block-buffers stdout below libc, so `stdbuf` cannot reach it
+      ! and a long run looks hung rather than slow. Flushing per case is the
+      ! portable fix; GFORTRAN_UNBUFFERED_ALL=1 is the environment one.
+      flush (output_unit)
    end subroutine check_case
 
    subroutine check_unrestricted_df_channels(n_bad)
@@ -265,12 +295,21 @@ contains
       real(dp), allocatable :: half_density(:, :)
       real(dp) :: worst
 
+      character(len=*), parameter :: label = &
+                                     "unrestricted DF branch against the restricted one (H2O / sto-3g)"
+
       coords = reshape([0.0_dp, 0.0_dp, 0.0_dp, &
                         0.0_dp, -1.4308_dp, 1.1078_dp, &
                         0.0_dp, 1.4308_dp, 1.1078_dp], [N_DIM, 3])
 
+      ! Same filter the labelled cases honour, so a filtered run is one case
+      ! rather than one case and this.
+      if (len_trim(filter) > 0) then
+         if (index(label, trim(filter)) == 0) return
+      end if
+
       write (*, "(a)") ""
-      write (*, "(a)") "== unrestricted DF branch against the restricted one (H2O / sto-3g)"
+      write (*, "(a,a)") "== ", label
 
       call build_libcint_molecule(numbers, symbols, coords, "sto-3g", mol, error)
       if (error%has_error()) then

--- a/validation/inputs/cpu/mqc/gradient/cpu_ch3_cc-pvdz_grad.json
+++ b/validation/inputs/cpu/mqc/gradient/cpu_ch3_cc-pvdz_grad.json
@@ -1,0 +1,29 @@
+{
+    "schema": {
+        "name": "mqc-frag",
+        "version": "1.0"
+    },
+    "molecules": [
+        {
+            "xyz": "../../../sample_inputs/ch3.xyz",
+            "molecular_charge": 0,
+            "molecular_multiplicity": 2
+        }
+    ],
+    "model": {
+        "method": "hf",
+        "basis": "cc-pvdz"
+    },
+    "keywords": {
+        "scf": {
+            "maxiter": 100,
+            "tolerance": 1e-11
+        }
+    },
+    "system": {
+        "logger": {
+            "level": "Verbose"
+        }
+    },
+    "driver": "Gradient"
+}

--- a/validation/inputs/cpu/mqc/gradient/cpu_ch3_cc-pvdz_pbe_grad.json
+++ b/validation/inputs/cpu/mqc/gradient/cpu_ch3_cc-pvdz_pbe_grad.json
@@ -1,0 +1,33 @@
+{
+    "schema": {
+        "name": "mqc-frag",
+        "version": "1.0"
+    },
+    "molecules": [
+        {
+            "xyz": "../../../sample_inputs/ch3.xyz",
+            "molecular_charge": 0,
+            "molecular_multiplicity": 2
+        }
+    ],
+    "model": {
+        "method": "dft",
+        "basis": "cc-pvdz",
+        "functional": "pbe"
+    },
+    "keywords": {
+        "scf": {
+            "maxiter": 100,
+            "tolerance": 1e-11
+        },
+        "dft": {
+            "grid_level": 3
+        }
+    },
+    "system": {
+        "logger": {
+            "level": "Verbose"
+        }
+    },
+    "driver": "Gradient"
+}

--- a/validation/inputs/cpu/mqc/gradient/cpu_ch4_6-31g_st__st__grad.json
+++ b/validation/inputs/cpu/mqc/gradient/cpu_ch4_6-31g_st__st__grad.json
@@ -1,0 +1,29 @@
+{
+    "schema": {
+        "name": "mqc-frag",
+        "version": "1.0"
+    },
+    "molecules": [
+        {
+            "xyz": "../../../sample_inputs/ch4.xyz",
+            "molecular_charge": 0,
+            "molecular_multiplicity": 1
+        }
+    ],
+    "model": {
+        "method": "hf",
+        "basis": "6-31g**"
+    },
+    "keywords": {
+        "scf": {
+            "maxiter": 100,
+            "tolerance": 1e-11
+        }
+    },
+    "system": {
+        "logger": {
+            "level": "Verbose"
+        }
+    },
+    "driver": "Gradient"
+}

--- a/validation/inputs/cpu/mqc/gradient/cpu_nh3_cc-pvdz_grad.json
+++ b/validation/inputs/cpu/mqc/gradient/cpu_nh3_cc-pvdz_grad.json
@@ -1,0 +1,29 @@
+{
+    "schema": {
+        "name": "mqc-frag",
+        "version": "1.0"
+    },
+    "molecules": [
+        {
+            "xyz": "../../../sample_inputs/nh3.xyz",
+            "molecular_charge": 0,
+            "molecular_multiplicity": 1
+        }
+    ],
+    "model": {
+        "method": "hf",
+        "basis": "cc-pvdz"
+    },
+    "keywords": {
+        "scf": {
+            "maxiter": 100,
+            "tolerance": 1e-11
+        }
+    },
+    "system": {
+        "logger": {
+            "level": "Verbose"
+        }
+    },
+    "driver": "Gradient"
+}

--- a/validation/inputs/cpu/mqc/gradient/cpu_w2dimer_cc-pvdz_grad_mbe2.json
+++ b/validation/inputs/cpu/mqc/gradient/cpu_w2dimer_cc-pvdz_grad_mbe2.json
@@ -1,0 +1,55 @@
+{
+    "schema": {
+        "name": "mqc-frag",
+        "version": "1.0"
+    },
+    "molecules": [
+        {
+            "xyz": "../../../sample_inputs/w2_dimer.xyz",
+            "molecular_charge": 0,
+            "molecular_multiplicity": 1,
+            "fragments": [
+                [
+                    0,
+                    1,
+                    2
+                ],
+                [
+                    3,
+                    4,
+                    5
+                ]
+            ],
+            "fragment_charges": [
+                0,
+                0
+            ],
+            "fragment_multiplicities": [
+                1,
+                1
+            ]
+        }
+    ],
+    "model": {
+        "method": "hf",
+        "basis": "cc-pvdz"
+    },
+    "keywords": {
+        "scf": {
+            "maxiter": 100,
+            "tolerance": 1e-11
+        },
+        "fragmentation": {
+            "method": "MBE",
+            "level": 2,
+            "allow_overlapping_fragments": false,
+            "embedding": "none"
+        }
+    },
+    "system": {
+        "logger": {
+            "level": "Verbose"
+        }
+    },
+    "driver": "Gradient"
+}

--- a/validation/inputs/cpu/mqc/gradient/cpu_water_cc-pvdz_b3lyp_grad.json
+++ b/validation/inputs/cpu/mqc/gradient/cpu_water_cc-pvdz_b3lyp_grad.json
@@ -1,0 +1,33 @@
+{
+    "schema": {
+        "name": "mqc-frag",
+        "version": "1.0"
+    },
+    "molecules": [
+        {
+            "xyz": "../../../sample_inputs/w1.xyz",
+            "molecular_charge": 0,
+            "molecular_multiplicity": 1
+        }
+    ],
+    "model": {
+        "method": "dft",
+        "basis": "cc-pvdz",
+        "functional": "b3lyp"
+    },
+    "keywords": {
+        "scf": {
+            "maxiter": 100,
+            "tolerance": 1e-11
+        },
+        "dft": {
+            "grid_level": 3
+        }
+    },
+    "system": {
+        "logger": {
+            "level": "Verbose"
+        }
+    },
+    "driver": "Gradient"
+}

--- a/validation/inputs/cpu/mqc/gradient/cpu_water_cc-pvdz_df_grad.json
+++ b/validation/inputs/cpu/mqc/gradient/cpu_water_cc-pvdz_df_grad.json
@@ -1,0 +1,31 @@
+{
+    "schema": {
+        "name": "mqc-frag",
+        "version": "1.0"
+    },
+    "molecules": [
+        {
+            "xyz": "../../../sample_inputs/w1.xyz",
+            "molecular_charge": 0,
+            "molecular_multiplicity": 1
+        }
+    ],
+    "model": {
+        "method": "hf",
+        "basis": "cc-pvdz",
+        "aux_basis": "cc-pvdz-rifit"
+    },
+    "keywords": {
+        "scf": {
+            "maxiter": 100,
+            "tolerance": 1e-11,
+            "density_fitting": true
+        }
+    },
+    "system": {
+        "logger": {
+            "level": "Verbose"
+        }
+    },
+    "driver": "Gradient"
+}

--- a/validation/inputs/cpu/mqc/gradient/cpu_water_cc-pvdz_pbe_grad.json
+++ b/validation/inputs/cpu/mqc/gradient/cpu_water_cc-pvdz_pbe_grad.json
@@ -1,0 +1,33 @@
+{
+    "schema": {
+        "name": "mqc-frag",
+        "version": "1.0"
+    },
+    "molecules": [
+        {
+            "xyz": "../../../sample_inputs/w1.xyz",
+            "molecular_charge": 0,
+            "molecular_multiplicity": 1
+        }
+    ],
+    "model": {
+        "method": "dft",
+        "basis": "cc-pvdz",
+        "functional": "pbe"
+    },
+    "keywords": {
+        "scf": {
+            "maxiter": 100,
+            "tolerance": 1e-11
+        },
+        "dft": {
+            "grid_level": 3
+        }
+    },
+    "system": {
+        "logger": {
+            "level": "Verbose"
+        }
+    },
+    "driver": "Gradient"
+}

--- a/validation/inputs/cpu/mqc/gradient/cpu_water_cc-pvdz_svwn_grad.json
+++ b/validation/inputs/cpu/mqc/gradient/cpu_water_cc-pvdz_svwn_grad.json
@@ -1,0 +1,33 @@
+{
+    "schema": {
+        "name": "mqc-frag",
+        "version": "1.0"
+    },
+    "molecules": [
+        {
+            "xyz": "../../../sample_inputs/w1.xyz",
+            "molecular_charge": 0,
+            "molecular_multiplicity": 1
+        }
+    ],
+    "model": {
+        "method": "dft",
+        "basis": "cc-pvdz",
+        "functional": "svwn"
+    },
+    "keywords": {
+        "scf": {
+            "maxiter": 100,
+            "tolerance": 1e-11
+        },
+        "dft": {
+            "grid_level": 3
+        }
+    },
+    "system": {
+        "logger": {
+            "level": "Verbose"
+        }
+    },
+    "driver": "Gradient"
+}

--- a/validation/inputs/cpu/mqc/gradient/cpu_water_sto-3g_grad.json
+++ b/validation/inputs/cpu/mqc/gradient/cpu_water_sto-3g_grad.json
@@ -1,0 +1,29 @@
+{
+    "schema": {
+        "name": "mqc-frag",
+        "version": "1.0"
+    },
+    "molecules": [
+        {
+            "xyz": "../../../sample_inputs/w1.xyz",
+            "molecular_charge": 0,
+            "molecular_multiplicity": 1
+        }
+    ],
+    "model": {
+        "method": "hf",
+        "basis": "sto-3g"
+    },
+    "keywords": {
+        "scf": {
+            "maxiter": 100,
+            "tolerance": 1e-11
+        }
+    },
+    "system": {
+        "logger": {
+            "level": "Verbose"
+        }
+    },
+    "driver": "Gradient"
+}

--- a/validation/run_validation.py
+++ b/validation/run_validation.py
@@ -131,6 +131,57 @@ def extract_gradient_norm(json_data: Dict) -> Optional[float]:
     return None
 
 
+def extract_gradient(json_data: Dict) -> Optional[List[List[float]]]:
+    """Extract the gradient components (Hartree/Bohr, one [x, y, z] per atom)"""
+    if not json_data:
+        return None
+
+    top_key = list(json_data.keys())[0]
+    data = json_data[top_key]
+
+    if "gradient" not in data:
+        return None
+
+    return [[float(c) for c in atom] for atom in data["gradient"]]
+
+
+def compare_gradients(calculated: List[List[float]],
+                      expected: List[List[float]],
+                      tolerance: float) -> tuple:
+    """Compare two gradients element by element
+
+    Returns (ok, max_diff, worst) where `worst` lists the offending
+    (atom, component, expected, calculated, diff) tuples, largest first. A norm
+    cannot distinguish a sign error or a swapped pair of atoms from a correct
+    gradient, which is the whole reason this compares components.
+    """
+    axes = ("x", "y", "z")
+    offenders = []
+    max_diff = 0.0
+
+    for iatom, (calc_atom, exp_atom) in enumerate(zip(calculated, expected), start=1):
+        for icomp, (calc, exp) in enumerate(zip(calc_atom, exp_atom)):
+            diff = abs(calc - exp)
+            max_diff = max(max_diff, diff)
+            if diff >= tolerance:
+                offenders.append((iatom, axes[icomp], exp, calc, diff))
+
+    offenders.sort(key=lambda row: row[4], reverse=True)
+    return (not offenders, max_diff, offenders)
+
+
+def translational_residual(gradient: List[List[float]]) -> float:
+    """Largest |sum over atoms of dE/dR| component; zero for an exact gradient
+
+    Free, and needs no reference value. But it is structurally blind to
+    exchange-correlation terms -- a rigid translation leaves the Becke
+    partition unchanged -- so it has passed at 2e-15 over an XC weight
+    derivative wrong by 0.77 Hartree/Bohr. A smoke test, never a pass criterion
+    on its own.
+    """
+    return max(abs(sum(atom[icomp] for atom in gradient)) for icomp in range(3))
+
+
 def extract_hessian_norm(json_data: Dict) -> Optional[float]:
     """Extract hessian_frobenius_norm from JSON output"""
     if not json_data:
@@ -519,6 +570,64 @@ def run_validation_tests(manifest_file: str = "validation_tests.json",
                         failure_reasons.append(f"Gradient mismatch (diff: {grad_diff:.2e})")
                     elif verbose:
                         print(f"    Gradient norm: {calculated_grad:.12f} (diff: {grad_diff:.2e})")
+
+            # Validate the gradient element by element if a reference is given
+            if "expected_gradient" in test:
+                expected_components = test["expected_gradient"]
+                calc_components = extract_gradient(output_data)
+
+                # Gradients are looser than energies by construction: the
+                # reference is usually an external code, and a converged energy
+                # agreeing to ten digits says nothing about the derivative.
+                grad_tol = test.get("gradient_tolerance", 1.0e-7)
+
+                if calc_components is None:
+                    print(f"  {Colors.RED}✗ FAILED{Colors.RESET} - No gradient components in JSON")
+                    test_passed = False
+                    failure_reasons.append("Missing gradient components")
+                elif len(calc_components) != len(expected_components):
+                    print(f"  {Colors.RED}✗ FAILED{Colors.RESET} - Gradient atom count mismatch")
+                    print(f"    Expected:   {len(expected_components)} atoms")
+                    print(f"    Calculated: {len(calc_components)} atoms")
+                    test_passed = False
+                    failure_reasons.append(
+                        f"Gradient size mismatch ({len(calc_components)} vs {len(expected_components)} atoms)")
+                else:
+                    ok, max_diff, offenders = compare_gradients(
+                        calc_components, expected_components, grad_tol)
+                    if not ok:
+                        print(f"  {Colors.RED}✗ FAILED{Colors.RESET} - Gradient mismatch "
+                              f"({len(offenders)} component(s), tolerance: {grad_tol:.2e})")
+                        for iatom, axis, exp_c, calc_c, diff in offenders[:10]:
+                            print(f"    atom {iatom:>4} {axis}: expected {exp_c: .12f}  "
+                                  f"calculated {calc_c: .12f}  diff {diff:.2e}")
+                        if len(offenders) > 10:
+                            print(f"    ... and {len(offenders) - 10} more")
+                        test_passed = False
+                        failure_reasons.append(f"Gradient mismatch (max diff: {max_diff:.2e})")
+                    elif verbose:
+                        print(f"    Gradient: {len(expected_components)} atoms "
+                              f"(max component diff: {max_diff:.2e})")
+
+            # Translational invariance, whenever components are available.
+            # Reported always because it is free; fails the case only where the
+            # deck asks for it, since it is blind to XC terms and a fragmented
+            # gradient carries cap-redistribution residue.
+            calc_components = extract_gradient(output_data)
+            if calc_components:
+                residual = translational_residual(calc_components)
+                trans_tol = test.get("translation_tolerance", 1.0e-8)
+                if residual >= trans_tol:
+                    if test.get("check_translation", False):
+                        print(f"  {Colors.RED}✗ FAILED{Colors.RESET} - Translational invariance")
+                        print(f"    |sum over atoms|: {residual:.2e} (tolerance: {trans_tol:.2e})")
+                        test_passed = False
+                        failure_reasons.append(f"Translation residual {residual:.2e}")
+                    else:
+                        print(f"  {Colors.YELLOW}! translational residual "
+                              f"{residual:.2e}{Colors.RESET}")
+                elif verbose:
+                    print(f"    Translational residual: {residual:.2e}")
 
             # Validate Hessian Frobenius norm if present
             if "expected_hessian_frobenius_norm" in test:

--- a/validation/validation_tests_cpu.json
+++ b/validation/validation_tests_cpu.json
@@ -23,7 +23,7 @@
         {
             "name": "RHF BH3 sto-3g (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_bh3_sto-3g.json",
-            "expected_energy": -26.068995738523,
+            "expected_energy": -26.068995738524,
             "type": "unfragmented"
         },
         {
@@ -47,7 +47,7 @@
         {
             "name": "RHF HF sto-3g (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_hf_sto-3g.json",
-            "expected_energy": -98.570757663479,
+            "expected_energy": -98.570757663478,
             "type": "unfragmented"
         },
         {
@@ -83,7 +83,7 @@
         {
             "name": "RHF PH3 sto-3g (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_ph3_sto-3g.json",
-            "expected_energy": -338.633614017913,
+            "expected_energy": -338.633614017912,
             "type": "unfragmented"
         },
         {
@@ -101,7 +101,7 @@
         {
             "name": "RHF Ar sto-3g (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_ar_sto-3g.json",
-            "expected_energy": -521.22288080353,
+            "expected_energy": -521.222880803531,
             "type": "unfragmented"
         },
         {
@@ -191,7 +191,7 @@
         {
             "name": "RHF H2S 3-21g (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_h2s_3-21g.json",
-            "expected_energy": -396.703944112624,
+            "expected_energy": -396.703944112623,
             "type": "unfragmented"
         },
         {
@@ -245,7 +245,7 @@
         {
             "name": "RHF H2O 6-31g (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_water_6-31g.json",
-            "expected_energy": -75.984779843968,
+            "expected_energy": -75.984779843967,
             "type": "unfragmented"
         },
         {
@@ -287,7 +287,7 @@
         {
             "name": "RHF PH3 6-31g (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_ph3_6-31g.json",
-            "expected_energy": -342.395943319632,
+            "expected_energy": -342.395943319633,
             "type": "unfragmented"
         },
         {
@@ -299,7 +299,7 @@
         {
             "name": "RHF HCl 6-31g (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_hcl_6-31g.json",
-            "expected_energy": -460.036920612294,
+            "expected_energy": -460.036920612293,
             "type": "unfragmented"
         },
         {
@@ -377,7 +377,7 @@
         {
             "name": "RHF AlH3 cc-pvdz (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_alh3_cc-pvdz.json",
-            "expected_energy": -243.631755712986,
+            "expected_energy": -243.631755712985,
             "type": "unfragmented"
         },
         {
@@ -473,7 +473,7 @@
         {
             "name": "RHF CH4 aug-cc-pvdz (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_ch4_aug-cc-pvdz.json",
-            "expected_energy": -40.199617623934,
+            "expected_energy": -40.199617623933,
             "type": "unfragmented"
         },
         {
@@ -503,7 +503,7 @@
         {
             "name": "RHF H2S aug-cc-pvdz (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_h2s_aug-cc-pvdz.json",
-            "expected_energy": -398.698035963355,
+            "expected_energy": -398.698035963353,
             "type": "unfragmented"
         },
         {
@@ -551,7 +551,7 @@
         {
             "name": "RHF SiH4 def2-svp (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_sih4_def2-svp.json",
-            "expected_energy": -291.153923860553,
+            "expected_energy": -291.153923860552,
             "type": "unfragmented"
         },
         {
@@ -605,7 +605,7 @@
         {
             "name": "RHF CH4 def2-tzvp (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_ch4_def2-tzvp.json",
-            "expected_energy": -40.213055304866,
+            "expected_energy": -40.213055304865,
             "type": "unfragmented"
         },
         {
@@ -647,13 +647,13 @@
         {
             "name": "RHF AlH3 def2-tzvp (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_alh3_def2-tzvp.json",
-            "expected_energy": -243.641284905954,
+            "expected_energy": -243.641284905955,
             "type": "unfragmented"
         },
         {
             "name": "RHF SiH4 def2-tzvp (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_sih4_def2-tzvp.json",
-            "expected_energy": -291.257893577066,
+            "expected_energy": -291.257893577067,
             "type": "unfragmented"
         },
         {
@@ -701,13 +701,13 @@
         {
             "name": "RHF BH3 6-31g* (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_bh3_6-31g_st_.json",
-            "expected_energy": -26.390003144425,
+            "expected_energy": -26.390003144424,
             "type": "unfragmented"
         },
         {
             "name": "RHF CH4 6-31g* (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_ch4_6-31g_st_.json",
-            "expected_energy": -40.195141002378,
+            "expected_energy": -40.195141002379,
             "type": "unfragmented"
         },
         {
@@ -743,13 +743,13 @@
         {
             "name": "RHF MgH2 6-31g* (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_mgh2_6-31g_st_.json",
-            "expected_energy": -200.715451153879,
+            "expected_energy": -200.71545115388,
             "type": "unfragmented"
         },
         {
             "name": "RHF AlH3 6-31g* (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_alh3_6-31g_st_.json",
-            "expected_energy": -243.616255399695,
+            "expected_energy": -243.616255399696,
             "type": "unfragmented"
         },
         {
@@ -761,13 +761,13 @@
         {
             "name": "RHF PH3 6-31g* (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_ph3_6-31g_st_.json",
-            "expected_energy": -342.447342229633,
+            "expected_energy": -342.447342229634,
             "type": "unfragmented"
         },
         {
             "name": "RHF H2S 6-31g* (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_h2s_6-31g_st_.json",
-            "expected_energy": -398.66707086397,
+            "expected_energy": -398.667070863969,
             "type": "unfragmented"
         },
         {
@@ -779,7 +779,7 @@
         {
             "name": "RHF Ar 6-31g* (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_ar_6-31g_st_.json",
-            "expected_energy": -526.773744920984,
+            "expected_energy": -526.773744920985,
             "type": "unfragmented"
         },
         {
@@ -909,6 +909,296 @@
             "type": "unfragmented"
         },
         {
+            "name": "RHF gradient H2O sto-3g (CPU)",
+            "input": "inputs/cpu/mqc/gradient/cpu_water_sto-3g_grad.json",
+            "expected_energy": -74.962005712275,
+            "expected_gradient": [
+                [
+                    -0.0,
+                    3.17e-10,
+                    -0.067617391053
+                ],
+                [
+                    0.0,
+                    -0.016791268482,
+                    0.033808695648
+                ],
+                [
+                    0.0,
+                    0.016791268166,
+                    0.033808695405
+                ]
+            ],
+            "gradient_tolerance": 1e-08,
+            "check_translation": true,
+            "type": "unfragmented"
+        },
+        {
+            "name": "RHF gradient CH4 6-31g** (CPU)",
+            "input": "inputs/cpu/mqc/gradient/cpu_ch4_6-31g_st__st__grad.json",
+            "expected_energy": -40.20167213402,
+            "expected_gradient": [
+                [
+                    -0.0,
+                    -0.0,
+                    -0.0
+                ],
+                [
+                    0.001437398944,
+                    0.001437398944,
+                    0.001437398944
+                ],
+                [
+                    0.001437398944,
+                    -0.001437398944,
+                    -0.001437398944
+                ],
+                [
+                    -0.001437398944,
+                    0.001437398944,
+                    -0.001437398944
+                ],
+                [
+                    -0.001437398944,
+                    -0.001437398944,
+                    0.001437398944
+                ]
+            ],
+            "gradient_tolerance": 1e-08,
+            "check_translation": true,
+            "type": "unfragmented"
+        },
+        {
+            "name": "RHF gradient NH3 cc-pvdz (CPU)",
+            "input": "inputs/cpu/mqc/gradient/cpu_nh3_cc-pvdz_grad.json",
+            "expected_energy": -56.195620015857,
+            "expected_gradient": [
+                [
+                    -0.0,
+                    -0.0,
+                    -0.002056418604
+                ],
+                [
+                    0.005193307714,
+                    -0.0,
+                    0.000685472868
+                ],
+                [
+                    -0.002596653857,
+                    0.00449753641,
+                    0.000685472868
+                ],
+                [
+                    -0.002596653857,
+                    -0.00449753641,
+                    0.000685472868
+                ]
+            ],
+            "gradient_tolerance": 1e-08,
+            "check_translation": true,
+            "type": "unfragmented"
+        },
+        {
+            "name": "UHF gradient CH3 cc-pvdz (CPU)",
+            "input": "inputs/cpu/mqc/gradient/cpu_ch3_cc-pvdz_grad.json",
+            "expected_energy": -39.563806767208,
+            "expected_gradient": [
+                [
+                    0.0,
+                    0.0,
+                    -0.0
+                ],
+                [
+                    -0.00167984256,
+                    -0.0,
+                    -0.0
+                ],
+                [
+                    0.00083992128,
+                    -0.001454786332,
+                    -0.0
+                ],
+                [
+                    0.00083992128,
+                    0.001454786332,
+                    0.0
+                ]
+            ],
+            "gradient_tolerance": 1e-08,
+            "check_translation": true,
+            "type": "unfragmented"
+        },
+        {
+            "name": "RHF gradient H2O cc-pvdz density fitted with cc-pvdz-rifit (CPU)",
+            "input": "inputs/cpu/mqc/gradient/cpu_water_cc-pvdz_df_grad.json",
+            "expected_energy": -76.027511701606,
+            "expected_gradient": [
+                [
+                    0.0,
+                    2.31e-10,
+                    0.01008181498
+                ],
+                [
+                    0.0,
+                    0.015838424428,
+                    -0.005040907405
+                ],
+                [
+                    -0.0,
+                    -0.015838424659,
+                    -0.005040907575
+                ]
+            ],
+            "gradient_tolerance": 1e-08,
+            "check_translation": true,
+            "type": "unfragmented"
+        },
+        {
+            "name": "SVWN gradient H2O cc-pvdz (CPU)",
+            "input": "inputs/cpu/mqc/gradient/cpu_water_cc-pvdz_svwn_grad.json",
+            "expected_energy": -75.854445341479,
+            "expected_gradient": [
+                [
+                    0.0,
+                    2.28e-10,
+                    -0.026683880803
+                ],
+                [
+                    -0.0,
+                    -0.008465018573,
+                    0.013341940487
+                ],
+                [
+                    -0.0,
+                    0.008465018345,
+                    0.013341940316
+                ]
+            ],
+            "gradient_tolerance": 1e-07,
+            "check_translation": true,
+            "type": "unfragmented"
+        },
+        {
+            "name": "PBE gradient H2O cc-pvdz (CPU)",
+            "input": "inputs/cpu/mqc/gradient/cpu_water_cc-pvdz_pbe_grad.json",
+            "expected_energy": -76.333065668911,
+            "expected_gradient": [
+                [
+                    0.0,
+                    2.24e-10,
+                    -0.028383098209
+                ],
+                [
+                    -0.0,
+                    -0.007020546936,
+                    0.014191549189
+                ],
+                [
+                    -0.0,
+                    0.007020546712,
+                    0.01419154902
+                ]
+            ],
+            "gradient_tolerance": 1e-07,
+            "check_translation": true,
+            "type": "unfragmented"
+        },
+        {
+            "name": "B3LYP gradient H2O cc-pvdz (CPU)",
+            "input": "inputs/cpu/mqc/gradient/cpu_water_cc-pvdz_b3lyp_grad.json",
+            "expected_energy": -76.420035465696,
+            "expected_gradient": [
+                [
+                    0.0,
+                    2.24e-10,
+                    -0.018529027149
+                ],
+                [
+                    0.0,
+                    -0.001754068653,
+                    0.009264513658
+                ],
+                [
+                    -0.0,
+                    0.00175406843,
+                    0.00926451349
+                ]
+            ],
+            "gradient_tolerance": 1e-07,
+            "check_translation": true,
+            "type": "unfragmented"
+        },
+        {
+            "name": "PBE gradient CH3 cc-pvdz (CPU)",
+            "input": "inputs/cpu/mqc/gradient/cpu_ch3_cc-pvdz_pbe_grad.json",
+            "expected_energy": -39.769139688915,
+            "expected_gradient": [
+                [
+                    -1.25558e-07,
+                    0.0,
+                    -0.0
+                ],
+                [
+                    -0.013273613865,
+                    -0.0,
+                    -0.0
+                ],
+                [
+                    0.006636869712,
+                    -0.011494995164,
+                    0.0
+                ],
+                [
+                    0.006636869712,
+                    0.011494995164,
+                    0.0
+                ]
+            ],
+            "gradient_tolerance": 1e-07,
+            "check_translation": true,
+            "type": "unfragmented"
+        },
+        {
+            "name": "MBE(2) RHF gradient (H2O)2 cc-pvdz (CPU)",
+            "input": "inputs/cpu/mqc/gradient/cpu_w2dimer_cc-pvdz_grad_mbe2.json",
+            "expected_energy": -152.056781852646,
+            "expected_gradient": [
+                [
+                    -0.030361505386,
+                    -0.002937044307,
+                    0.03430925928
+                ],
+                [
+                    0.005120740756,
+                    -0.003913870952,
+                    -0.025693361708
+                ],
+                [
+                    0.01311961193,
+                    0.012041480777,
+                    -0.007558260211
+                ],
+                [
+                    -0.016719024023,
+                    0.016713876951,
+                    -0.01542924636
+                ],
+                [
+                    -0.009415355265,
+                    -0.003692597292,
+                    0.012723378969
+                ],
+                [
+                    0.038255531988,
+                    -0.018211845177,
+                    0.00164823003
+                ]
+            ],
+            "gradient_tolerance": 1e-07,
+            "check_translation": true,
+            "type": "fragmented"
+        },
+        {
             "name": "UHF OH sto-3g multiplicity 2 (CPU)",
             "input": "inputs/cpu/mqc/uhf/cpu_oh_sto-3g_m2.json",
             "expected_energy": -74.362637545612,
@@ -965,7 +1255,7 @@
         {
             "name": "MP2 H2O def2-svp frozen 1 (CPU)",
             "input": "inputs/cpu/mqc/mp2/cpu_water_def2-svp_mp2_f1.json",
-            "expected_energy": -76.161689337976,
+            "expected_energy": -76.161689337977,
             "type": "unfragmented"
         },
         {
@@ -1007,7 +1297,7 @@
         {
             "name": "CCSD(T) CH4 sto-3g frozen 1 (CPU)",
             "input": "inputs/cpu/mqc/ccsd-t/cpu_ch4_sto-3g_ccsdt_f1.json",
-            "expected_energy": -39.805169969882,
+            "expected_energy": -39.805169969925,
             "type": "unfragmented"
         },
         {
@@ -1124,7 +1414,7 @@
         {
             "name": "RI-CCSD H2O sto-3g/cc-pvdz-rifit frozen 0 (CPU)",
             "input": "inputs/cpu/mqc/ri-ccsd/cpu_water_sto-3g_riccsd_f0.json",
-            "expected_energy": -75.011179195171,
+            "expected_energy": -75.01117919517,
             "type": "unfragmented"
         },
         {
@@ -1136,7 +1426,7 @@
         {
             "name": "RI-CCSD(T) H2O cc-pvdz/cc-pvdz-rifit frozen 1 (CPU)",
             "input": "inputs/cpu/mqc/ri-ccsd-t/cpu_water_cc-pvdz_riccsdt_f1.json",
-            "expected_energy": -76.240689531948,
+            "expected_energy": -76.240689531951,
             "type": "unfragmented"
         },
         {


### PR DESCRIPTION
Update the method-object tests: HF and DFT gradients exist now

`test_hf_gradient` asserted "HF gradients are unimplemented and must report an
error", and the three beside it said the same for the HF Hessian and both DFT
derivatives. That stopped being true when the analytic gradients were wired
into the bridge, so the four have been failing since -- not detecting a defect,
but asserting a contract the code deliberately left behind.

They now carry the contract the energy tests next door already had: exactly one
of "produced a result" and "reported an error" is true. Which one depends on
the build and the machine -- these fragments carry no basis set and the test
environment has no `basis_sets/` in its working directory -- so asserting
success outright would make the suite a test of the environment instead.

The replacement is stronger than what it replaces, not weaker. The old
assertion only asked whether a flag was false, which a zero-initialised
placeholder would have satisfied while handing back a fabricated array. The new
one follows a true flag through to the array: allocated, `(3, n_atoms)` or
`(3 n_atoms, 3 n_atoms)`, and every element finite. Values stay where they are
already checked properly, in `validation/check_scf_gradient` against PySCF and
finite differences.

MCSCF is still a stub and its three tests still say so, which is now the only
thing in the file the name is accurate about.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>