### PR TITLE
mp2 grads

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -512,6 +512,13 @@ if(MQC_ENABLE_LIBCINT)
   target_link_libraries(check_scf_gradient PRIVATE ${main_lib} cint_fortran
                                                    cint)
 
+  add_executable(bench_mp2_gradient
+                 ${PROJECT_SOURCE_DIR}/validation/bench_mp2_gradient.f90)
+  target_include_directories(bench_mp2_gradient
+                             PRIVATE "${CMAKE_BINARY_DIR}/modules")
+  target_link_libraries(bench_mp2_gradient PRIVATE ${main_lib} cint_fortran
+                                                   cint)
+
   add_executable(check_mp2_gradient
                  ${PROJECT_SOURCE_DIR}/validation/check_mp2_gradient.f90)
   target_include_directories(check_mp2_gradient

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -512,6 +512,13 @@ if(MQC_ENABLE_LIBCINT)
   target_link_libraries(check_scf_gradient PRIVATE ${main_lib} cint_fortran
                                                    cint)
 
+  add_executable(check_mp2_gradient
+                 ${PROJECT_SOURCE_DIR}/validation/check_mp2_gradient.f90)
+  target_include_directories(check_mp2_gradient
+                             PRIVATE "${CMAKE_BINARY_DIR}/modules")
+  target_link_libraries(check_mp2_gradient PRIVATE ${main_lib} cint_fortran
+                                                   cint)
+
   add_executable(check_direct ${PROJECT_SOURCE_DIR}/validation/check_direct.f90)
   target_include_directories(check_direct PRIVATE "${CMAKE_BINARY_DIR}/modules")
   target_link_libraries(check_direct PRIVATE ${main_lib} cint_fortran cint)

--- a/backends/libcint/CMakeLists.txt
+++ b/backends/libcint/CMakeLists.txt
@@ -27,6 +27,7 @@ target_sources(
           mqc_libcint_projection.f90
           mqc_libcint_rhf.f90
           mqc_libcint_mp2.f90
+          mqc_libcint_mp2_gradient.f90
           mqc_libcint_cc.f90
           mqc_libcint_ao_data.f90
           mqc_libcint_ao.f90

--- a/backends/libcint/mqc_libcint_bridge.f90
+++ b/backends/libcint/mqc_libcint_bridge.f90
@@ -29,6 +29,7 @@ module mqc_libcint_bridge
                                        guess_display_name
    use mqc_libcint_xc, only: xc_context_t, xc_context_create, xc_available
    use mqc_libcint_gradient, only: libcint_scf_gradient
+   use mqc_libcint_mp2_gradient, only: libcint_mp2_gradient
    use mqc_libcint_mp2, only: mp2_result_t, run_libcint_mp2, run_libcint_ri_mp2
    use mqc_libcint_cc, only: cc_result_t, run_libcint_ccsd
    use mqc_program_limits, only: MAX_LINE_LENGTH
@@ -197,21 +198,35 @@ contains
       do_gradient = .false.
       if (present(want_gradient)) do_gradient = want_gradient
 
-      ! What is differentiated here is the SCF energy, and nothing above it. A
-      ! correlated method asked for alongside a gradient would get the
-      ! reference gradient reported against a correlated energy -- of the right
-      ! magnitude, and wrong by the whole relaxation, with nothing in the
-      ! output to say which of the two numbers the other belongs to. The
-      ! functional-side gaps (range separation, meta-GGA) are refused inside
-      ! the gradient itself, where the functional is known.
-      if (do_gradient .and. (settings%run_mp2 .or. settings%run_cc)) then
-         call result%error%set(ERROR_VALIDATION, "the CPU gradient differentiates the "// &
-                               "SCF energy: MP2 and coupled cluster gradients need a "// &
-                               "relaxed density and a response solve, which are not "// &
-                               "written yet. Run the gradient at the reference level, "// &
-                               "or the correlated method as an energy.")
+      ! Coupled cluster stops here: its gradient needs the Lambda equations,
+      ! which do not exist on this side at all. MP2's does exist, and is taken
+      ! below -- but only where the reference underneath it is one the relaxed
+      ! density was written for, which is the three refusals after this.
+      if (do_gradient .and. settings%run_cc) then
+         call result%error%set(ERROR_VALIDATION, "a coupled cluster gradient needs the "// &
+                               "Lambda amplitudes, which are not implemented. Run the "// &
+                               "gradient at the Hartree-Fock or MP2 level, or coupled "// &
+                               "cluster as an energy.")
          result%has_error = .true.
          return
+      end if
+      if (do_gradient .and. settings%run_mp2) then
+         if (settings%density_fitting) then
+            call result%error%set(ERROR_VALIDATION, "the MP2 gradient differentiates an "// &
+                                  "exact-ERI reference: with density_fitting on it would "// &
+                                  "be the derivative of an energy nothing computed. Run "// &
+                                  "the MP2 gradient without density fitting.")
+            result%has_error = .true.
+            return
+         end if
+         if (settings%freeze_core .and. settings%n_frozen_core /= 0) then
+            call result%error%set(ERROR_VALIDATION, "the MP2 gradient does not implement "// &
+                                  "a frozen core: the relaxed density gains "// &
+                                  "occupied-frozen and virtual-frozen blocks that are not "// &
+                                  "built. Run the MP2 gradient with freeze_core off.")
+            result%has_error = .true.
+            return
+         end if
       end if
 
       ! Same rule the GPU backend applies, so a deck does not change meaning
@@ -502,7 +517,7 @@ contains
       ! auxiliary basis handed over is the one the SCF fitted with rather than
       ! whatever the deck names: a fitted energy differentiated as an exact one
       ! is a gradient of a function nobody computed.
-      if (do_gradient) then
+      if (do_gradient .and. .not. settings%run_mp2) then
          aux_arg => null()
          xc_arg => null()
          if (settings%density_fitting) aux_arg => aux
@@ -576,6 +591,40 @@ contains
             result%energy%mp2%os = mp2%opposite_spin
             result%energy%mp2%ss_scale = settings%scs_ss
             result%energy%mp2%os_scale = settings%scs_os
+
+            ! The gradient of what was just computed, and only where that is
+            ! literally true: a scaled MP2 is a different energy, and its
+            ! gradient is not this one scaled -- the amplitudes enter the
+            ! relaxed density and the Z-vector unscaled.
+            if (do_gradient) then
+               if (settings%scs_ss /= 1.0_dp .or. settings%scs_os /= 1.0_dp) then
+                  call result%error%set(ERROR_VALIDATION, "a spin-scaled MP2 gradient "// &
+                                        "is not the unscaled one rescaled: the "// &
+                                        "amplitudes enter the relaxed density and the "// &
+                                        "response equations, where the two spin cases "// &
+                                        "are not separable afterwards. Run SCS-MP2 as "// &
+                                        "an energy.")
+                  result%has_error = .true.
+                  call mol%destroy()
+                  return
+               end if
+               call libcint_mp2_gradient(mol, scf%orbitals, scf%orbital_energies, &
+                                         fragment%nelec/2, result%gradient, error, &
+                                         n_frozen=frozen)
+               if (error%has_error()) then
+                  call result%error%set(ERROR_VALIDATION, "MP2 gradient: "// &
+                                        error%get_message())
+                  result%has_error = .true.
+                  call mol%destroy()
+                  return
+               end if
+               result%has_gradient = .true.
+               if (settings%verbose) then
+                  write (*, "(a,f20.12)") "  |gradient|     ", &
+                     sqrt(sum(result%gradient**2))
+               end if
+            end if
+
             if (settings%verbose) then
                write (line, "(a,i0,a,i0,a,i0)") "  MP2: frozen ", mp2%n_frozen, "  occupied ", &
                   mp2%n_occupied, "  virtual ", mp2%n_virtual

--- a/backends/libcint/mqc_libcint_cphf.f90
+++ b/backends/libcint/mqc_libcint_cphf.f90
@@ -135,7 +135,8 @@ contains
    end subroutine hessian_destroy
 
    subroutine cphf_solve(mol, orbitals, orbital_energies, n_occ, perturbations, &
-                         response, error, max_iter, tol, iterations, in_core, mo_rhs)
+                         response, error, max_iter, tol, iterations, in_core, mo_rhs, &
+                         eri_in)
       !! Solve the coupled-perturbed equations for one or more perturbations
       type(libcint_molecule_t), intent(in) :: mol
       real(dp), intent(in) :: orbitals(:, :)          !! MO coefficients, (n_ao, n_mo)
@@ -158,6 +159,11 @@ contains
          !! Store every integral instead of recomputing them. Default is direct.
          !! Present and true is the reference path, not the production one -- see
          !! the note where it is used.
+      real(dp), intent(in), optional, target :: eri_in(:, :, :, :)
+         !! An already-built two-electron tensor, used in place of building one.
+         !! Implies `in_core`. A caller that has the tensor for its own reasons --
+         !! the MP2 gradient contracts it against the two-particle density --
+         !! would otherwise pay for a second identical build.
       real(dp), intent(in), optional :: mo_rhs(:, :, :)
          !! The right-hand side already in the occupied-virtual MO block,
          !! `(n_vir, n_occ, n_perturbations)`. The Z-vector equation of an MP2
@@ -165,7 +171,9 @@ contains
          !! assembled in the MO basis, not a one-electron operator, and there is
          !! no AO matrix it is the transform of.
 
-      real(dp), allocatable :: eri(:, :, :, :), c_occ(:, :), c_vir(:, :), bounds(:, :)
+      real(dp), allocatable, target :: eri_own(:, :, :, :)
+      real(dp), pointer :: eri(:, :, :, :)
+      real(dp), allocatable :: c_occ(:, :), c_vir(:, :), bounds(:, :)
       real(dp), allocatable :: gaps(:, :), rhs(:, :), x(:, :), r(:, :), z(:, :)
       real(dp), allocatable :: p(:, :), ap(:, :), work(:, :), zero_h(:, :)
       real(dp) :: rz, rz_new, pap, target_norm, step, use_tol
@@ -238,12 +246,21 @@ contains
       ! against, exactly as `run_libcint_rhf` keeps its own `in_core`.
       direct = .true.
       if (present(in_core)) direct = .not. in_core
-      if (direct) then
+      if (present(eri_in)) direct = .false.
+      if (present(eri_in)) then
+         ! Pointed at, not copied: the tensor is the largest object either side
+         ! of this call has, and duplicating it to pass it would cost more than
+         ! the solve.
+         eri => eri_in
+         allocate (bounds(0, 0))
+      else if (direct) then
          call schwarz_bounds(mol, bounds, error)
          if (error%has_error()) return
-         allocate (eri(0, 0, 0, 0))
+         allocate (eri_own(0, 0, 0, 0))
+         eri => eri_own
       else
-         call mol%eris(eri)
+         call mol%eris(eri_own)
+         eri => eri_own
          allocate (bounds(0, 0))
       end if
       allocate (zero_h(n_ao, n_ao))
@@ -317,7 +334,9 @@ contains
       end do
 
       if (present(iterations)) iterations = worst
-      deallocate (eri, bounds, c_occ, c_vir, gaps, rhs, x, r, z, p, ap, work, zero_h)
+      nullify (eri)
+      if (allocated(eri_own)) deallocate (eri_own)
+      deallocate (bounds, c_occ, c_vir, gaps, rhs, x, r, z, p, ap, work, zero_h)
    end subroutine cphf_solve
 
    subroutine response_operator(mol, direct, eri, bounds, zero_h, c_occ, c_vir, &

--- a/backends/libcint/mqc_libcint_cphf.f90
+++ b/backends/libcint/mqc_libcint_cphf.f90
@@ -135,17 +135,17 @@ contains
    end subroutine hessian_destroy
 
    subroutine cphf_solve(mol, orbitals, orbital_energies, n_occ, perturbations, &
-                         response, error, max_iter, tol, iterations, in_core)
+                         response, error, max_iter, tol, iterations, in_core, mo_rhs)
       !! Solve the coupled-perturbed equations for one or more perturbations
       type(libcint_molecule_t), intent(in) :: mol
       real(dp), intent(in) :: orbitals(:, :)          !! MO coefficients, (n_ao, n_mo)
       real(dp), intent(in) :: orbital_energies(:)     !! (n_mo), Hartree
       integer, intent(in) :: n_occ
-      real(dp), intent(in) :: perturbations(:, :, :)
+      real(dp), intent(in), optional :: perturbations(:, :, :)
          !! One-electron perturbation operators in the **AO** basis,
          !! `(n_ao, n_ao, n_perturbations)`. AO rather than MO because every
          !! caller has them that way and the occupied-virtual transform is this
-         !! routine's business.
+         !! routine's business. Exactly one of this and `mo_rhs` is given.
       real(dp), allocatable, intent(out) :: response(:, :, :)
          !! `U_ai` per perturbation, `(n_vir, n_occ, n_perturbations)`.
       type(error_t), intent(inout) :: error
@@ -158,6 +158,12 @@ contains
          !! Store every integral instead of recomputing them. Default is direct.
          !! Present and true is the reference path, not the production one -- see
          !! the note where it is used.
+      real(dp), intent(in), optional :: mo_rhs(:, :, :)
+         !! The right-hand side already in the occupied-virtual MO block,
+         !! `(n_vir, n_occ, n_perturbations)`. The Z-vector equation of an MP2
+         !! gradient arrives this way: its right-hand side is a Lagrangian
+         !! assembled in the MO basis, not a one-electron operator, and there is
+         !! no AO matrix it is the transform of.
 
       real(dp), allocatable :: eri(:, :, :, :), c_occ(:, :), c_vir(:, :), bounds(:, :)
       real(dp), allocatable :: gaps(:, :), rhs(:, :), x(:, :), r(:, :), z(:, :)
@@ -181,12 +187,25 @@ contains
          call error%set(ERROR_VALIDATION, "CPHF: one orbital energy per orbital")
          return
       end if
-      if (size(perturbations, 1) /= n_ao .or. size(perturbations, 2) /= n_ao) then
-         call error%set(ERROR_VALIDATION, "CPHF: the perturbations are not n_ao square")
+      if (present(perturbations) .eqv. present(mo_rhs)) then
+         call error%set(ERROR_VALIDATION, "CPHF: give either AO perturbations or an "// &
+                        "MO-basis right-hand side, not both and not neither")
          return
       end if
-
-      n_pert = size(perturbations, 3)
+      if (present(perturbations)) then
+         if (size(perturbations, 1) /= n_ao .or. size(perturbations, 2) /= n_ao) then
+            call error%set(ERROR_VALIDATION, "CPHF: the perturbations are not n_ao square")
+            return
+         end if
+         n_pert = size(perturbations, 3)
+      else
+         if (size(mo_rhs, 1) /= n_vir .or. size(mo_rhs, 2) /= n_occ) then
+            call error%set(ERROR_VALIDATION, "CPHF: the right-hand side is not "// &
+                           "(n_vir, n_occ)")
+            return
+         end if
+         n_pert = size(mo_rhs, 3)
+      end if
       limit = DEFAULT_MAX_ITER
       if (present(max_iter)) limit = max_iter
       use_tol = DEFAULT_TOL
@@ -237,9 +256,14 @@ contains
       worst = 0
 
       do ipert = 1, n_pert
-         ! h_ai, the perturbation in the occupied-virtual block.
-         call pic_gemm(perturbations(:, :, ipert), c_occ, work)
-         call pic_gemm(c_vir, work, rhs, transa="T")
+         ! h_ai, the perturbation in the occupied-virtual block -- or that
+         ! block itself, when the caller assembled it there.
+         if (present(perturbations)) then
+            call pic_gemm(perturbations(:, :, ipert), c_occ, work)
+            call pic_gemm(c_vir, work, rhs, transa="T")
+         else
+            rhs = mo_rhs(:, :, ipert)
+         end if
          rhs = -rhs
 
          target_norm = sqrt(sum(rhs*rhs))

--- a/backends/libcint/mqc_libcint_gradient.f90
+++ b/backends/libcint/mqc_libcint_gradient.f90
@@ -54,6 +54,14 @@ module mqc_libcint_gradient
    public :: nuclear_repulsion_gradient   !! Exposed for the tests
    public :: three_centre_deriv           !! Exposed for the tests
    public :: two_centre_deriv             !! Exposed for the tests
+   ! The pieces an MP2 gradient assembles for itself. It cannot call
+   ! `libcint_scf_gradient` and add to the answer -- the relaxed density enters
+   ! the one-electron and overlap terms in place of the reference one, not
+   ! alongside it -- so it needs the same derivative integrals rather than the
+   ! same assembly.
+   public :: one_electron_deriv
+   public :: iprinv_deriv_at
+   public :: DERIV_OVLP, DERIV_KIN, DERIV_NUC
 
    ! Which one-electron derivative `one_electron_deriv` should build.
    integer, parameter :: DERIV_OVLP = 1

--- a/backends/libcint/mqc_libcint_mp2.f90
+++ b/backends/libcint/mqc_libcint_mp2.f90
@@ -46,6 +46,7 @@ module mqc_libcint_mp2
    ! (ia|jb). Lives here because this is where the two-half transform is, and a
    ! second copy of it in the CC module is a second chance to transpose a half.
    public :: transform_block
+   public :: transform_ovov   !! The MP2 gradient builds its own amplitudes from this
 
    type :: mp2_result_t
       !! What an MP2 calculation leaves behind

--- a/backends/libcint/mqc_libcint_mp2_gradient.f90
+++ b/backends/libcint/mqc_libcint_mp2_gradient.f90
@@ -37,10 +37,12 @@ module mqc_libcint_mp2_gradient
    !! relaxed density which are not built here.
    use pic_types, only: dp
    use mqc_error, only: error_t, ERROR_VALIDATION
-   use mqc_libcint_integrals, only: libcint_molecule_t, shell_dim, atom_ao_blocks
+   use mqc_libcint_integrals, only: libcint_molecule_t, shell_dim, atom_ao_blocks, &
+                                    two_electron_block
    use mqc_libcint_mp2, only: transform_ovov
    use mqc_libcint_cphf, only: cphf_solve
    use mqc_libcint_rhf, only: build_fock
+   use mqc_libcint_direct, only: build_fock_direct, schwarz_bounds, direct_stats_t
    use pic_blas_interfaces, only: pic_gemm
    use mqc_libcint_gradient, only: nuclear_repulsion_gradient, one_electron_deriv, &
                                    iprinv_deriv_at, DERIV_OVLP, DERIV_KIN, DERIV_NUC
@@ -53,6 +55,12 @@ module mqc_libcint_mp2_gradient
 
    public :: libcint_mp2_gradient
 
+   real(dp), parameter :: BLOCK_TARGET = 5.0e8_dp
+      !! Bytes the blocked path aims to hold in its two live block arrays. Not a
+      !! hard limit on the routine -- the half-transformed amplitudes and the
+      !! one-particle quantities sit outside it -- but it is what sets the block
+      !! size, and it is the number to raise on a machine with room.
+
    real(dp), parameter :: IN_CORE_LIMIT = 4.0e9_dp
       !! Bytes. The same ceiling `mqc_libcint_cphf` applies to its own stored
       !! tensor, for the same reason and deliberately not a different number.
@@ -60,7 +68,7 @@ module mqc_libcint_mp2_gradient
 contains
 
    subroutine libcint_mp2_gradient(mol, coeff, orbital_energies, n_occ, gradient, &
-                                   error, n_frozen)
+                                   error, n_frozen, block_bytes)
       !! dE(MP2)/dR for a closed-shell reference, in Hartree/Bohr
       type(libcint_molecule_t), intent(in) :: mol
       real(dp), intent(in) :: coeff(:, :)            !! C, (n_ao, n_mo)
@@ -69,6 +77,12 @@ contains
       real(dp), allocatable, intent(out) :: gradient(:, :)   !! (3, natm)
       type(error_t), intent(inout) :: error
       integer, intent(in), optional :: n_frozen
+      real(dp), intent(in), optional :: block_bytes
+         !! Take the blocked path whatever the size, with this byte target
+         !! instead of `BLOCK_TARGET`. For the check harness, which runs every
+         !! case both ways and compares -- and which passes something small
+         !! enough to force *several* blocks, since a single block exercises
+         !! neither the loop over them nor the index offset.
 
       real(dp), allocatable :: eri_packed(:, :), eri(:, :, :, :)
       real(dp), allocatable :: ovov(:, :, :, :), t2(:, :, :, :)
@@ -86,7 +100,9 @@ contains
       real(dp), allocatable :: im1_t(:, :), work_t(:, :)
       integer, allocatable :: offsets(:), counts(:)
       integer :: n_ao, n_mo, n_o, n_v, frozen, iatom, comp, p0, p1, p, q, i, a
-      character(len=32) :: text, gigabytes
+      logical :: dense
+      real(dp) :: target_bytes
+      real(dp), allocatable :: half(:, :), bounds(:, :)
 
       n_ao = mol%nao
       n_mo = size(coeff, 2)
@@ -113,22 +129,18 @@ contains
          return
       end if
 
-      ! Refused rather than attempted. Two dense `n_ao^4` arrays are live at
-      ! once here -- the integrals and the two-particle density -- so the
-      ! ceiling arrives as an allocation failure or an out-of-memory kill, with
-      ! nothing to say which array or how far over it went. Blocking the
-      ! two-particle density over its first index is what lifts this; until
-      ! then the limit is worth stating in the one place that knows it.
-      if (2.0_dp*real(n_ao, dp)**4*8.0_dp > IN_CORE_LIMIT) then
-         write (text, "(i0)") n_ao
-         write (gigabytes, "(f0.1)") 2.0_dp*real(n_ao, dp)**4*8.0_dp/1.0e9_dp
-         call error%set(ERROR_VALIDATION, "the MP2 gradient stores the integrals and "// &
-                        "the two-particle density as dense n^4 arrays, which for "// &
-                        trim(text)//" basis functions is "//trim(gigabytes)//" GB. "// &
-                        "Blocking over the auxiliary index is not implemented, so this "// &
-                        "is refused rather than attempted. Use a smaller basis, or "// &
-                        "fragment the system.")
-         return
+      ! Dense or blocked. Dense keeps two `n_ao^4` arrays live -- the integrals
+      ! and the two-particle density -- and is worth taking whenever it fits,
+      ! because one gemm over the whole first index beats the same gemm run
+      ! block by block, and because the integrals get built once with their full
+      ! eightfold symmetry instead of once per block with only the ket pair's.
+      ! Blocked pays roughly four times the integral work for a memory ceiling
+      ! that is a choice rather than the basis size.
+      dense = 2.0_dp*real(n_ao, dp)**4*8.0_dp <= IN_CORE_LIMIT
+      target_bytes = BLOCK_TARGET
+      if (present(block_bytes)) then
+         dense = .false.
+         target_bytes = block_bytes
       end if
 
       allocate (c_occ(n_ao, n_o), c_vir(n_ao, n_v))
@@ -151,10 +163,38 @@ contains
       dm1mo(n_o + 1:n_mo, n_o + 1:n_mo) = dvv + transpose(dvv)
 
       ! ---- the two-particle density, and what it contracts against ----------
-      call build_two_particle_density(t2, c_occ, c_vir, n_ao, n_o, n_v, gamma_ao)
+      call build_half_transformed(t2, c_vir, n_ao, n_o, n_v, half)
+      deallocate (t2)
 
-      call mol%eris(eri)
-      call contract_gamma_eri(eri, gamma_ao, n_ao, imat_ao)
+      if (.not. dense) then
+         ! The direct Fock builds below need these, and so does the response
+         ! solve, which cannot be handed a tensor that was never formed.
+         call schwarz_bounds(mol, bounds, error)
+         if (error%has_error()) return
+      else
+         allocate (bounds(0, 0))
+      end if
+
+      allocate (imat_ao(n_ao, n_ao), de2(3, mol%natm), vhf1(n_ao, n_ao, 3, mol%natm))
+      imat_ao = 0.0_dp
+      de2 = 0.0_dp
+      vhf1 = 0.0_dp
+
+      allocate (hf_density(n_ao, n_ao))
+      hf_density = 2.0_dp*matmul(c_occ, transpose(c_occ))
+
+      if (dense) then
+         call build_two_particle_density(half, c_occ, n_ao, n_o, gamma_ao)
+         call mol%eris(eri)
+         call contract_gamma_eri(eri, gamma_ao, n_ao, imat_ao)
+         call two_electron_mp2_terms(mol, gamma_ao, hf_density, de2, vhf1)
+         deallocate (gamma_ao)
+      else
+         call blocked_two_electron_terms(mol, half, c_occ, hf_density, n_ao, n_o, &
+                                         target_bytes, imat_ao, de2, vhf1, error)
+         if (error%has_error()) return
+      end if
+      deallocate (half)
 
       ! ---- the Lagrangian, and the orbitals relaxing under it ---------------
       !
@@ -167,9 +207,6 @@ contains
       imat = -matmul(transpose(coeff), work)
       deallocate (work)
 
-      allocate (hf_density(n_ao, n_ao))
-      hf_density = 2.0_dp*matmul(c_occ, transpose(c_occ))
-
       allocate (dm1(n_ao, n_ao))
       dm1 = matmul(coeff, matmul(dm1mo, transpose(coeff)))
       ! `build_fock` returns `H + J - K/2`; a zero core Hamiltonian leaves the
@@ -177,7 +214,8 @@ contains
       ! the target element, and already the hot routine of the CPHF solver.
       allocate (zero_h(n_ao, n_ao), veff(n_ao, n_ao))
       zero_h = 0.0_dp
-      call build_fock(zero_h, eri, dm1, veff)
+      call two_electron_potential(dense, mol, eri, bounds, zero_h, dm1, veff, error)
+      if (error%has_error()) return
       veff = 2.0_dp*veff
 
       allocate (xvo(n_v, n_o, 1))
@@ -198,9 +236,18 @@ contains
       ! would land in the gradient undiluted. Handing over the tensor built for
       ! the Lagrangian rather than letting it build its own saves a second
       ! identical pass over every integral -- 10% of this routine at cc-pVTZ.
-      call cphf_solve(mol, coeff, orbital_energies, n_occ, response=zvec, &
-                      error=error, mo_rhs=xvo, tol=1.0e-12_dp, max_iter=200, &
-                      eri_in=eri)
+      if (dense) then
+         call cphf_solve(mol, coeff, orbital_energies, n_occ, response=zvec, &
+                         error=error, mo_rhs=xvo, tol=1.0e-12_dp, max_iter=200, &
+                         eri_in=eri)
+      else
+         ! Integral-direct, with the same Schwarz bound the Fock builds use.
+         ! Measured against the stored path on water/cc-pVDZ, the screening
+         ! moves the gradient by less than 1e-12 -- it is the reference's own
+         ! Krylov solver, not screening, that put 4e-8 between the two codes.
+         call cphf_solve(mol, coeff, orbital_energies, n_occ, response=zvec, &
+                         error=error, mo_rhs=xvo, tol=1.0e-12_dp, max_iter=200)
+      end if
       if (error%has_error()) return
 
       dm1mo(n_o + 1:n_mo, 1:n_o) = dm1mo(n_o + 1:n_mo, 1:n_o) + zvec(:, :, 1)
@@ -238,7 +285,9 @@ contains
 
       allocate (p_occ(n_ao, n_ao))
       p_occ = matmul(c_occ, transpose(c_occ))
-      call build_fock(zero_h, eri, dm1 + transpose(dm1), veff)
+      call two_electron_potential(dense, mol, eri, bounds, zero_h, &
+                                  dm1 + transpose(dm1), veff, error)
+      if (error%has_error()) return
       allocate (vhf_s1occ(n_ao, n_ao))
       vhf_s1occ = matmul(p_occ, matmul(veff, p_occ))
 
@@ -256,9 +305,7 @@ contains
          end do
       end do
 
-      ! ---- the differentiated integrals -------------------------------------
-      call two_electron_mp2_terms(mol, gamma_ao, hf_density, de2, vhf1)
-
+      ! ---- the one-electron derivatives -------------------------------------
       call one_electron_deriv(mol, s1, DERIV_OVLP)
       s1 = -s1
       call one_electron_deriv(mol, kin, DERIV_KIN)
@@ -389,7 +436,144 @@ contains
       end do
    end subroutine gamma1_intermediates
 
-   subroutine build_two_particle_density(t2, c_occ, c_vir, n_ao, n_o, n_v, gamma_ao)
+   subroutine two_electron_potential(dense, mol, eri, bounds, zero_h, density, &
+                                     veff, error)
+      !! `J - K/2`, from the stored tensor or from the integrals directly
+      !!
+      !! Which one is not a choice about accuracy -- the two agree to better
+      !! than 1e-12 here -- but about whether a tensor exists to read. The
+      !! blocked path never forms one.
+      logical, intent(in) :: dense
+      type(libcint_molecule_t), intent(in) :: mol
+      real(dp), intent(in) :: eri(:, :, :, :), bounds(:, :)
+      real(dp), intent(in) :: zero_h(:, :), density(:, :)
+      real(dp), intent(out) :: veff(:, :)
+      type(error_t), intent(inout) :: error
+
+      type(direct_stats_t) :: stats
+
+      if (dense) then
+         call build_fock(zero_h, eri, density, veff)
+      else
+         call build_fock_direct(mol, zero_h, density, bounds, veff, stats, error)
+      end if
+   end subroutine two_electron_potential
+
+   subroutine build_half_transformed(t2, c_vir, n_ao, n_o, n_v, half)
+      !! `half(i, (q, r, j))`, the amplitudes with both virtual indices in the
+      !! AO basis and the energy's weighting applied
+      !!
+      !! `4 t2(i,j,a,b) - 2 t2(i,j,b,a)` is the coefficient the energy gives
+      !! each integral. Shared by the dense and blocked paths, and `n_o^2
+      !! n_ao^2` either way -- smaller than `n_ao^4` by `(n_o/n_ao)^2`, but not
+      !! bounded: past a few hundred functions this is what the blocked path's
+      !! footprint is, not the block target. Blocking it over `j` is the next
+      !! ceiling to lift, and nothing above depends on it being whole.
+      real(dp), intent(in) :: t2(:, :, :, :)
+      real(dp), intent(in) :: c_vir(:, :)
+      integer, intent(in) :: n_ao, n_o, n_v
+      real(dp), allocatable, intent(out) :: half(:, :)
+
+      real(dp), allocatable :: part(:, :, :, :), tmp(:, :)
+      integer :: i, j, q, r, col
+
+      ! part(i,j,p,q) = sum_ab t2(i,j,a,b) C_vir(p,a) C_vir(q,b)
+      allocate (part(n_o, n_o, n_ao, n_ao), tmp(n_v, n_ao))
+      do j = 1, n_o
+         do i = 1, n_o
+            tmp = matmul(t2(i, j, :, :), transpose(c_vir))
+            part(i, j, :, :) = matmul(c_vir, tmp)
+         end do
+      end do
+      deallocate (tmp)
+
+      allocate (half(n_o, n_ao*n_ao*n_o))
+      !$omp parallel do collapse(3) default(none) &
+      !$omp    shared(half, part, n_o, n_ao) private(i, j, q, r, col)
+      do j = 1, n_o
+         do r = 1, n_ao
+            do q = 1, n_ao
+               col = q + n_ao*(r - 1) + n_ao*n_ao*(j - 1)
+               do i = 1, n_o
+                  half(i, col) = 4.0_dp*part(i, j, q, r) - 2.0_dp*part(i, j, r, q)
+               end do
+            end do
+         end do
+      end do
+      !$omp end parallel do
+      deallocate (part)
+   end subroutine build_half_transformed
+
+   subroutine build_gamma_block(half, c_occ, n_ao, n_o, p_lo, p_hi, gamma_blk)
+      !! The two-particle density for a range of its first index
+      !!
+      !! The same two contractions the dense path makes, with the first index
+      !! restricted -- and the bra-pair term written out rather than obtained by
+      !! transposing, because the transpose of a block is not a block: the
+      !! `sum_i C(q,i) half(i,p,r,j)` term needs `p` restricted and `q` free,
+      !! which is a different contraction rather than a rearrangement of the
+      !! first one.
+      real(dp), intent(in) :: half(:, :)
+      real(dp), intent(in) :: c_occ(:, :)
+      integer, intent(in) :: n_ao, n_o, p_lo, p_hi
+      real(dp), allocatable, target, intent(out) :: gamma_blk(:, :, :, :)
+
+      real(dp), allocatable, target :: xbuf(:)
+      real(dp), allocatable :: hblk(:, :), tblk(:, :)
+      real(dp), pointer :: x_first(:, :), x_second(:, :), gamma_flat(:, :)
+      integer :: np, p, q, r, j, col, colb
+
+      np = p_hi - p_lo + 1
+
+      allocate (xbuf(int(np, kind=8)*n_ao*n_ao*n_o))
+      x_first(1:np, 1:n_ao*n_ao*n_o) => xbuf
+      x_second(1:np*n_ao*n_ao, 1:n_o) => xbuf
+
+      ! term one: sum_i C(p,i) half(i, q, r, j), for p in the block
+      call pic_gemm(c_occ(p_lo:p_hi, :), half, x_first)
+
+      ! term two: sum_i C(q,i) half(i, p, r, j), same block of p. Gathered into
+      ! `(i, (p r j))` first, because the block is a stride in `half` and BLAS
+      ! wants it contiguous.
+      allocate (hblk(n_o, np*n_ao*n_o), tblk(n_ao, np*n_ao*n_o))
+      !$omp parallel do collapse(3) default(none) &
+      !$omp    shared(hblk, half, n_o, n_ao, np, p_lo) private(j, r, p, col, colb)
+      do j = 1, n_o
+         do r = 1, n_ao
+            do p = 1, np
+               colb = p + np*(r - 1) + np*n_ao*(j - 1)
+               col = (p_lo + p - 1) + n_ao*(r - 1) + n_ao*n_ao*(j - 1)
+               hblk(:, colb) = half(:, col)
+            end do
+         end do
+      end do
+      !$omp end parallel do
+      call pic_gemm(c_occ, hblk, tblk)
+      deallocate (hblk)
+
+      !$omp parallel do collapse(3) default(none) &
+      !$omp    shared(x_first, tblk, n_o, n_ao, np) private(j, r, p, q, col, colb)
+      do j = 1, n_o
+         do r = 1, n_ao
+            do q = 1, n_ao
+               col = q + n_ao*(r - 1) + n_ao*n_ao*(j - 1)
+               colb = np*(r - 1) + np*n_ao*(j - 1)
+               do p = 1, np
+                  x_first(p, col) = x_first(p, col) + tblk(q, p + colb)
+               end do
+            end do
+         end do
+      end do
+      !$omp end parallel do
+      deallocate (tblk)
+
+      allocate (gamma_blk(np, n_ao, n_ao, n_ao))
+      gamma_flat(1:np*n_ao*n_ao, 1:n_ao) => gamma_blk
+      call pic_gemm(x_second, c_occ, gamma_flat, transb="T")
+      deallocate (xbuf)
+   end subroutine build_gamma_block
+
+   subroutine build_two_particle_density(half, c_occ, n_ao, n_o, gamma_ao)
       !! The non-separable two-particle density, in the AO basis
       !!
       !! `4 t2(i,j,a,b) - 2 t2(i,j,b,a)` is the coefficient the energy gives
@@ -407,53 +591,25 @@ contains
       !! `(p, q r j)` by the first and `(p q r, j)` by the second without a
       !! copy: the memory order is the same either way.
       !!
-      !! `n_ao^4` and dense. That is what limits this to validation-sized
-      !! systems; blocking over the first index is the way out, and is a
-      !! separate change.
-      real(dp), intent(in) :: t2(:, :, :, :)
-      real(dp), intent(in) :: c_occ(:, :), c_vir(:, :)
-      integer, intent(in) :: n_ao, n_o, n_v
+      !! `n_ao^4` and dense, which is the point: this is the path taken when
+      !! the whole thing fits, where one gemm over the full first index beats
+      !! the same gemm run block by block. `build_gamma_block` is the other
+      !! path, and the driver picks between them on the size.
+      real(dp), intent(in) :: half(:, :)
+      real(dp), intent(in) :: c_occ(:, :)
+      integer, intent(in) :: n_ao, n_o
       real(dp), allocatable, target, intent(out) :: gamma_ao(:, :, :, :)
 
-      real(dp), allocatable :: part(:, :, :, :), tmp(:, :), half(:, :)
       real(dp), allocatable, target :: xbuf(:)
       real(dp), pointer :: x_first(:, :), x_second(:, :), gamma_flat(:, :)
       real(dp) :: acc
-      integer :: i, j, p, q, r, s, col
-
-      ! part(i,j,p,q) = sum_ab t2(i,j,a,b) C_vir(p,a) C_vir(q,b)
-      allocate (part(n_o, n_o, n_ao, n_ao), tmp(n_v, n_ao))
-      do j = 1, n_o
-         do i = 1, n_o
-            tmp = matmul(t2(i, j, :, :), transpose(c_vir))
-            part(i, j, :, :) = matmul(c_vir, tmp)
-         end do
-      end do
-      deallocate (tmp)
-
-      ! half(i, (q, r, j)), the combination the energy weights each integral by
-      allocate (half(n_o, n_ao*n_ao*n_o))
-      !$omp parallel do collapse(3) default(none) &
-      !$omp    shared(half, part, n_o, n_ao) private(i, j, q, r, col)
-      do j = 1, n_o
-         do r = 1, n_ao
-            do q = 1, n_ao
-               col = q + n_ao*(r - 1) + n_ao*n_ao*(j - 1)
-               do i = 1, n_o
-                  half(i, col) = 4.0_dp*part(i, j, q, r) - 2.0_dp*part(i, j, r, q)
-               end do
-            end do
-         end do
-      end do
-      !$omp end parallel do
-      deallocate (part)
+      integer :: p, q, r, s
 
       allocate (xbuf(int(n_ao, kind=8)*n_ao*n_ao*n_o))
       x_first(1:n_ao, 1:n_ao*n_ao*n_o) => xbuf
       x_second(1:n_ao*n_ao*n_ao, 1:n_o) => xbuf
 
       call pic_gemm(c_occ, half, x_first)
-      deallocate (half)
 
       allocate (gamma_ao(n_ao, n_ao, n_ao, n_ao))
       gamma_flat(1:n_ao*n_ao*n_ao, 1:n_ao) => gamma_ao
@@ -491,6 +647,87 @@ contains
       !$omp end parallel do
 
    end subroutine build_two_particle_density
+
+   subroutine blocked_two_electron_terms(mol, half, c_occ, hf_density, n_ao, n_o, &
+                                         target_bytes, imat_ao, de2, vhf1, error)
+      !! The Lagrangian and the gradient's two-electron term, a block at a time
+      !!
+      !! Neither the integrals nor the two-particle density is ever whole here.
+      !! Both are built for one range of the first index, contracted, and
+      !! discarded, so the peak is `BLOCK_TARGET` rather than `2 n_ao^4`.
+      !!
+      !! **What blocking costs.** The undifferentiated integrals are rebuilt for
+      !! each block instead of being stored, and within a block only the ket
+      !! pair's symmetry is available -- the first index is pinned to the block,
+      !! which is what rules the other permutations out. That is roughly four
+      !! times the integral work of the dense path's one symmetric build. It
+      !! buys a ceiling set by choice instead of by the basis.
+      !!
+      !! Blocks are cut on shell boundaries, since a shell's functions share a
+      !! quartet and cannot be split across two passes.
+      type(libcint_molecule_t), intent(in) :: mol
+      real(dp), intent(in) :: half(:, :), c_occ(:, :), hf_density(:, :)
+      integer, intent(in) :: n_ao, n_o
+      real(dp), intent(in) :: target_bytes
+      real(dp), intent(inout) :: imat_ao(:, :)
+      real(dp), intent(inout) :: de2(:, :), vhf1(:, :, :, :)
+      type(error_t), intent(inout) :: error
+
+      real(dp), allocatable, target :: gamma_blk(:, :, :, :)
+      real(dp), allocatable :: eri_blk(:, :, :, :), local(:, :)
+      integer :: ish, ish_lo, ish_hi, p_lo, p_hi, np, per_block, r, s
+
+      ! How many functions of the first index one block may carry, from the
+      ! target and the two arrays that scale with it.
+      per_block = max(1, int(target_bytes/(2.0_dp*real(n_ao, dp)**3*8.0_dp)))
+
+      ish_lo = 1
+      do while (ish_lo <= mol%nbas)
+         ! Grow the block by whole shells until it would exceed the target.
+         p_lo = mol%shell_offset(ish_lo) + 1
+         ish_hi = ish_lo
+         do ish = ish_lo, mol%nbas
+            p_hi = mol%shell_offset(ish) + shell_dim(mol%cartesian, ish - 1, mol%bas)
+            if (ish > ish_lo .and. p_hi - p_lo + 1 > per_block) exit
+            ish_hi = ish
+         end do
+         p_hi = mol%shell_offset(ish_hi) + shell_dim(mol%cartesian, ish_hi - 1, mol%bas)
+         np = p_hi - p_lo + 1
+
+         call build_gamma_block(half, c_occ, n_ao, n_o, p_lo, p_hi, gamma_blk)
+
+         allocate (eri_blk(np, n_ao, n_ao, n_ao))
+         eri_blk = 0.0_dp
+         call two_electron_mp2_terms(mol, gamma_blk, hf_density, de2, vhf1, &
+                                     ish_lo=ish_lo, ish_hi=ish_hi, &
+                                     p_offset=p_lo - 1, eri_blk=eri_blk)
+
+         ! The Lagrangian, over this block of the contracted first index. Same
+         ! product as the dense path, with `k` the block rather than `n_ao`.
+         !$omp parallel default(none) shared(eri_blk, gamma_blk, imat_ao, n_ao) &
+         !$omp    private(r, s, local)
+         allocate (local(n_ao, n_ao))
+         local = 0.0_dp
+         !$omp do collapse(2) schedule(static)
+         do s = 1, n_ao
+            do r = 1, n_ao
+               call pic_gemm(eri_blk(:, :, r, s), gamma_blk(:, :, r, s), local, &
+                             transa="T", beta=1.0_dp)
+            end do
+         end do
+         !$omp end do
+         !$omp critical
+         imat_ao = imat_ao + local
+         !$omp end critical
+         deallocate (local)
+         !$omp end parallel
+
+         deallocate (eri_blk, gamma_blk)
+         ish_lo = ish_hi + 1
+      end do
+
+      if (error%has_error()) return
+   end subroutine blocked_two_electron_terms
 
    subroutine contract_gamma_eri(eri, gamma_ao, n_ao, imat_ao)
       !! `Imat(p,q) = sum_{u,r,s} (u p|r s) gamma(u,q,r,s)`
@@ -530,7 +767,8 @@ contains
       !$omp end parallel
    end subroutine contract_gamma_eri
 
-   subroutine two_electron_mp2_terms(mol, gamma_ao, hf_density, de2, vhf1)
+   subroutine two_electron_mp2_terms(mol, gamma_ao, hf_density, de2, vhf1, &
+                                     ish_lo, ish_hi, p_offset, eri_blk)
       !! The differentiated integrals, contracted twice
       !!
       !! Once against the two-particle density, which gives a gradient
@@ -549,8 +787,19 @@ contains
       !! contraction rather than the same number twice.
       type(libcint_molecule_t), intent(in) :: mol
       real(dp), intent(in) :: gamma_ao(:, :, :, :), hf_density(:, :)
-      real(dp), allocatable, intent(out) :: de2(:, :)        !! (3, natm)
-      real(dp), allocatable, intent(out) :: vhf1(:, :, :, :)  !! (nao, nao, 3, natm)
+      real(dp), intent(inout) :: de2(:, :)        !! (3, natm), accumulated into
+      real(dp), intent(inout) :: vhf1(:, :, :, :)  !! (nao, nao, 3, natm), likewise
+      integer, intent(in), optional :: ish_lo, ish_hi
+         !! Shells to differentiate over. Absent means all of them, which is the
+         !! dense path; present is one block of the first index.
+      integer, intent(in), optional :: p_offset
+         !! What `gamma_ao`'s first index is offset by. Absent means zero.
+      real(dp), intent(inout), optional, target :: eri_blk(:, :, :, :)
+         !! Present, the undifferentiated integrals of the same quartets are
+         !! stored here as they are computed. The blocked path needs them for
+         !! the Lagrangian and cannot afford to keep the whole tensor; the dense
+         !! path already has the tensor and leaves this absent, which is why the
+         !! two share this loop rather than each having one.
 
       real(dp), allocatable :: buf(:)
       real(dp), allocatable :: de_local(:, :), vhf_local(:, :, :, :)
@@ -559,8 +808,11 @@ contains
       integer :: shls(4)
       integer :: ish, jsh, ksh, lsh, di, dj, dk, dl
       integer :: io, jo, ko, lo, i, j, k, l, comp, ret, mx, idx
-      integer :: nao, nbas, natm, ia
-      real(dp) :: g
+      integer :: nao, nbas, natm, ia, first, last, off, gi
+      real(dp) :: g, g0
+      real(dp), allocatable :: eri_local(:)
+      real(dp), pointer :: eri_out(:, :, :, :)
+      logical :: want_eri
 
       nao = mol%nao
       nbas = mol%nbas
@@ -578,9 +830,18 @@ contains
          end do
       end do
 
-      allocate (de2(3, natm), vhf1(nao, nao, 3, natm))
-      de2 = 0.0_dp
-      vhf1 = 0.0_dp
+      first = 1
+      last = nbas
+      if (present(ish_lo)) first = ish_lo
+      if (present(ish_hi)) last = ish_hi
+      off = 0
+      if (present(p_offset)) off = p_offset
+      ! Through a pointer rather than the dummy itself: an absent optional
+      ! cannot appear in a data-sharing clause, and naming it there costs more
+      ! than the branch it saves.
+      want_eri = present(eri_blk)
+      eri_out => null()
+      if (want_eri) eri_out => eri_blk
 
       opt = c_null_ptr
       if (mol%cartesian) then
@@ -591,16 +852,18 @@ contains
 
       !$omp parallel default(none) &
       !$omp    shared(mol, gamma_ao, hf_density, de2, vhf1, opt, mx, nao, nbas, natm, &
-      !$omp           shell_atom) &
+      !$omp           shell_atom, first, last, off, want_eri, eri_out) &
       !$omp    private(ish, jsh, ksh, lsh, di, dj, dk, dl, io, jo, ko, lo, &
-      !$omp            i, j, k, l, comp, ret, idx, g, shls, ia, buf, de_local, vhf_local)
+      !$omp            i, j, k, l, comp, ret, idx, g, g0, gi, shls, ia, buf, &
+      !$omp            de_local, vhf_local, eri_local)
       allocate (buf(mx**4*3))
       allocate (de_local(3, natm), vhf_local(nao, nao, 3, natm))
+      allocate (eri_local(mx**4))
       de_local = 0.0_dp
       vhf_local = 0.0_dp
 
       !$omp do schedule(dynamic)
-      do ish = 1, nbas
+      do ish = first, last
          di = shell_dim(mol%cartesian, ish - 1, mol%bas)
          io = mol%shell_offset(ish)
          ia = shell_atom(ish)
@@ -624,6 +887,33 @@ contains
                   end if
                   if (ret == 0) cycle
 
+                  ! The same quartet undifferentiated, where the caller wants
+                  ! it. Written straight into the block rather than accumulated,
+                  ! because each quartet appears once in this loop.
+                  if (want_eri) then
+                     ret = two_electron_block(mol%cartesian, eri_local, shls, mol%atm, &
+                                              mol%natm, mol%bas, nbas, mol%env)
+                     if (ret /= 0) then
+                        do l = 1, dl
+                           do k = 1, dk
+                              do j = 1, dj
+                                 do i = 1, di
+                                    ! libcint packs with the shells' own
+                                    ! dimensions, not the buffer's, so this is
+                                    ! indexed by hand rather than shaped.
+                                    gi = i + di*(j - 1 + dj*(k - 1 + dk*(l - 1)))
+                                    g0 = eri_local(gi)
+                                    eri_out(io + i - off, jo + j, ko + k, lo + l) = g0
+                                    if (lsh /= ksh) then
+                                       eri_out(io + i - off, jo + j, lo + l, ko + k) = g0
+                                    end if
+                                 end do
+                              end do
+                           end do
+                        end do
+                     end if
+                  end if
+
                   do comp = 1, 3
                      do l = 1, dl
                         do k = 1, dk
@@ -633,7 +923,7 @@ contains
                                  g = buf(idx)
 
                                  de_local(comp, ia) = de_local(comp, ia) &
-                                                      - 2.0_dp*g*gamma_ao(io + i, jo + j, ko + k, lo + l)
+                                                      - 2.0_dp*g*gamma_ao(io + i - off, jo + j, ko + k, lo + l)
 
                                  vhf_local(ko + k, lo + l, comp, ia) = &
                                     vhf_local(ko + k, lo + l, comp, ia) &
@@ -654,7 +944,7 @@ contains
                                  ! counted.
                                  if (lsh /= ksh) then
                                     de_local(comp, ia) = de_local(comp, ia) &
-                                                         - 2.0_dp*g*gamma_ao(io + i, jo + j, lo + l, ko + k)
+                                                         - 2.0_dp*g*gamma_ao(io + i - off, jo + j, lo + l, ko + k)
                                     vhf_local(lo + l, ko + k, comp, ia) = &
                                        vhf_local(lo + l, ko + k, comp, ia) &
                                        + g*hf_density(io + i, jo + j)
@@ -683,7 +973,7 @@ contains
       de2 = de2 + de_local
       vhf1 = vhf1 + vhf_local
       !$omp end critical
-      deallocate (buf, de_local, vhf_local)
+      deallocate (buf, de_local, vhf_local, eri_local)
       !$omp end parallel
 
       call libcint_del_optimizer(opt)

--- a/backends/libcint/mqc_libcint_mp2_gradient.f90
+++ b/backends/libcint/mqc_libcint_mp2_gradient.f90
@@ -1,0 +1,642 @@
+!! The MP2 nuclear gradient over a closed-shell reference
+module mqc_libcint_mp2_gradient
+   !! **Why this is not the shape of every gradient before it.** Hartree-Fock,
+   !! density fitting and Kohn-Sham are all variational: the energy is
+   !! stationary with respect to the orbitals, so moving a nucleus changes the
+   !! energy only through the integrals, and the orbital response never appears.
+   !! MP2 is not stationary in the reference orbitals. Its derivative therefore
+   !! carries a term for how the orbitals themselves relax, and that term is the
+   !! solution of a linear system the size of the occupied-virtual space -- the
+   !! Z-vector equation, solved once rather than once per displacement, which is
+   !! the whole reason an analytic MP2 gradient is affordable at all.
+   !!
+   !! The assembly follows Handy and Schaefer's interchange, in the arrangement
+   !! `pyscf.grad.mp2` uses, because that is what these numbers are checked
+   !! against and a different but equivalent grouping would make a disagreement
+   !! impossible to localise.
+   !!
+   !! **What is built, in order.**
+   !!
+   !! 1. `t2(i,j,a,b) = (ia|jb) / (e_i + e_j - e_a - e_b)`, the amplitudes.
+   !! 2. `doo` and `dvv`, the occupied-occupied and virtual-virtual blocks of
+   !!    the unrelaxed one-particle correction.
+   !! 3. `gamma`, the two-particle density in the AO basis. This is the
+   !!    expensive object -- `n_ao^4` -- and the reason this routine is for
+   !!    validation-sized systems until the blocked version replaces it.
+   !! 4. `Imat`, that two-particle density contracted with the *undifferentiated*
+   !!    integrals, which is what makes the Lagrangian.
+   !! 5. The Z-vector solve, through the response operator the CPHF module
+   !!    already applies -- it is the same operator, and writing a second one
+   !!    would mean two things to keep in agreement.
+   !! 6. The contraction with the differentiated integrals.
+   !!
+   !! **Restricted, exact ERIs, no frozen core.** Each of those is a refusal
+   !! rather than an approximation: an unrestricted reference needs separate
+   !! alpha and beta amplitudes, a fitted one differentiates a different energy,
+   !! and a frozen core adds occupied-frozen and virtual-frozen blocks to the
+   !! relaxed density which are not built here.
+   use pic_types, only: dp
+   use mqc_error, only: error_t, ERROR_VALIDATION
+   use mqc_libcint_integrals, only: libcint_molecule_t, shell_dim, atom_ao_blocks
+   use mqc_libcint_mp2, only: transform_ovov
+   use mqc_libcint_cphf, only: cphf_solve
+   use mqc_libcint_gradient, only: nuclear_repulsion_gradient, one_electron_deriv, &
+                                   iprinv_deriv_at, DERIV_OVLP, DERIV_KIN, DERIV_NUC
+   use libcint_fortran, only: libcint_2e_ip1_sph, libcint_2e_ip1_cart, &
+                              libcint_2e_ip1_sph_optimizer, libcint_2e_ip1_cart_optimizer, &
+                              libcint_del_optimizer
+   use, intrinsic :: iso_c_binding, only: c_ptr, c_null_ptr
+   implicit none
+   private
+
+   public :: libcint_mp2_gradient
+
+contains
+
+   subroutine libcint_mp2_gradient(mol, coeff, orbital_energies, n_occ, gradient, &
+                                   error, n_frozen)
+      !! dE(MP2)/dR for a closed-shell reference, in Hartree/Bohr
+      type(libcint_molecule_t), intent(in) :: mol
+      real(dp), intent(in) :: coeff(:, :)            !! C, (n_ao, n_mo)
+      real(dp), intent(in) :: orbital_energies(:)    !! (n_mo), Hartree
+      integer, intent(in) :: n_occ                   !! Doubly occupied count
+      real(dp), allocatable, intent(out) :: gradient(:, :)   !! (3, natm)
+      type(error_t), intent(inout) :: error
+      integer, intent(in), optional :: n_frozen
+
+      real(dp), allocatable :: eri_packed(:, :), eri(:, :, :, :)
+      real(dp), allocatable :: ovov(:, :, :, :), t2(:, :, :, :)
+      real(dp), allocatable :: doo(:, :), dvv(:, :), dm1mo(:, :), zeta(:, :)
+      real(dp), allocatable :: gamma_ao(:, :, :, :)
+      real(dp), allocatable :: imat_ao(:, :), imat(:, :), im1(:, :)
+      real(dp), allocatable :: c_occ(:, :), c_vir(:, :)
+      real(dp), allocatable :: hf_density(:, :), dm1(:, :), dm1_total(:, :), dm1p(:, :)
+      real(dp), allocatable :: veff(:, :), xvo(:, :, :), zvec(:, :, :)
+      real(dp), allocatable :: overlap(:, :), work(:, :), p_occ(:, :), vhf_s1occ(:, :)
+      real(dp), allocatable :: s1(:, :, :), h1(:, :, :), kin(:, :, :)
+      real(dp), allocatable :: vrinv(:, :, :), hcore_a(:, :, :)
+      real(dp), allocatable :: de2(:, :), vhf1(:, :, :, :)
+      real(dp), allocatable :: im1_t(:, :), work_t(:, :)
+      integer, allocatable :: offsets(:), counts(:)
+      integer :: n_ao, n_mo, n_o, n_v, frozen, iatom, comp, p0, p1, p, q, i, a
+
+      n_ao = mol%nao
+      n_mo = size(coeff, 2)
+      n_o = n_occ
+      n_v = n_mo - n_occ
+
+      frozen = 0
+      if (present(n_frozen)) frozen = n_frozen
+      if (frozen /= 0) then
+         call error%set(ERROR_VALIDATION, "the MP2 gradient does not implement a "// &
+                        "frozen core: the relaxed density gains occupied-frozen and "// &
+                        "virtual-frozen blocks, which are not built here. Run the "// &
+                        "gradient with freeze_core off.")
+         return
+      end if
+      if (n_v < 1 .or. n_o < 1) then
+         call error%set(ERROR_VALIDATION, "the MP2 gradient needs both occupied and "// &
+                        "virtual orbitals")
+         return
+      end if
+      if (size(orbital_energies) /= n_mo) then
+         call error%set(ERROR_VALIDATION, "the MP2 gradient: one orbital energy per "// &
+                        "orbital")
+         return
+      end if
+
+      allocate (c_occ(n_ao, n_o), c_vir(n_ao, n_v))
+      c_occ = coeff(:, 1:n_o)
+      c_vir = coeff(:, n_o + 1:n_mo)
+
+      ! ---- amplitudes -------------------------------------------------------
+      call mol%eris_packed(eri_packed)
+      call transform_ovov(eri_packed, coeff, frozen, n_occ, n_ao, n_mo, ovov)
+      deallocate (eri_packed)
+
+      call build_amplitudes(ovov, orbital_energies, n_o, n_v, n_occ, t2)
+
+      ! ---- the unrelaxed one-particle correction ----------------------------
+      call gamma1_intermediates(t2, n_o, n_v, doo, dvv)
+
+      allocate (dm1mo(n_mo, n_mo))
+      dm1mo = 0.0_dp
+      dm1mo(1:n_o, 1:n_o) = doo + transpose(doo)
+      dm1mo(n_o + 1:n_mo, n_o + 1:n_mo) = dvv + transpose(dvv)
+
+      ! ---- the two-particle density, and what it contracts against ----------
+      call build_two_particle_density(t2, c_occ, c_vir, n_ao, n_o, n_v, gamma_ao)
+
+      call mol%eris(eri)
+      call contract_gamma_eri(eri, gamma_ao, n_ao, imat_ao)
+
+      ! ---- the Lagrangian, and the orbitals relaxing under it ---------------
+      !
+      ! `imat` in the MO basis is where the two-particle density enters the
+      ! right-hand side; the `veff` term is where the unrelaxed one-particle
+      ! correction does. Neither alone is the Lagrangian.
+      call mol%overlap(overlap)
+      allocate (imat(n_mo, n_mo), work(n_ao, n_ao))
+      work = matmul(imat_ao, matmul(overlap, coeff(:, 1:n_mo)))
+      imat = -matmul(transpose(coeff), work)
+      deallocate (work)
+
+      allocate (hf_density(n_ao, n_ao))
+      hf_density = 2.0_dp*matmul(c_occ, transpose(c_occ))
+
+      allocate (dm1(n_ao, n_ao))
+      dm1 = matmul(coeff, matmul(dm1mo, transpose(coeff)))
+      call veff_rhf(eri, dm1, n_ao, veff)
+      veff = 2.0_dp*veff
+
+      allocate (xvo(n_v, n_o, 1))
+      xvo(:, :, 1) = matmul(transpose(c_vir), matmul(veff, c_occ))
+      do i = 1, n_o
+         do a = 1, n_v
+            xvo(a, i, 1) = xvo(a, i, 1) + imat(i, n_o + a) - imat(n_o + a, i)
+         end do
+      end do
+
+      ! Tighter than the solver's default. The Z-vector residual enters the
+      ! gradient directly rather than quadratically -- there is no variational
+      ! principle to make it second order here -- so the default 1e-9 leaves
+      ! ~1e-7 in the answer, which is the size of the terms being checked.
+      ! In core, not screened. The solver's default is integral-direct with a
+      ! Schwarz bound, which is right where the response is one quantity among
+      ! many; here the screening error lands in the gradient undiluted -- it was
+      ! 4e-8 on water/cc-pVDZ, the whole disagreement with the reference. This
+      ! routine has already built the tensor for the Lagrangian, so asking for
+      ! it again costs nothing it has not already paid.
+      call cphf_solve(mol, coeff, orbital_energies, n_occ, response=zvec, &
+                      error=error, mo_rhs=xvo, tol=1.0e-12_dp, max_iter=200, &
+                      in_core=.true.)
+      if (error%has_error()) return
+
+      dm1mo(n_o + 1:n_mo, 1:n_o) = dm1mo(n_o + 1:n_mo, 1:n_o) + zvec(:, :, 1)
+      dm1mo(1:n_o, n_o + 1:n_mo) = dm1mo(1:n_o, n_o + 1:n_mo) + transpose(zvec(:, :, 1))
+
+      ! `imat` is not symmetric, and the occupied-virtual block is the one the
+      ! Lagrangian defined; the virtual-occupied block is its transpose by
+      ! construction rather than by computation.
+      imat(n_o + 1:n_mo, 1:n_o) = transpose(imat(1:n_o, n_o + 1:n_mo))
+      allocate (im1(n_ao, n_ao))
+      im1 = matmul(coeff, matmul(imat, transpose(coeff)))
+
+      ! ---- the energy-weighted densities ------------------------------------
+      allocate (zeta(n_mo, n_mo))
+      do q = 1, n_mo
+         do p = 1, n_mo
+            zeta(p, q) = 0.5_dp*(orbital_energies(p) + orbital_energies(q))
+         end do
+      end do
+      ! An occupied orbital energy rather than an average wherever one index is
+      ! occupied and the other virtual: that block multiplies the relaxation,
+      ! which is a rotation of occupied orbitals into virtual ones.
+      do i = 1, n_o
+         do a = 1, n_v
+            zeta(n_o + a, i) = orbital_energies(i)
+            zeta(i, n_o + a) = orbital_energies(i)
+         end do
+      end do
+      zeta = zeta*dm1mo
+      allocate (work(n_ao, n_ao))
+      work = matmul(coeff, matmul(zeta, transpose(coeff)))
+      deallocate (zeta)
+
+      dm1 = matmul(coeff, matmul(dm1mo, transpose(coeff)))
+
+      allocate (p_occ(n_ao, n_ao))
+      p_occ = matmul(c_occ, transpose(c_occ))
+      call veff_rhf(eri, dm1 + transpose(dm1), n_ao, veff)
+      allocate (vhf_s1occ(n_ao, n_ao))
+      vhf_s1occ = matmul(p_occ, matmul(veff, p_occ))
+
+      allocate (dm1p(n_ao, n_ao), dm1_total(n_ao, n_ao))
+      dm1p = hf_density + 2.0_dp*dm1
+      dm1_total = hf_density + dm1
+
+      ! The Hartree-Fock energy-weighted density, on top of the correlation one
+      ! already in `work`.
+      do i = 1, n_o
+         do q = 1, n_ao
+            do p = 1, n_ao
+               work(p, q) = work(p, q) + 2.0_dp*orbital_energies(i)*c_occ(p, i)*c_occ(q, i)
+            end do
+         end do
+      end do
+
+      ! ---- the differentiated integrals -------------------------------------
+      call two_electron_mp2_terms(mol, gamma_ao, hf_density, de2, vhf1)
+
+      call one_electron_deriv(mol, s1, DERIV_OVLP)
+      s1 = -s1
+      call one_electron_deriv(mol, kin, DERIV_KIN)
+      call one_electron_deriv(mol, h1, DERIV_NUC)
+      h1 = -(kin + h1)
+      deallocate (kin)
+
+      allocate (gradient(3, mol%natm))
+      ! Zeroed first: `nuclear_repulsion_gradient` accumulates.
+      gradient = 0.0_dp
+      call nuclear_repulsion_gradient(mol, gradient)
+      gradient = gradient + de2
+
+      allocate (offsets(mol%natm), counts(mol%natm))
+      call atom_ao_blocks(mol, offsets, counts)
+      allocate (vrinv(n_ao, n_ao, 3), hcore_a(n_ao, n_ao, 3))
+      allocate (im1_t(n_ao, n_ao), work_t(n_ao, n_ao))
+      im1_t = transpose(im1)
+      work_t = transpose(work)
+
+      do iatom = 1, mol%natm
+         p0 = offsets(iatom) + 1
+         p1 = offsets(iatom) + counts(iatom)
+
+         call iprinv_deriv_at(mol, iatom, vrinv)
+         vrinv = -mol%charges(iatom)*vrinv
+         if (counts(iatom) > 0) then
+            vrinv(p0:p1, :, :) = vrinv(p0:p1, :, :) + h1(p0:p1, :, :)
+         end if
+         do comp = 1, 3
+            hcore_a(:, :, comp) = vrinv(:, :, comp) + transpose(vrinv(:, :, comp))
+            gradient(comp, iatom) = gradient(comp, iatom) &
+                                    + sum(hcore_a(:, :, comp)*dm1_total)
+            gradient(comp, iatom) = gradient(comp, iatom) &
+                                    - sum(vhf1(:, :, comp, iatom)*dm1p)
+         end do
+
+         if (counts(iatom) == 0) cycle
+
+         do comp = 1, 3
+            ! Both halves differentiate a basis function on this atom -- the
+            ! bra in one, the ket in the other -- so both slice `s1` the same
+            ! way and it is the *matrix* that is transposed. Slicing `s1` on
+            ! the ket instead makes the two cancel, because the derivative of
+            ! an overlap changes sign with which centre moves.
+            gradient(comp, iatom) = gradient(comp, iatom) &
+                                    + sum(s1(p0:p1, :, comp)*im1(p0:p1, :)) &
+                                    + sum(s1(p0:p1, :, comp)*im1_t(p0:p1, :))
+            gradient(comp, iatom) = gradient(comp, iatom) &
+                                    - sum(s1(p0:p1, :, comp)*work(p0:p1, :)) &
+                                    - sum(s1(p0:p1, :, comp)*work_t(p0:p1, :))
+            gradient(comp, iatom) = gradient(comp, iatom) &
+                                    - 2.0_dp*sum(s1(p0:p1, :, comp)*vhf_s1occ(p0:p1, :))
+         end do
+      end do
+
+   end subroutine libcint_mp2_gradient
+
+   subroutine build_amplitudes(ovov, orbital_energies, n_o, n_v, n_occ, t2)
+      !! `t2(i,j,a,b) = (ia|jb) / (e_i + e_j - e_a - e_b)`
+      real(dp), intent(in) :: ovov(:, :, :, :)       !! (i, a, j, b)
+      real(dp), intent(in) :: orbital_energies(:)
+      integer, intent(in) :: n_o, n_v, n_occ
+      real(dp), allocatable, intent(out) :: t2(:, :, :, :)   !! (i, j, a, b)
+
+      integer :: i, j, a, b
+      real(dp) :: denom
+
+      allocate (t2(n_o, n_o, n_v, n_v))
+      do b = 1, n_v
+         do a = 1, n_v
+            do j = 1, n_o
+               do i = 1, n_o
+                  denom = orbital_energies(i) + orbital_energies(j) &
+                          - orbital_energies(n_occ + a) - orbital_energies(n_occ + b)
+                  t2(i, j, a, b) = ovov(i, a, j, b)/denom
+               end do
+            end do
+         end do
+      end do
+   end subroutine build_amplitudes
+
+   subroutine gamma1_intermediates(t2, n_o, n_v, doo, dvv)
+      !! The occupied-occupied and virtual-virtual blocks of the correction
+      !!
+      !! Both are the amplitudes contracted with themselves, once directly and
+      !! once with the two virtual indices exchanged -- the same two spin cases
+      !! the energy expression separates.
+      real(dp), intent(in) :: t2(:, :, :, :)
+      integer, intent(in) :: n_o, n_v
+      real(dp), allocatable, intent(out) :: doo(:, :), dvv(:, :)
+
+      integer :: i, j, k, a, b, c
+      real(dp) :: acc
+
+      allocate (doo(n_o, n_o), dvv(n_v, n_v))
+      doo = 0.0_dp
+      dvv = 0.0_dp
+
+      do j = 1, n_o
+         do i = 1, n_o
+            acc = 0.0_dp
+            do k = 1, n_o
+               do b = 1, n_v
+                  do a = 1, n_v
+                     acc = acc + 2.0_dp*t2(k, i, a, b)*t2(k, j, a, b) &
+                           - t2(k, i, a, b)*t2(k, j, b, a)
+                  end do
+               end do
+            end do
+            doo(i, j) = -acc
+         end do
+      end do
+
+      do b = 1, n_v
+         do a = 1, n_v
+            acc = 0.0_dp
+            do i = 1, n_o
+               do j = 1, n_o
+                  do c = 1, n_v
+                     acc = acc + 2.0_dp*t2(i, j, c, a)*t2(i, j, c, b) &
+                           - t2(i, j, c, a)*t2(i, j, b, c)
+                  end do
+               end do
+            end do
+            dvv(b, a) = acc
+         end do
+      end do
+   end subroutine gamma1_intermediates
+
+   subroutine build_two_particle_density(t2, c_occ, c_vir, n_ao, n_o, n_v, gamma_ao)
+      !! The non-separable two-particle density, in the AO basis
+      !!
+      !! `4 t2(i,j,a,b) - 2 t2(i,j,b,a)` is the coefficient the energy gives
+      !! each integral, and the rest is four index transformations and the two
+      !! symmetrisations that make the object contract correctly against
+      !! integrals that carry the permutational symmetry of the ERIs.
+      !!
+      !! `n_ao^4` and dense. That is what limits this to validation-sized
+      !! systems; blocking over the first index is the way out and is a
+      !! performance change, not a correctness one.
+      real(dp), intent(in) :: t2(:, :, :, :)
+      real(dp), intent(in) :: c_occ(:, :), c_vir(:, :)
+      integer, intent(in) :: n_ao, n_o, n_v
+      real(dp), allocatable, intent(out) :: gamma_ao(:, :, :, :)
+
+      real(dp), allocatable :: part(:, :, :, :), tmp(:, :), half(:, :, :, :)
+      real(dp), allocatable :: swap(:, :, :, :)
+      integer :: i, j, p, q, r, s
+
+      ! part(i,j,p,q) = sum_ab t2(i,j,a,b) C_vir(p,a) C_vir(q,b)
+      allocate (part(n_o, n_o, n_ao, n_ao), tmp(n_v, n_ao))
+      do j = 1, n_o
+         do i = 1, n_o
+            tmp = matmul(t2(i, j, :, :), transpose(c_vir))
+            part(i, j, :, :) = matmul(c_vir, tmp)
+         end do
+      end do
+      deallocate (tmp)
+
+      ! half(i,p,q,j), the combination the energy weights each integral by
+      allocate (half(n_o, n_ao, n_ao, n_o))
+      do j = 1, n_o
+         do q = 1, n_ao
+            do p = 1, n_ao
+               do i = 1, n_o
+                  half(i, p, q, j) = 4.0_dp*part(i, j, p, q) - 2.0_dp*part(i, j, q, p)
+               end do
+            end do
+         end do
+      end do
+      deallocate (part)
+
+      allocate (gamma_ao(n_ao, n_ao, n_ao, n_ao))
+      gamma_ao = 0.0_dp
+      do s = 1, n_ao
+         do r = 1, n_ao
+            do q = 1, n_ao
+               do p = 1, n_ao
+                  gamma_ao(p, q, r, s) = sum(matmul(c_occ(p, :), half(:, q, r, :)) &
+                                             *c_occ(s, :)) &
+                                         + sum(matmul(c_occ(q, :), half(:, p, r, :)) &
+                                               *c_occ(s, :))
+               end do
+            end do
+         end do
+      end do
+      deallocate (half)
+
+      ! The ket pair, symmetrised: the integrals cannot tell `(pq|rs)` from
+      ! `(pq|sr)`, so the density it contracts with must not either. Written as
+      ! a loop rather than `reshape(..., order=)`, which permutes the fill order
+      ! of the result and is not the array transpose it looks like.
+      allocate (swap(n_ao, n_ao, n_ao, n_ao))
+      do s = 1, n_ao
+         do r = 1, n_ao
+            swap(:, :, r, s) = gamma_ao(:, :, s, r)
+         end do
+      end do
+
+      ! And the half. Both contractions this feeds -- the Lagrangian and the
+      ! gradient -- are written over the full four-index range, where the
+      ! reference implementation sums a packed lower triangle whose diagonal it
+      ! halves. That packed sum is exactly half of the full one for a density
+      ! symmetric in the ket pair, so the factor belongs here rather than being
+      ! spelled twice downstream.
+      gamma_ao = 0.5_dp*(gamma_ao + swap)
+      deallocate (swap)
+   end subroutine build_two_particle_density
+
+   subroutine contract_gamma_eri(eri, gamma_ao, n_ao, imat_ao)
+      !! `Imat(p,q) = sum_{u,r,s} (u p|r s) gamma(u,q,r,s)`
+      real(dp), intent(in) :: eri(:, :, :, :), gamma_ao(:, :, :, :)
+      integer, intent(in) :: n_ao
+      real(dp), allocatable, intent(out) :: imat_ao(:, :)
+
+      integer :: u, p, q, r, s
+      real(dp) :: acc
+
+      allocate (imat_ao(n_ao, n_ao))
+      imat_ao = 0.0_dp
+      !$omp parallel do collapse(2) default(none) &
+      !$omp    shared(eri, gamma_ao, imat_ao, n_ao) private(u, p, q, r, s, acc)
+      do q = 1, n_ao
+         do p = 1, n_ao
+            acc = 0.0_dp
+            do s = 1, n_ao
+               do r = 1, n_ao
+                  do u = 1, n_ao
+                     acc = acc + eri(u, p, r, s)*gamma_ao(u, q, r, s)
+                  end do
+               end do
+            end do
+            imat_ao(p, q) = acc
+         end do
+      end do
+      !$omp end parallel do
+   end subroutine contract_gamma_eri
+
+   subroutine veff_rhf(eri, density, n_ao, veff)
+      !! `J - K/2` from a stored ERI tensor and a symmetric density
+      real(dp), intent(in) :: eri(:, :, :, :), density(:, :)
+      integer, intent(in) :: n_ao
+      real(dp), allocatable, intent(inout) :: veff(:, :)
+
+      integer :: p, q, r, s
+      real(dp) :: acc
+
+      if (.not. allocated(veff)) allocate (veff(n_ao, n_ao))
+      !$omp parallel do collapse(2) default(none) &
+      !$omp    shared(eri, density, veff, n_ao) private(p, q, r, s, acc)
+      do q = 1, n_ao
+         do p = 1, n_ao
+            acc = 0.0_dp
+            do s = 1, n_ao
+               do r = 1, n_ao
+                  acc = acc + eri(p, q, r, s)*density(r, s) &
+                        - 0.5_dp*eri(p, r, s, q)*density(r, s)
+               end do
+            end do
+            veff(p, q) = acc
+         end do
+      end do
+      !$omp end parallel do
+   end subroutine veff_rhf
+
+   subroutine two_electron_mp2_terms(mol, gamma_ao, hf_density, de2, vhf1)
+      !! The differentiated integrals, contracted twice
+      !!
+      !! Once against the two-particle density, which gives a gradient
+      !! contribution directly, and once against the reference density, which
+      !! gives the per-atom matrices the relaxed density is contracted with
+      !! afterwards. One quartet loop rather than two because the integrals are
+      !! the expensive part and both contractions want the same ones.
+      !!
+      !! No permutational symmetry is used at all. The differentiated quartet
+      !! keeps only the ket-pair exchange, and taking even that requires the
+      !! two-particle density to be symmetrised to match -- worth doing, and a
+      !! separate change from getting the terms right.
+      type(libcint_molecule_t), intent(in) :: mol
+      real(dp), intent(in) :: gamma_ao(:, :, :, :), hf_density(:, :)
+      real(dp), allocatable, intent(out) :: de2(:, :)        !! (3, natm)
+      real(dp), allocatable, intent(out) :: vhf1(:, :, :, :)  !! (nao, nao, 3, natm)
+
+      real(dp), allocatable :: buf(:)
+      real(dp), allocatable :: de_local(:, :), vhf_local(:, :, :, :)
+      integer, allocatable :: offsets(:), counts(:), shell_atom(:)
+      type(c_ptr) :: opt
+      integer :: shls(4)
+      integer :: ish, jsh, ksh, lsh, di, dj, dk, dl
+      integer :: io, jo, ko, lo, i, j, k, l, comp, ret, mx, idx
+      integer :: nao, nbas, natm, ia
+      real(dp) :: g
+
+      nao = mol%nao
+      nbas = mol%nbas
+      natm = mol%natm
+      mx = largest_shell(mol)
+
+      allocate (offsets(natm), counts(natm))
+      call atom_ao_blocks(mol, offsets, counts)
+      allocate (shell_atom(nbas))
+      do ish = 1, nbas
+         io = mol%shell_offset(ish)
+         shell_atom(ish) = 1
+         do ia = 1, natm
+            if (io >= offsets(ia) .and. io < offsets(ia) + counts(ia)) shell_atom(ish) = ia
+         end do
+      end do
+
+      allocate (de2(3, natm), vhf1(nao, nao, 3, natm))
+      de2 = 0.0_dp
+      vhf1 = 0.0_dp
+
+      opt = c_null_ptr
+      if (mol%cartesian) then
+         call libcint_2e_ip1_cart_optimizer(opt, mol%atm, mol%natm, mol%bas, mol%nbas, mol%env)
+      else
+         call libcint_2e_ip1_sph_optimizer(opt, mol%atm, mol%natm, mol%bas, mol%nbas, mol%env)
+      end if
+
+      !$omp parallel default(none) &
+      !$omp    shared(mol, gamma_ao, hf_density, de2, vhf1, opt, mx, nao, nbas, natm, &
+      !$omp           shell_atom) &
+      !$omp    private(ish, jsh, ksh, lsh, di, dj, dk, dl, io, jo, ko, lo, &
+      !$omp            i, j, k, l, comp, ret, idx, g, shls, ia, buf, de_local, vhf_local)
+      allocate (buf(mx**4*3))
+      allocate (de_local(3, natm), vhf_local(nao, nao, 3, natm))
+      de_local = 0.0_dp
+      vhf_local = 0.0_dp
+
+      !$omp do schedule(dynamic)
+      do ish = 1, nbas
+         di = shell_dim(mol%cartesian, ish - 1, mol%bas)
+         io = mol%shell_offset(ish)
+         ia = shell_atom(ish)
+         do jsh = 1, nbas
+            dj = shell_dim(mol%cartesian, jsh - 1, mol%bas)
+            jo = mol%shell_offset(jsh)
+            do ksh = 1, nbas
+               dk = shell_dim(mol%cartesian, ksh - 1, mol%bas)
+               ko = mol%shell_offset(ksh)
+               do lsh = 1, nbas
+                  dl = shell_dim(mol%cartesian, lsh - 1, mol%bas)
+                  lo = mol%shell_offset(lsh)
+                  shls = [ish - 1, jsh - 1, ksh - 1, lsh - 1]
+
+                  if (mol%cartesian) then
+                     ret = libcint_2e_ip1_cart(buf, shls, mol%atm, mol%natm, &
+                                               mol%bas, nbas, mol%env, opt)
+                  else
+                     ret = libcint_2e_ip1_sph(buf, shls, mol%atm, mol%natm, &
+                                              mol%bas, nbas, mol%env, opt)
+                  end if
+                  if (ret == 0) cycle
+
+                  do comp = 1, 3
+                     do l = 1, dl
+                        do k = 1, dk
+                           do j = 1, dj
+                              do i = 1, di
+                                 idx = i + di*(j - 1 + dj*(k - 1 + dk*(l - 1 + dl*(comp - 1))))
+                                 g = buf(idx)
+
+                                 de_local(comp, ia) = de_local(comp, ia) &
+                                                      - 2.0_dp*g*gamma_ao(io + i, jo + j, ko + k, lo + l)
+
+                                 vhf_local(ko + k, lo + l, comp, ia) = &
+                                    vhf_local(ko + k, lo + l, comp, ia) &
+                                    + g*hf_density(io + i, jo + j)
+                                 vhf_local(ko + k, jo + j, comp, ia) = &
+                                    vhf_local(ko + k, jo + j, comp, ia) &
+                                    - 0.5_dp*g*hf_density(io + i, lo + l)
+                                 vhf_local(io + i, jo + j, comp, ia) = &
+                                    vhf_local(io + i, jo + j, comp, ia) &
+                                    + g*hf_density(ko + k, lo + l)
+                                 vhf_local(io + i, lo + l, comp, ia) = &
+                                    vhf_local(io + i, lo + l, comp, ia) &
+                                    - 0.5_dp*g*hf_density(jo + j, ko + k)
+                              end do
+                           end do
+                        end do
+                     end do
+                  end do
+               end do
+            end do
+         end do
+      end do
+      !$omp end do
+
+      !$omp critical
+      de2 = de2 + de_local
+      vhf1 = vhf1 + vhf_local
+      !$omp end critical
+      deallocate (buf, de_local, vhf_local)
+      !$omp end parallel
+
+      call libcint_del_optimizer(opt)
+   end subroutine two_electron_mp2_terms
+
+   function largest_shell(mol) result(mx)
+      !! The largest number of functions any one shell contributes
+      type(libcint_molecule_t), intent(in) :: mol
+      integer :: mx, ish
+
+      mx = 1
+      do ish = 1, mol%nbas
+         mx = max(mx, shell_dim(mol%cartesian, ish - 1, mol%bas))
+      end do
+   end function largest_shell
+
+end module mqc_libcint_mp2_gradient

--- a/backends/libcint/mqc_libcint_mp2_gradient.f90
+++ b/backends/libcint/mqc_libcint_mp2_gradient.f90
@@ -40,6 +40,8 @@ module mqc_libcint_mp2_gradient
    use mqc_libcint_integrals, only: libcint_molecule_t, shell_dim, atom_ao_blocks
    use mqc_libcint_mp2, only: transform_ovov
    use mqc_libcint_cphf, only: cphf_solve
+   use mqc_libcint_rhf, only: build_fock
+   use pic_blas_interfaces, only: pic_gemm
    use mqc_libcint_gradient, only: nuclear_repulsion_gradient, one_electron_deriv, &
                                    iprinv_deriv_at, DERIV_OVLP, DERIV_KIN, DERIV_NUC
    use libcint_fortran, only: libcint_2e_ip1_sph, libcint_2e_ip1_cart, &
@@ -50,6 +52,10 @@ module mqc_libcint_mp2_gradient
    private
 
    public :: libcint_mp2_gradient
+
+   real(dp), parameter :: IN_CORE_LIMIT = 4.0e9_dp
+      !! Bytes. The same ceiling `mqc_libcint_cphf` applies to its own stored
+      !! tensor, for the same reason and deliberately not a different number.
 
 contains
 
@@ -67,18 +73,20 @@ contains
       real(dp), allocatable :: eri_packed(:, :), eri(:, :, :, :)
       real(dp), allocatable :: ovov(:, :, :, :), t2(:, :, :, :)
       real(dp), allocatable :: doo(:, :), dvv(:, :), dm1mo(:, :), zeta(:, :)
-      real(dp), allocatable :: gamma_ao(:, :, :, :)
+      real(dp), allocatable, target :: gamma_ao(:, :, :, :)
       real(dp), allocatable :: imat_ao(:, :), imat(:, :), im1(:, :)
       real(dp), allocatable :: c_occ(:, :), c_vir(:, :)
       real(dp), allocatable :: hf_density(:, :), dm1(:, :), dm1_total(:, :), dm1p(:, :)
       real(dp), allocatable :: veff(:, :), xvo(:, :, :), zvec(:, :, :)
       real(dp), allocatable :: overlap(:, :), work(:, :), p_occ(:, :), vhf_s1occ(:, :)
+      real(dp), allocatable :: zero_h(:, :)
       real(dp), allocatable :: s1(:, :, :), h1(:, :, :), kin(:, :, :)
       real(dp), allocatable :: vrinv(:, :, :), hcore_a(:, :, :)
       real(dp), allocatable :: de2(:, :), vhf1(:, :, :, :)
       real(dp), allocatable :: im1_t(:, :), work_t(:, :)
       integer, allocatable :: offsets(:), counts(:)
       integer :: n_ao, n_mo, n_o, n_v, frozen, iatom, comp, p0, p1, p, q, i, a
+      character(len=32) :: text, gigabytes
 
       n_ao = mol%nao
       n_mo = size(coeff, 2)
@@ -102,6 +110,24 @@ contains
       if (size(orbital_energies) /= n_mo) then
          call error%set(ERROR_VALIDATION, "the MP2 gradient: one orbital energy per "// &
                         "orbital")
+         return
+      end if
+
+      ! Refused rather than attempted. Two dense `n_ao^4` arrays are live at
+      ! once here -- the integrals and the two-particle density -- so the
+      ! ceiling arrives as an allocation failure or an out-of-memory kill, with
+      ! nothing to say which array or how far over it went. Blocking the
+      ! two-particle density over its first index is what lifts this; until
+      ! then the limit is worth stating in the one place that knows it.
+      if (2.0_dp*real(n_ao, dp)**4*8.0_dp > IN_CORE_LIMIT) then
+         write (text, "(i0)") n_ao
+         write (gigabytes, "(f0.1)") 2.0_dp*real(n_ao, dp)**4*8.0_dp/1.0e9_dp
+         call error%set(ERROR_VALIDATION, "the MP2 gradient stores the integrals and "// &
+                        "the two-particle density as dense n^4 arrays, which for "// &
+                        trim(text)//" basis functions is "//trim(gigabytes)//" GB. "// &
+                        "Blocking over the auxiliary index is not implemented, so this "// &
+                        "is refused rather than attempted. Use a smaller basis, or "// &
+                        "fragment the system.")
          return
       end if
 
@@ -146,7 +172,12 @@ contains
 
       allocate (dm1(n_ao, n_ao))
       dm1 = matmul(coeff, matmul(dm1mo, transpose(coeff)))
-      call veff_rhf(eri, dm1, n_ao, veff)
+      ! `build_fock` returns `H + J - K/2`; a zero core Hamiltonian leaves the
+      ! two-electron part alone, which is what a response wants. Threaded over
+      ! the target element, and already the hot routine of the CPHF solver.
+      allocate (zero_h(n_ao, n_ao), veff(n_ao, n_ao))
+      zero_h = 0.0_dp
+      call build_fock(zero_h, eri, dm1, veff)
       veff = 2.0_dp*veff
 
       allocate (xvo(n_v, n_o, 1))
@@ -161,15 +192,15 @@ contains
       ! gradient directly rather than quadratically -- there is no variational
       ! principle to make it second order here -- so the default 1e-9 leaves
       ! ~1e-7 in the answer, which is the size of the terms being checked.
-      ! In core, not screened. The solver's default is integral-direct with a
-      ! Schwarz bound, which is right where the response is one quantity among
-      ! many; here the screening error lands in the gradient undiluted -- it was
-      ! 4e-8 on water/cc-pVDZ, the whole disagreement with the reference. This
-      ! routine has already built the tensor for the Lagrangian, so asking for
-      ! it again costs nothing it has not already paid.
+      ! In core, not screened, and over the tensor already in hand. The
+      ! solver's default is integral-direct with a Schwarz bound, which is right
+      ! where the response is one quantity among many; here the screening error
+      ! would land in the gradient undiluted. Handing over the tensor built for
+      ! the Lagrangian rather than letting it build its own saves a second
+      ! identical pass over every integral -- 10% of this routine at cc-pVTZ.
       call cphf_solve(mol, coeff, orbital_energies, n_occ, response=zvec, &
                       error=error, mo_rhs=xvo, tol=1.0e-12_dp, max_iter=200, &
-                      in_core=.true.)
+                      eri_in=eri)
       if (error%has_error()) return
 
       dm1mo(n_o + 1:n_mo, 1:n_o) = dm1mo(n_o + 1:n_mo, 1:n_o) + zvec(:, :, 1)
@@ -207,7 +238,7 @@ contains
 
       allocate (p_occ(n_ao, n_ao))
       p_occ = matmul(c_occ, transpose(c_occ))
-      call veff_rhf(eri, dm1 + transpose(dm1), n_ao, veff)
+      call build_fock(zero_h, eri, dm1 + transpose(dm1), veff)
       allocate (vhf_s1occ(n_ao, n_ao))
       vhf_s1occ = matmul(p_occ, matmul(veff, p_occ))
 
@@ -364,19 +395,31 @@ contains
       !! `4 t2(i,j,a,b) - 2 t2(i,j,b,a)` is the coefficient the energy gives
       !! each integral, and the rest is four index transformations and the two
       !! symmetrisations that make the object contract correctly against
-      !! integrals that carry the permutational symmetry of the ERIs.
+      !! integrals carrying the permutational symmetry of the ERIs.
+      !!
+      !! **Two occupied transformations, as two matrix multiplies.** Written
+      !! elementwise -- one small `matmul` per `(p,q,r,s)` -- this was 65% of
+      !! the whole gradient, because `n_ao^4` is eleven million calls at
+      !! cc-pVTZ and each one costs more in call overhead than in arithmetic.
+      !! Contracted instead as `(n_ao x n_o) (n_o x n_ao^2 n_o)` and then
+      !! `(n_ao^3 x n_o) (n_o x n_ao)`, the same flops sit in two gemms.
+      !! Pointer bounds remapping is what lets the intermediate be read as
+      !! `(p, q r j)` by the first and `(p q r, j)` by the second without a
+      !! copy: the memory order is the same either way.
       !!
       !! `n_ao^4` and dense. That is what limits this to validation-sized
-      !! systems; blocking over the first index is the way out and is a
-      !! performance change, not a correctness one.
+      !! systems; blocking over the first index is the way out, and is a
+      !! separate change.
       real(dp), intent(in) :: t2(:, :, :, :)
       real(dp), intent(in) :: c_occ(:, :), c_vir(:, :)
       integer, intent(in) :: n_ao, n_o, n_v
-      real(dp), allocatable, intent(out) :: gamma_ao(:, :, :, :)
+      real(dp), allocatable, target, intent(out) :: gamma_ao(:, :, :, :)
 
-      real(dp), allocatable :: part(:, :, :, :), tmp(:, :), half(:, :, :, :)
-      real(dp), allocatable :: swap(:, :, :, :)
-      integer :: i, j, p, q, r, s
+      real(dp), allocatable :: part(:, :, :, :), tmp(:, :), half(:, :)
+      real(dp), allocatable, target :: xbuf(:)
+      real(dp), pointer :: x_first(:, :), x_second(:, :), gamma_flat(:, :)
+      real(dp) :: acc
+      integer :: i, j, p, q, r, s, col
 
       ! part(i,j,p,q) = sum_ab t2(i,j,a,b) C_vir(p,a) C_vir(q,b)
       allocate (part(n_o, n_o, n_ao, n_ao), tmp(n_v, n_ao))
@@ -388,111 +431,104 @@ contains
       end do
       deallocate (tmp)
 
-      ! half(i,p,q,j), the combination the energy weights each integral by
-      allocate (half(n_o, n_ao, n_ao, n_o))
+      ! half(i, (q, r, j)), the combination the energy weights each integral by
+      allocate (half(n_o, n_ao*n_ao*n_o))
+      !$omp parallel do collapse(3) default(none) &
+      !$omp    shared(half, part, n_o, n_ao) private(i, j, q, r, col)
       do j = 1, n_o
-         do q = 1, n_ao
-            do p = 1, n_ao
+         do r = 1, n_ao
+            do q = 1, n_ao
+               col = q + n_ao*(r - 1) + n_ao*n_ao*(j - 1)
                do i = 1, n_o
-                  half(i, p, q, j) = 4.0_dp*part(i, j, p, q) - 2.0_dp*part(i, j, q, p)
+                  half(i, col) = 4.0_dp*part(i, j, q, r) - 2.0_dp*part(i, j, r, q)
                end do
             end do
          end do
       end do
+      !$omp end parallel do
       deallocate (part)
 
+      allocate (xbuf(int(n_ao, kind=8)*n_ao*n_ao*n_o))
+      x_first(1:n_ao, 1:n_ao*n_ao*n_o) => xbuf
+      x_second(1:n_ao*n_ao*n_ao, 1:n_o) => xbuf
+
+      call pic_gemm(c_occ, half, x_first)
+      deallocate (half)
+
       allocate (gamma_ao(n_ao, n_ao, n_ao, n_ao))
-      gamma_ao = 0.0_dp
+      gamma_flat(1:n_ao*n_ao*n_ao, 1:n_ao) => gamma_ao
+      call pic_gemm(x_second, c_occ, gamma_flat, transb="T")
+      deallocate (xbuf)
+
+      ! The bra pair, symmetrised in place. This is the second of the two
+      ! transformation terms -- `sum_i C(q,i) half(i,p,r,j)` is the first one
+      ! with `p` and `q` exchanged -- so it needs no second contraction, only a
+      ! transpose-add on each `(r,s)` slice.
+      !
+      ! **The ket pair is deliberately not symmetrised.** Both consumers
+      ! contract this against something already symmetric in `(r,s)`: the
+      ! integrals for the Lagrangian, and the differentiated integrals for the
+      ! gradient, where the nabla sits on the bra and leaves `(rs|` alone. For a
+      ! symmetric partner `sum B(r,s) X(s,r)` equals `sum B(r,s) X(r,s)`, so
+      ! symmetrising here would compute a quantity that contracts to the same
+      ! number -- at the cost of a second `n_ao^4` array and a strided pass over
+      ! it. That pass, and the packing half it carried, cancel exactly against
+      ! each other.
+      !$omp parallel do collapse(2) default(none) &
+      !$omp    shared(gamma_ao, n_ao) private(p, q, r, s, acc)
       do s = 1, n_ao
          do r = 1, n_ao
             do q = 1, n_ao
-               do p = 1, n_ao
-                  gamma_ao(p, q, r, s) = sum(matmul(c_occ(p, :), half(:, q, r, :)) &
-                                             *c_occ(s, :)) &
-                                         + sum(matmul(c_occ(q, :), half(:, p, r, :)) &
-                                               *c_occ(s, :))
+               do p = 1, q - 1
+                  acc = gamma_ao(p, q, r, s) + gamma_ao(q, p, r, s)
+                  gamma_ao(p, q, r, s) = acc
+                  gamma_ao(q, p, r, s) = acc
                end do
+               gamma_ao(q, q, r, s) = 2.0_dp*gamma_ao(q, q, r, s)
             end do
          end do
       end do
-      deallocate (half)
+      !$omp end parallel do
 
-      ! The ket pair, symmetrised: the integrals cannot tell `(pq|rs)` from
-      ! `(pq|sr)`, so the density it contracts with must not either. Written as
-      ! a loop rather than `reshape(..., order=)`, which permutes the fill order
-      ! of the result and is not the array transpose it looks like.
-      allocate (swap(n_ao, n_ao, n_ao, n_ao))
-      do s = 1, n_ao
-         do r = 1, n_ao
-            swap(:, :, r, s) = gamma_ao(:, :, s, r)
-         end do
-      end do
-
-      ! And the half. Both contractions this feeds -- the Lagrangian and the
-      ! gradient -- are written over the full four-index range, where the
-      ! reference implementation sums a packed lower triangle whose diagonal it
-      ! halves. That packed sum is exactly half of the full one for a density
-      ! symmetric in the ket pair, so the factor belongs here rather than being
-      ! spelled twice downstream.
-      gamma_ao = 0.5_dp*(gamma_ao + swap)
-      deallocate (swap)
    end subroutine build_two_particle_density
 
    subroutine contract_gamma_eri(eri, gamma_ao, n_ao, imat_ao)
       !! `Imat(p,q) = sum_{u,r,s} (u p|r s) gamma(u,q,r,s)`
+      !!
+      !! `n_ao^5` either way; the question is only whether those flops sit in a
+      !! loop nest or in BLAS. Fixing the ket pair leaves an ordinary
+      !! `(n_ao x n_ao) (n_ao x n_ao)` product of two contiguous slices -- the
+      !! integrals are symmetric in `(u,p)`, so the slice can be read with
+      !! either index first -- and the outer pair parallelises with no
+      !! reduction beyond one accumulator per thread.
       real(dp), intent(in) :: eri(:, :, :, :), gamma_ao(:, :, :, :)
       integer, intent(in) :: n_ao
       real(dp), allocatable, intent(out) :: imat_ao(:, :)
 
-      integer :: u, p, q, r, s
-      real(dp) :: acc
+      real(dp), allocatable :: local(:, :)
+      integer :: r, s
 
       allocate (imat_ao(n_ao, n_ao))
       imat_ao = 0.0_dp
-      !$omp parallel do collapse(2) default(none) &
-      !$omp    shared(eri, gamma_ao, imat_ao, n_ao) private(u, p, q, r, s, acc)
-      do q = 1, n_ao
-         do p = 1, n_ao
-            acc = 0.0_dp
-            do s = 1, n_ao
-               do r = 1, n_ao
-                  do u = 1, n_ao
-                     acc = acc + eri(u, p, r, s)*gamma_ao(u, q, r, s)
-                  end do
-               end do
-            end do
-            imat_ao(p, q) = acc
+
+      !$omp parallel default(none) shared(eri, gamma_ao, imat_ao, n_ao) &
+      !$omp    private(r, s, local)
+      allocate (local(n_ao, n_ao))
+      local = 0.0_dp
+      !$omp do collapse(2) schedule(static)
+      do s = 1, n_ao
+         do r = 1, n_ao
+            call pic_gemm(eri(:, :, r, s), gamma_ao(:, :, r, s), local, &
+                          beta=1.0_dp)
          end do
       end do
-      !$omp end parallel do
+      !$omp end do
+      !$omp critical
+      imat_ao = imat_ao + local
+      !$omp end critical
+      deallocate (local)
+      !$omp end parallel
    end subroutine contract_gamma_eri
-
-   subroutine veff_rhf(eri, density, n_ao, veff)
-      !! `J - K/2` from a stored ERI tensor and a symmetric density
-      real(dp), intent(in) :: eri(:, :, :, :), density(:, :)
-      integer, intent(in) :: n_ao
-      real(dp), allocatable, intent(inout) :: veff(:, :)
-
-      integer :: p, q, r, s
-      real(dp) :: acc
-
-      if (.not. allocated(veff)) allocate (veff(n_ao, n_ao))
-      !$omp parallel do collapse(2) default(none) &
-      !$omp    shared(eri, density, veff, n_ao) private(p, q, r, s, acc)
-      do q = 1, n_ao
-         do p = 1, n_ao
-            acc = 0.0_dp
-            do s = 1, n_ao
-               do r = 1, n_ao
-                  acc = acc + eri(p, q, r, s)*density(r, s) &
-                        - 0.5_dp*eri(p, r, s, q)*density(r, s)
-               end do
-            end do
-            veff(p, q) = acc
-         end do
-      end do
-      !$omp end parallel do
-   end subroutine veff_rhf
 
    subroutine two_electron_mp2_terms(mol, gamma_ao, hf_density, de2, vhf1)
       !! The differentiated integrals, contracted twice
@@ -503,10 +539,14 @@ contains
       !! afterwards. One quartet loop rather than two because the integrals are
       !! the expensive part and both contractions want the same ones.
       !!
-      !! No permutational symmetry is used at all. The differentiated quartet
-      !! keeps only the ket-pair exchange, and taking even that requires the
-      !! two-particle density to be symmetrised to match -- worth doing, and a
-      !! separate change from getting the terms right.
+      !! **One permutation survives, and it is used.** A differentiated quartet
+      !! has none of the eightfold symmetry of an ordinary one: the nabla
+      !! distinguishes the first index from the second and the bra from the
+      !! ket. What is untouched is the ket pair, `(∇i j|k l) = (∇i j|l k)`, so
+      !! this walks `l <= k` and writes the transposed contribution out rather
+      !! than doubling -- the two-particle density is deliberately not
+      !! symmetric in that pair, so `k` and `l` exchanged is a different
+      !! contraction rather than the same number twice.
       type(libcint_molecule_t), intent(in) :: mol
       real(dp), intent(in) :: gamma_ao(:, :, :, :), hf_density(:, :)
       real(dp), allocatable, intent(out) :: de2(:, :)        !! (3, natm)
@@ -570,7 +610,7 @@ contains
             do ksh = 1, nbas
                dk = shell_dim(mol%cartesian, ksh - 1, mol%bas)
                ko = mol%shell_offset(ksh)
-               do lsh = 1, nbas
+               do lsh = 1, ksh
                   dl = shell_dim(mol%cartesian, lsh - 1, mol%bas)
                   lo = mol%shell_offset(lsh)
                   shls = [ish - 1, jsh - 1, ksh - 1, lsh - 1]
@@ -607,6 +647,27 @@ contains
                                  vhf_local(io + i, lo + l, comp, ia) = &
                                     vhf_local(io + i, lo + l, comp, ia) &
                                     - 0.5_dp*g*hf_density(jo + j, ko + k)
+
+                                 ! The transposed ket pair: the same integral,
+                                 ! and not the same contraction. Skipped on the
+                                 ! diagonal, where it is the quartet already
+                                 ! counted.
+                                 if (lsh /= ksh) then
+                                    de_local(comp, ia) = de_local(comp, ia) &
+                                                         - 2.0_dp*g*gamma_ao(io + i, jo + j, lo + l, ko + k)
+                                    vhf_local(lo + l, ko + k, comp, ia) = &
+                                       vhf_local(lo + l, ko + k, comp, ia) &
+                                       + g*hf_density(io + i, jo + j)
+                                    vhf_local(lo + l, jo + j, comp, ia) = &
+                                       vhf_local(lo + l, jo + j, comp, ia) &
+                                       - 0.5_dp*g*hf_density(io + i, ko + k)
+                                    vhf_local(io + i, jo + j, comp, ia) = &
+                                       vhf_local(io + i, jo + j, comp, ia) &
+                                       + g*hf_density(lo + l, ko + k)
+                                    vhf_local(io + i, ko + k, comp, ia) = &
+                                       vhf_local(io + i, ko + k, comp, ia) &
+                                       - 0.5_dp*g*hf_density(jo + j, lo + l)
+                                 end if
                               end do
                            end do
                         end do

--- a/backends/libcint/mqc_libcint_mp2_gradient.f90
+++ b/backends/libcint/mqc_libcint_mp2_gradient.f90
@@ -35,7 +35,7 @@ module mqc_libcint_mp2_gradient
    !! alpha and beta amplitudes, a fitted one differentiates a different energy,
    !! and a frozen core adds occupied-frozen and virtual-frozen blocks to the
    !! relaxed density which are not built here.
-   use pic_types, only: dp
+   use pic_types, only: dp, int64
    use mqc_error, only: error_t, ERROR_VALIDATION
    use mqc_libcint_integrals, only: libcint_molecule_t, shell_dim, atom_ao_blocks, &
                                     two_electron_block
@@ -68,7 +68,7 @@ module mqc_libcint_mp2_gradient
 contains
 
    subroutine libcint_mp2_gradient(mol, coeff, orbital_energies, n_occ, gradient, &
-                                   error, n_frozen, block_bytes)
+                                   error, n_frozen, block_bytes, force_blocked)
       !! dE(MP2)/dR for a closed-shell reference, in Hartree/Bohr
       type(libcint_molecule_t), intent(in) :: mol
       real(dp), intent(in) :: coeff(:, :)            !! C, (n_ao, n_mo)
@@ -78,11 +78,14 @@ contains
       type(error_t), intent(inout) :: error
       integer, intent(in), optional :: n_frozen
       real(dp), intent(in), optional :: block_bytes
-         !! Take the blocked path whatever the size, with this byte target
-         !! instead of `BLOCK_TARGET`. For the check harness, which runs every
-         !! case both ways and compares -- and which passes something small
-         !! enough to force *several* blocks, since a single block exercises
-         !! neither the loop over them nor the index offset.
+         !! Byte target for the block sizes, in place of `BLOCK_TARGET`. Small
+         !! enough, it forces several blocks of both the first index and the
+         !! occupied one, which is what the check harness passes: a single
+         !! block exercises neither loop nor the offsets they carry.
+      logical, intent(in), optional :: force_blocked
+         !! Take the blocked path whatever the size. Separate from the target
+         !! on purpose -- the dense path blocks over the occupied index too,
+         !! and a knob that forced the other path would leave that untested.
 
       real(dp), allocatable :: eri_packed(:, :), eri(:, :, :, :)
       real(dp), allocatable :: ovov(:, :, :, :), t2(:, :, :, :)
@@ -102,7 +105,7 @@ contains
       integer :: n_ao, n_mo, n_o, n_v, frozen, iatom, comp, p0, p1, p, q, i, a
       logical :: dense
       real(dp) :: target_bytes
-      real(dp), allocatable :: half(:, :), bounds(:, :)
+      real(dp), allocatable :: bounds(:, :)
 
       n_ao = mol%nao
       n_mo = size(coeff, 2)
@@ -138,9 +141,9 @@ contains
       ! that is a choice rather than the basis size.
       dense = 2.0_dp*real(n_ao, dp)**4*8.0_dp <= IN_CORE_LIMIT
       target_bytes = BLOCK_TARGET
-      if (present(block_bytes)) then
-         dense = .false.
-         target_bytes = block_bytes
+      if (present(block_bytes)) target_bytes = block_bytes
+      if (present(force_blocked)) then
+         if (force_blocked) dense = .false.
       end if
 
       allocate (c_occ(n_ao, n_o), c_vir(n_ao, n_v))
@@ -163,9 +166,6 @@ contains
       dm1mo(n_o + 1:n_mo, n_o + 1:n_mo) = dvv + transpose(dvv)
 
       ! ---- the two-particle density, and what it contracts against ----------
-      call build_half_transformed(t2, c_vir, n_ao, n_o, n_v, half)
-      deallocate (t2)
-
       if (.not. dense) then
          ! The direct Fock builds below need these, and so does the response
          ! solve, which cannot be handed a tensor that was never formed.
@@ -184,17 +184,19 @@ contains
       hf_density = 2.0_dp*matmul(c_occ, transpose(c_occ))
 
       if (dense) then
-         call build_two_particle_density(half, c_occ, n_ao, n_o, gamma_ao)
+         call build_two_particle_density(t2, c_occ, c_vir, n_ao, n_o, n_v, &
+                                         target_bytes, gamma_ao)
          call mol%eris(eri)
          call contract_gamma_eri(eri, gamma_ao, n_ao, imat_ao)
          call two_electron_mp2_terms(mol, gamma_ao, hf_density, de2, vhf1)
          deallocate (gamma_ao)
       else
-         call blocked_two_electron_terms(mol, half, c_occ, hf_density, n_ao, n_o, &
-                                         target_bytes, imat_ao, de2, vhf1, error)
+         call blocked_two_electron_terms(mol, t2, c_occ, c_vir, n_ao, n_o, n_v, &
+                                         target_bytes, hf_density, imat_ao, de2, &
+                                         vhf1, error)
          if (error%has_error()) return
       end if
-      deallocate (half)
+      deallocate (t2)
 
       ! ---- the Lagrangian, and the orbitals relaxing under it ---------------
       !
@@ -459,38 +461,44 @@ contains
       end if
    end subroutine two_electron_potential
 
-   subroutine build_half_transformed(t2, c_vir, n_ao, n_o, n_v, half)
-      !! `half(i, (q, r, j))`, the amplitudes with both virtual indices in the
-      !! AO basis and the energy's weighting applied
+   subroutine build_half_block(t2, c_vir, n_ao, n_o, n_v, j_lo, j_hi, half)
+      !! `half(i, (q, r, j))` for one range of `j`: the amplitudes with both
+      !! virtual indices in the AO basis and the energy's weighting applied
       !!
       !! `4 t2(i,j,a,b) - 2 t2(i,j,b,a)` is the coefficient the energy gives
-      !! each integral. Shared by the dense and blocked paths, and `n_o^2
-      !! n_ao^2` either way -- smaller than `n_ao^4` by `(n_o/n_ao)^2`, but not
-      !! bounded: past a few hundred functions this is what the blocked path's
-      !! footprint is, not the block target. Blocking it over `j` is the next
-      !! ceiling to lift, and nothing above depends on it being whole.
+      !! each integral.
+      !!
+      !! Whole, this is `n_o^2 n_ao^2` -- smaller than `n_ao^4` by
+      !! `(n_o/n_ao)^2`, and still unbounded, which past a few hundred
+      !! functions made it the footprint rather than the block target. `j` is
+      !! the index to cut on because it is contracted last, against `C_occ`, so
+      !! a range of it contributes an addend to the two-particle density rather
+      !! than a slice of one. When the whole range fits, the caller asks for it
+      !! in one call and this is what it always was.
       real(dp), intent(in) :: t2(:, :, :, :)
       real(dp), intent(in) :: c_vir(:, :)
-      integer, intent(in) :: n_ao, n_o, n_v
+      integer, intent(in) :: n_ao, n_o, n_v, j_lo, j_hi
       real(dp), allocatable, intent(out) :: half(:, :)
 
       real(dp), allocatable :: part(:, :, :, :), tmp(:, :)
-      integer :: i, j, q, r, col
+      integer :: i, j, q, r, col, nj
+
+      nj = j_hi - j_lo + 1
 
       ! part(i,j,p,q) = sum_ab t2(i,j,a,b) C_vir(p,a) C_vir(q,b)
-      allocate (part(n_o, n_o, n_ao, n_ao), tmp(n_v, n_ao))
-      do j = 1, n_o
+      allocate (part(n_o, nj, n_ao, n_ao), tmp(n_v, n_ao))
+      do j = 1, nj
          do i = 1, n_o
-            tmp = matmul(t2(i, j, :, :), transpose(c_vir))
+            tmp = matmul(t2(i, j_lo + j - 1, :, :), transpose(c_vir))
             part(i, j, :, :) = matmul(c_vir, tmp)
          end do
       end do
       deallocate (tmp)
 
-      allocate (half(n_o, n_ao*n_ao*n_o))
+      allocate (half(n_o, n_ao*n_ao*nj))
       !$omp parallel do collapse(3) default(none) &
-      !$omp    shared(half, part, n_o, n_ao) private(i, j, q, r, col)
-      do j = 1, n_o
+      !$omp    shared(half, part, n_o, n_ao, nj) private(i, j, q, r, col)
+      do j = 1, nj
          do r = 1, n_ao
             do q = 1, n_ao
                col = q + n_ao*(r - 1) + n_ao*n_ao*(j - 1)
@@ -502,9 +510,27 @@ contains
       end do
       !$omp end parallel do
       deallocate (part)
-   end subroutine build_half_transformed
+   end subroutine build_half_block
 
-   subroutine build_gamma_block(half, c_occ, n_ao, n_o, p_lo, p_hi, gamma_blk)
+   pure function occupied_per_block(n_ao, n_o, target_bytes) result(nj)
+      !! How many occupied orbitals one pass over `j` may carry
+      !!
+      !! Sized on the two arrays that scale with it: the half-transformed
+      !! amplitudes at `n_o n_ao^2` per `j`, and the transformation
+      !! intermediate at `n_ao^3` per `j`. At least one, always -- a single
+      !! occupied orbital is the smallest pass there is, and if that does not
+      !! fit, nothing else here will either.
+      integer, intent(in) :: n_ao, n_o
+      real(dp), intent(in) :: target_bytes
+      integer :: nj
+
+      nj = int(target_bytes/((real(n_o, dp)*real(n_ao, dp)**2 &
+                              + real(n_ao, dp)**3)*8.0_dp))
+      nj = max(1, min(n_o, nj))
+   end function occupied_per_block
+
+   subroutine build_gamma_block(t2, c_occ, c_vir, n_ao, n_o, n_v, p_lo, p_hi, &
+                                target_bytes, gamma_blk)
       !! The two-particle density for a range of its first index
       !!
       !! The same two contractions the dense path makes, with the first index
@@ -513,108 +539,147 @@ contains
       !! `sum_i C(q,i) half(i,p,r,j)` term needs `p` restricted and `q` free,
       !! which is a different contraction rather than a rearrangement of the
       !! first one.
-      real(dp), intent(in) :: half(:, :)
-      real(dp), intent(in) :: c_occ(:, :)
-      integer, intent(in) :: n_ao, n_o, p_lo, p_hi
+      !!
+      !! Blocked over `j` as well, on the same target, so nothing here is
+      !! `n_o^2 n_ao^2`. The price is that the half transform is redone for
+      !! each block of the first index; it is `n_o^2 n_v^2 n_ao` against the
+      !! `n_ao^4` of integrals a block already pays for, and it is what buys a
+      !! footprint that does not grow with the basis.
+      real(dp), intent(in) :: t2(:, :, :, :)
+      real(dp), intent(in) :: c_occ(:, :), c_vir(:, :)
+      integer, intent(in) :: n_ao, n_o, n_v, p_lo, p_hi
+      real(dp), intent(in) :: target_bytes
       real(dp), allocatable, target, intent(out) :: gamma_blk(:, :, :, :)
 
       real(dp), allocatable, target :: xbuf(:)
-      real(dp), allocatable :: hblk(:, :), tblk(:, :)
+      real(dp), allocatable :: half(:, :), hblk(:, :), tblk(:, :)
       real(dp), pointer :: x_first(:, :), x_second(:, :), gamma_flat(:, :)
-      integer :: np, p, q, r, j, col, colb
+      integer :: np, p, q, r, j, col, colb, j_lo, j_hi, nj, per_block
 
       np = p_hi - p_lo + 1
-
-      allocate (xbuf(int(np, kind=8)*n_ao*n_ao*n_o))
-      x_first(1:np, 1:n_ao*n_ao*n_o) => xbuf
-      x_second(1:np*n_ao*n_ao, 1:n_o) => xbuf
-
-      ! term one: sum_i C(p,i) half(i, q, r, j), for p in the block
-      call pic_gemm(c_occ(p_lo:p_hi, :), half, x_first)
-
-      ! term two: sum_i C(q,i) half(i, p, r, j), same block of p. Gathered into
-      ! `(i, (p r j))` first, because the block is a stride in `half` and BLAS
-      ! wants it contiguous.
-      allocate (hblk(n_o, np*n_ao*n_o), tblk(n_ao, np*n_ao*n_o))
-      !$omp parallel do collapse(3) default(none) &
-      !$omp    shared(hblk, half, n_o, n_ao, np, p_lo) private(j, r, p, col, colb)
-      do j = 1, n_o
-         do r = 1, n_ao
-            do p = 1, np
-               colb = p + np*(r - 1) + np*n_ao*(j - 1)
-               col = (p_lo + p - 1) + n_ao*(r - 1) + n_ao*n_ao*(j - 1)
-               hblk(:, colb) = half(:, col)
-            end do
-         end do
-      end do
-      !$omp end parallel do
-      call pic_gemm(c_occ, hblk, tblk)
-      deallocate (hblk)
-
-      !$omp parallel do collapse(3) default(none) &
-      !$omp    shared(x_first, tblk, n_o, n_ao, np) private(j, r, p, q, col, colb)
-      do j = 1, n_o
-         do r = 1, n_ao
-            do q = 1, n_ao
-               col = q + n_ao*(r - 1) + n_ao*n_ao*(j - 1)
-               colb = np*(r - 1) + np*n_ao*(j - 1)
-               do p = 1, np
-                  x_first(p, col) = x_first(p, col) + tblk(q, p + colb)
-               end do
-            end do
-         end do
-      end do
-      !$omp end parallel do
-      deallocate (tblk)
+      per_block = occupied_per_block(n_ao, n_o, target_bytes)
 
       allocate (gamma_blk(np, n_ao, n_ao, n_ao))
       gamma_flat(1:np*n_ao*n_ao, 1:n_ao) => gamma_blk
-      call pic_gemm(x_second, c_occ, gamma_flat, transb="T")
-      deallocate (xbuf)
+      gamma_blk = 0.0_dp
+
+      j_lo = 1
+      do while (j_lo <= n_o)
+         j_hi = min(n_o, j_lo + per_block - 1)
+         nj = j_hi - j_lo + 1
+
+         call build_half_block(t2, c_vir, n_ao, n_o, n_v, j_lo, j_hi, half)
+
+         allocate (xbuf(int(np, kind=int64)*n_ao*n_ao*nj))
+         x_first(1:np, 1:n_ao*n_ao*nj) => xbuf
+         x_second(1:np*n_ao*n_ao, 1:nj) => xbuf
+
+         ! term one: sum_i C(p,i) half(i, q, r, j), for p in the block
+         call pic_gemm(c_occ(p_lo:p_hi, :), half, x_first)
+
+         ! term two: sum_i C(q,i) half(i, p, r, j), same block of p. Gathered
+         ! into `(i, (p r j))` first, because the block is a stride in `half`
+         ! and BLAS wants it contiguous.
+         allocate (hblk(n_o, np*n_ao*nj), tblk(n_ao, np*n_ao*nj))
+         !$omp parallel do collapse(3) default(none) &
+         !$omp    shared(hblk, half, n_o, n_ao, np, nj, p_lo) &
+         !$omp    private(j, r, p, col, colb)
+         do j = 1, nj
+            do r = 1, n_ao
+               do p = 1, np
+                  colb = p + np*(r - 1) + np*n_ao*(j - 1)
+                  col = (p_lo + p - 1) + n_ao*(r - 1) + n_ao*n_ao*(j - 1)
+                  hblk(:, colb) = half(:, col)
+               end do
+            end do
+         end do
+         !$omp end parallel do
+         deallocate (half)
+         call pic_gemm(c_occ, hblk, tblk)
+         deallocate (hblk)
+
+         !$omp parallel do collapse(3) default(none) &
+         !$omp    shared(x_first, tblk, n_ao, np, nj) private(j, r, p, q, col, colb)
+         do j = 1, nj
+            do r = 1, n_ao
+               do q = 1, n_ao
+                  col = q + n_ao*(r - 1) + n_ao*n_ao*(j - 1)
+                  colb = np*(r - 1) + np*n_ao*(j - 1)
+                  do p = 1, np
+                     x_first(p, col) = x_first(p, col) + tblk(q, p + colb)
+                  end do
+               end do
+            end do
+         end do
+         !$omp end parallel do
+         deallocate (tblk)
+
+         call pic_gemm(x_second, c_occ(:, j_lo:j_hi), gamma_flat, transb="T", &
+                       beta=1.0_dp)
+         deallocate (xbuf)
+         j_lo = j_hi + 1
+      end do
    end subroutine build_gamma_block
 
-   subroutine build_two_particle_density(half, c_occ, n_ao, n_o, gamma_ao)
+   subroutine build_two_particle_density(t2, c_occ, c_vir, n_ao, n_o, n_v, &
+                                         target_bytes, gamma_ao)
       !! The non-separable two-particle density, in the AO basis
-      !!
-      !! `4 t2(i,j,a,b) - 2 t2(i,j,b,a)` is the coefficient the energy gives
-      !! each integral, and the rest is four index transformations and the two
-      !! symmetrisations that make the object contract correctly against
-      !! integrals carrying the permutational symmetry of the ERIs.
       !!
       !! **Two occupied transformations, as two matrix multiplies.** Written
       !! elementwise -- one small `matmul` per `(p,q,r,s)` -- this was 65% of
       !! the whole gradient, because `n_ao^4` is eleven million calls at
       !! cc-pVTZ and each one costs more in call overhead than in arithmetic.
-      !! Contracted instead as `(n_ao x n_o) (n_o x n_ao^2 n_o)` and then
-      !! `(n_ao^3 x n_o) (n_o x n_ao)`, the same flops sit in two gemms.
+      !! Contracted instead as `(n_ao x n_o) (n_o x n_ao^2 n_j)` and then
+      !! `(n_ao^3 x n_j) (n_j x n_ao)`, the same flops sit in two gemms.
       !! Pointer bounds remapping is what lets the intermediate be read as
       !! `(p, q r j)` by the first and `(p q r, j)` by the second without a
       !! copy: the memory order is the same either way.
       !!
-      !! `n_ao^4` and dense, which is the point: this is the path taken when
-      !! the whole thing fits, where one gemm over the full first index beats
-      !! the same gemm run block by block. `build_gamma_block` is the other
-      !! path, and the driver picks between them on the size.
-      real(dp), intent(in) :: half(:, :)
-      real(dp), intent(in) :: c_occ(:, :)
-      integer, intent(in) :: n_ao, n_o
+      !! `j` is contracted last, so a range of it gives an addend rather than a
+      !! slice: the second gemm accumulates. One pass when the whole occupied
+      !! range fits, which is the ordinary case.
+      !!
+      !! `n_ao^4` and dense in its result, which is the point: this is the path
+      !! taken when the whole thing fits, where one gemm over the full first
+      !! index beats the same gemm run block by block.
+      !! `build_gamma_block` is the other path, and the driver picks on size.
+      real(dp), intent(in) :: t2(:, :, :, :)
+      real(dp), intent(in) :: c_occ(:, :), c_vir(:, :)
+      integer, intent(in) :: n_ao, n_o, n_v
+      real(dp), intent(in) :: target_bytes
       real(dp), allocatable, target, intent(out) :: gamma_ao(:, :, :, :)
 
       real(dp), allocatable, target :: xbuf(:)
+      real(dp), allocatable :: half(:, :)
       real(dp), pointer :: x_first(:, :), x_second(:, :), gamma_flat(:, :)
       real(dp) :: acc
-      integer :: p, q, r, s
+      integer :: p, q, r, s, j_lo, j_hi, nj, per_block
 
-      allocate (xbuf(int(n_ao, kind=8)*n_ao*n_ao*n_o))
-      x_first(1:n_ao, 1:n_ao*n_ao*n_o) => xbuf
-      x_second(1:n_ao*n_ao*n_ao, 1:n_o) => xbuf
-
-      call pic_gemm(c_occ, half, x_first)
+      per_block = occupied_per_block(n_ao, n_o, target_bytes)
 
       allocate (gamma_ao(n_ao, n_ao, n_ao, n_ao))
       gamma_flat(1:n_ao*n_ao*n_ao, 1:n_ao) => gamma_ao
-      call pic_gemm(x_second, c_occ, gamma_flat, transb="T")
-      deallocate (xbuf)
+      gamma_ao = 0.0_dp
+
+      j_lo = 1
+      do while (j_lo <= n_o)
+         j_hi = min(n_o, j_lo + per_block - 1)
+         nj = j_hi - j_lo + 1
+
+         call build_half_block(t2, c_vir, n_ao, n_o, n_v, j_lo, j_hi, half)
+
+         allocate (xbuf(int(n_ao, kind=int64)*n_ao*n_ao*nj))
+         x_first(1:n_ao, 1:n_ao*n_ao*nj) => xbuf
+         x_second(1:n_ao*n_ao*n_ao, 1:nj) => xbuf
+
+         call pic_gemm(c_occ, half, x_first)
+         deallocate (half)
+
+         call pic_gemm(x_second, c_occ(:, j_lo:j_hi), gamma_flat, transb="T", &
+                       beta=1.0_dp)
+         deallocate (xbuf)
+         j_lo = j_hi + 1
+      end do
 
       ! The bra pair, symmetrised in place. This is the second of the two
       ! transformation terms -- `sum_i C(q,i) half(i,p,r,j)` is the first one
@@ -648,8 +713,9 @@ contains
 
    end subroutine build_two_particle_density
 
-   subroutine blocked_two_electron_terms(mol, half, c_occ, hf_density, n_ao, n_o, &
-                                         target_bytes, imat_ao, de2, vhf1, error)
+   subroutine blocked_two_electron_terms(mol, t2, c_occ, c_vir, n_ao, n_o, n_v, &
+                                         target_bytes, hf_density, imat_ao, de2, &
+                                         vhf1, error)
       !! The Lagrangian and the gradient's two-electron term, a block at a time
       !!
       !! Neither the integrals nor the two-particle density is ever whole here.
@@ -666,8 +732,9 @@ contains
       !! Blocks are cut on shell boundaries, since a shell's functions share a
       !! quartet and cannot be split across two passes.
       type(libcint_molecule_t), intent(in) :: mol
-      real(dp), intent(in) :: half(:, :), c_occ(:, :), hf_density(:, :)
-      integer, intent(in) :: n_ao, n_o
+      real(dp), intent(in) :: t2(:, :, :, :), c_occ(:, :), c_vir(:, :)
+      real(dp), intent(in) :: hf_density(:, :)
+      integer, intent(in) :: n_ao, n_o, n_v
       real(dp), intent(in) :: target_bytes
       real(dp), intent(inout) :: imat_ao(:, :)
       real(dp), intent(inout) :: de2(:, :), vhf1(:, :, :, :)
@@ -694,7 +761,8 @@ contains
          p_hi = mol%shell_offset(ish_hi) + shell_dim(mol%cartesian, ish_hi - 1, mol%bas)
          np = p_hi - p_lo + 1
 
-         call build_gamma_block(half, c_occ, n_ao, n_o, p_lo, p_hi, gamma_blk)
+         call build_gamma_block(t2, c_occ, c_vir, n_ao, n_o, n_v, p_lo, p_hi, &
+                                target_bytes, gamma_blk)
 
          allocate (eri_blk(np, n_ao, n_ao, n_ao))
          eri_blk = 0.0_dp

--- a/mqc_docs/source/capabilities.rst
+++ b/mqc_docs/source/capabilities.rst
@@ -173,6 +173,32 @@ Gradient Calculations
 - **Units**: Hartree/Bohr
 - **Applications**: Geometry optimization, molecular dynamics
 
+On the CPU backend the analytic gradient covers Hartree-Fock restricted and
+unrestricted, density-fitted restricted Hartree-Fock, Kohn-Sham through LDA,
+GGA and hybrid GGA, and MP2 over a restricted reference. What is refused rather
+than approximated, and why:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Case
+     - Why it is refused
+   * - Meta-GGA functionals
+     - The kinetic energy density brings a term of its own, which is not built
+   * - Range-separated hybrids
+     - Needs a second exchange derivative at the screened omega
+   * - Density-fitted MP2
+     - Would differentiate an energy nothing computed
+   * - Frozen-core MP2
+     - The relaxed density gains occupied-frozen and virtual-frozen blocks
+   * - Spin-scaled MP2 (SCS, SOS)
+     - The amplitudes enter the response equations, where the two spin cases
+       are no longer separable, so the scaled gradient is not the unscaled one
+       rescaled
+   * - Coupled cluster
+     - Needs the Lambda amplitudes, which are not implemented
+
 Geometry Optimization
 ---------------------
 

--- a/tools/cpu_validation/gen_cpu_validation.py
+++ b/tools/cpu_validation/gen_cpu_validation.py
@@ -413,6 +413,19 @@ GRADIENT_CASES = [
     ("ch3", "cc-pvdz", "", "pbe", 2),               # unrestricted GGA
 ]
 
+# MP2 gradients, as (molecule, basis). Small on purpose: the relaxed density
+# is assembled as a dense `n_ao^4` two-particle density, which is a memory
+# ceiling long before it is a speed problem.
+#
+# The reference needs one thing that is not a default -- see `dense_zvector` --
+# and these are the only cases in the suite whose reference implementation had
+# to be corrected before it could be used at all.
+GRADIENT_MP2_CASES = [
+    ("water", "sto-3g"),
+    ("water", "cc-pvdz"),
+    ("nh3", "6-31g"),
+]
+
 # The same gradient through the many-body expansion, as
 # (molecule, basis, fragments). Its reference is the supermolecule and that is
 # exact rather than tolerated: over two fragments the expansion collapses term
@@ -836,6 +849,61 @@ def pyscf_ri_cc(atoms, basis, aux, method, frozen):
     return float(escf + ecorr), mol.nao
 
 
+def dense_zvector(fvind, mo_energy, mo_occ, h1, s1=None, max_cycle=50, tol=1e-9, **kw):
+    """Solve the Z-vector equation densely, in place of PySCF's Krylov solver.
+
+    Not an optimisation -- a correction. `pyscf.scf.cphf.solve` returns a
+    solution carrying ~1e-6 relative error that its `tol` argument does not
+    control, and an MP2 gradient built on it is ~4e-8 off in a way that looks
+    exactly like a missing term on the other side. Measured on water/cc-pVDZ:
+    the Krylov solution gives 0.0126434122, the dense one 0.0126434488, and
+    metalquicha's own conjugate-gradient solve gives 0.012643449.
+
+    The occupied-virtual space is `n_occ * n_vir`, so for anything in this table
+    building the operator column by column and calling LAPACK is cheap.
+    """
+    import numpy
+
+    nvir, nocc = h1.shape
+    gaps = (mo_energy[mo_occ == 0][:, None] - mo_energy[mo_occ > 0][None, :]).ravel()
+    n = nvir * nocc
+    operator = numpy.zeros((n, n))
+    for k in range(n):
+        column = numpy.zeros(n)
+        column[k] = 1.0
+        operator[:, k] = fvind(column.reshape(nvir, nocc)).ravel()
+    operator += numpy.diag(gaps)
+    return numpy.linalg.solve(operator, -h1.ravel()).reshape(h1.shape), None
+
+
+def pyscf_mp2_gradient(atoms, basis):
+    """Reference MP2 energy and analytic nuclear gradient, in Hartree/Bohr."""
+    from pyscf import gto, mp, scf
+    from pyscf.grad import mp2 as mp2_grad
+
+    mp2_grad.cphf.solve = dense_zvector
+
+    mol = gto.Mole()
+    mol.atom = [(s, (x, y, z)) for s, x, y, z in atoms]
+    mol.unit = "Angstrom"
+    symbols = {a[0] for a in atoms}
+    mol.basis = {s: bse_to_pyscf(basis, s) for s in symbols}
+    mol.charge = 0
+    mol.spin = 0
+    mol.cart = molecule_form(basis, symbols) == CARTESIAN
+    mol.verbose = 0
+    mol.build()
+
+    mf = scf.RHF(mol)
+    mf.conv_tol = 1e-13
+    mf.kernel()
+    if not mf.converged:
+        raise SystemExit(f"PySCF RHF did not converge for {basis}")
+    pt = mp.MP2(mf)
+    pt.kernel()
+    return float(mf.e_tot + pt.e_corr), pt.Gradients().kernel().tolist(), mol.nao
+
+
 def pyscf_gradient(atoms, basis, aux="", functional="", multiplicity=1,
                    level=GRADIENT_GRID_LEVEL):
     """Reference energy and analytic nuclear gradient, in Hartree/Bohr.
@@ -1029,6 +1097,31 @@ def main():
         })
         norm = math.sqrt(sum(c*c for atom in gradient for c in atom))
         print(f"{mol.label:6s} {basis:12s} {theory:8s} grad |g|={norm:.10f} "
+              f"nao={nao:4d} E={energy:.12f}", flush=True)
+
+    for name, basis in GRADIENT_MP2_CASES:
+        mol = MOLECULES[name]
+        energy, gradient, nao = pyscf_mp2_gradient(mol.atoms, basis)
+        deck = deck_for(f"{CPU_MQC}/gradient",
+                        f"cpu_{name}_{normalize_basis_name(basis)}_mp2_grad")
+        written.add(str((VALIDATION / deck).relative_to(INPUTS)))
+        if not args.dry_run:
+            d = deck_json(xyz_for(mol), basis, method="mp2",
+                          correlation={"freeze_core": False})
+            d["keywords"]["scf"]["tolerance"] = 1e-12
+            d["driver"] = "Gradient"
+            _write_deck(VALIDATION / deck, json.dumps(d, indent=4) + "\n")
+        tests.append({
+            "name": f"MP2 gradient {mol.label} {basis} (CPU)",
+            "input": deck,
+            "expected_energy": round(energy, 12),
+            "expected_gradient": [[round(c, 12) for c in atom] for atom in gradient],
+            "gradient_tolerance": GRADIENT_TOLERANCE,
+            "check_translation": True,
+            "type": "unfragmented",
+        })
+        norm = math.sqrt(sum(c*c for atom in gradient for c in atom))
+        print(f"{mol.label:6s} {basis:12s} {'MP2':8s} grad |g|={norm:.10f} "
               f"nao={nao:4d} E={energy:.12f}", flush=True)
 
     for name, basis, fragments in GRADIENT_FRAGMENTED_CASES:

--- a/validation/bench_mp2_gradient.f90
+++ b/validation/bench_mp2_gradient.f90
@@ -1,0 +1,94 @@
+!! Where the time goes in the MP2 gradient
+program bench_mp2_gradient
+   !! **Warm, and on a wall clock.** The first call into this path resolves
+   !! symbols lazily and allocates for the first time, which on a small molecule
+   !! is most of what a cold timing measures -- an earlier benchmark in this
+   !! repository reported an 11x gap that was entirely that. And `cpu_time` sums
+   !! over threads, so a threaded routine appears to get *slower* as it speeds
+   !! up; `system_clock` is what answers the question being asked.
+   use pic_types, only: dp, int64
+   use mqc_error, only: error_t
+   use mqc_libcint_integrals, only: libcint_molecule_t, build_libcint_molecule
+   use mqc_libcint_rhf, only: rhf_result_t, run_libcint_rhf
+   use mqc_libcint_mp2_gradient, only: libcint_mp2_gradient
+   use omp_lib, only: omp_get_max_threads
+   use, intrinsic :: iso_fortran_env, only: output_unit
+   implicit none
+
+   integer, parameter :: N_DIM = 3
+
+   write (*, "(a,i0,a)") "== MP2 gradient, ", omp_get_max_threads(), " threads"
+
+   call bench_case("H2O / cc-pvdz", [8, 1, 1], ["O", "H", "H"], &
+                   reshape([0.0_dp, 0.0_dp, 0.0_dp, &
+                            0.0_dp, -1.4308_dp, 1.1078_dp, &
+                            0.0_dp, 1.4308_dp, 1.1078_dp], [N_DIM, 3]), &
+                   "cc-pvdz", 10)
+
+   call bench_case("H2O / cc-pvtz", [8, 1, 1], ["O", "H", "H"], &
+                   reshape([0.0_dp, 0.0_dp, 0.0_dp, &
+                            0.0_dp, -1.4308_dp, 1.1078_dp, &
+                            0.0_dp, 1.4308_dp, 1.1078_dp], [N_DIM, 3]), &
+                   "cc-pvtz", 10)
+
+   call bench_case("(H2O)2 / cc-pvdz", [8, 1, 1, 8, 1, 1], &
+                   ["O", "H", "H", "O", "H", "H"], &
+                   reshape([0.0_dp, 0.0_dp, 0.0_dp, &
+                            0.0_dp, -1.4308_dp, 1.1078_dp, &
+                            0.0_dp, 1.4308_dp, 1.1078_dp, &
+                            0.0_dp, 0.0_dp, 5.6_dp, &
+                            0.0_dp, -1.4308_dp, 6.7078_dp, &
+                            0.0_dp, 1.4308_dp, 6.7078_dp], [N_DIM, 6]), &
+                   "cc-pvdz", 20)
+
+contains
+
+   subroutine bench_case(label, numbers, symbols, coords, basis, nelec)
+      character(len=*), intent(in) :: label
+      integer, intent(in) :: numbers(:)
+      character(len=*), intent(in) :: symbols(:)
+      real(dp), intent(in) :: coords(:, :)
+      character(len=*), intent(in) :: basis
+      integer, intent(in) :: nelec
+
+      type(libcint_molecule_t) :: mol
+      type(rhf_result_t) :: scf
+      type(error_t) :: error
+      real(dp), allocatable :: gradient(:, :)
+      integer(int64) :: t0, t1, rate
+      real(dp) :: seconds
+
+      call build_libcint_molecule(numbers, symbols, coords, basis, mol, error)
+      if (error%has_error()) then
+         write (*, "(a,a)") "FAIL: ", error%get_message()
+         return
+      end if
+      call run_libcint_rhf(mol, nelec, 200, 1.0e-11_dp, 1.0e-9_dp, .false., scf, error)
+      if (error%has_error()) then
+         write (*, "(a,a)") "FAIL: ", error%get_message()
+         return
+      end if
+
+      ! Warm-up, discarded.
+      call libcint_mp2_gradient(mol, scf%orbitals, scf%orbital_energies, nelec/2, &
+                                gradient, error)
+      if (error%has_error()) then
+         write (*, "(a,a)") "FAIL: ", error%get_message()
+         return
+      end if
+      deallocate (gradient)
+
+      call system_clock(t0, rate)
+      call libcint_mp2_gradient(mol, scf%orbitals, scf%orbital_energies, nelec/2, &
+                                gradient, error)
+      call system_clock(t1)
+      seconds = real(t1 - t0, dp)/real(rate, dp)
+
+      write (*, "(a,a,a,i0,a,f10.3,a,es12.4)") "  ", label, "  nao=", mol%nao, &
+         "   ", seconds, " s   |g|=", sqrt(sum(gradient**2))
+      flush (output_unit)
+      deallocate (gradient)
+      call mol%destroy()
+   end subroutine bench_case
+
+end program bench_mp2_gradient

--- a/validation/bench_mp2_gradient.f90
+++ b/validation/bench_mp2_gradient.f90
@@ -107,11 +107,11 @@ contains
       ! storing anything: the integrals are rebuilt per block and only the ket
       ! pair's symmetry survives.
       call libcint_mp2_gradient(mol, scf%orbitals, scf%orbital_energies, nelec/2, &
-                                gradient, error, block_bytes=BLOCK_BYTES)
+                                gradient, error, force_blocked=.true.)
       deallocate (gradient)
       call system_clock(t0, rate)
       call libcint_mp2_gradient(mol, scf%orbitals, scf%orbital_energies, nelec/2, &
-                                gradient, error, block_bytes=BLOCK_BYTES)
+                                gradient, error, force_blocked=.true.)
       call system_clock(t1)
       blocked_seconds = real(t1 - t0, dp)/real(rate, dp)
 

--- a/validation/bench_mp2_gradient.f90
+++ b/validation/bench_mp2_gradient.f90
@@ -16,7 +16,15 @@ program bench_mp2_gradient
    implicit none
 
    integer, parameter :: N_DIM = 3
+   real(dp), parameter :: BLOCK_BYTES = 5.0e8_dp
+      !! What the blocked path would use of its own accord. Passed explicitly
+      !! because these molecules are far too small to take that path otherwise.
+   character(len=32) :: mode
+      !! "dense" measures only that path, so a run cannot be perturbed by the
+      !! allocation and release of the other one's arrays.
 
+   mode = ""
+   call get_command_argument(1, mode)
    write (*, "(a,i0,a)") "== MP2 gradient, ", omp_get_max_threads(), " threads"
 
    call bench_case("H2O / cc-pvdz", [8, 1, 1], ["O", "H", "H"], &
@@ -56,7 +64,7 @@ contains
       type(error_t) :: error
       real(dp), allocatable :: gradient(:, :)
       integer(int64) :: t0, t1, rate
-      real(dp) :: seconds
+      real(dp) :: seconds, blocked_seconds
 
       call build_libcint_molecule(numbers, symbols, coords, basis, mol, error)
       if (error%has_error()) then
@@ -84,8 +92,32 @@ contains
       call system_clock(t1)
       seconds = real(t1 - t0, dp)/real(rate, dp)
 
-      write (*, "(a,a,a,i0,a,f10.3,a,es12.4)") "  ", label, "  nao=", mol%nao, &
-         "   ", seconds, " s   |g|=", sqrt(sum(gradient**2))
+      blocked_seconds = 0.0_dp
+      if (trim(mode) == "dense") then
+         write (*, "(a,a,a,i0,a,f9.3,a,es12.4)") "  ", label, "  nao=", mol%nao, &
+            "   dense ", seconds, " s   |g|=", sqrt(sum(gradient**2))
+         flush (output_unit)
+         call mol%destroy()
+         return
+      end if
+      deallocate (gradient)
+
+      ! And the same case through the blocked path, which these are all far too
+      ! small to take on their own. What it measures is the overhead of never
+      ! storing anything: the integrals are rebuilt per block and only the ket
+      ! pair's symmetry survives.
+      call libcint_mp2_gradient(mol, scf%orbitals, scf%orbital_energies, nelec/2, &
+                                gradient, error, block_bytes=BLOCK_BYTES)
+      deallocate (gradient)
+      call system_clock(t0, rate)
+      call libcint_mp2_gradient(mol, scf%orbitals, scf%orbital_energies, nelec/2, &
+                                gradient, error, block_bytes=BLOCK_BYTES)
+      call system_clock(t1)
+      blocked_seconds = real(t1 - t0, dp)/real(rate, dp)
+
+      write (*, "(a,a,a,i0,a,f9.3,a,f9.3,a,es12.4)") "  ", label, "  nao=", mol%nao, &
+         "   dense ", seconds, " s   blocked ", blocked_seconds, &
+         " s   |g|=", sqrt(sum(gradient**2))
       flush (output_unit)
       deallocate (gradient)
       call mol%destroy()

--- a/validation/check_mp2_gradient.f90
+++ b/validation/check_mp2_gradient.f90
@@ -98,7 +98,7 @@ contains
       integer, intent(in) :: nelec
       integer, intent(inout) :: n_bad
 
-      real(dp), allocatable :: analytic(:, :), numeric(:, :)
+      real(dp), allocatable :: analytic(:, :), numeric(:, :), blocked(:, :)
       real(dp) :: translation(3)
       real(dp) :: worst
       integer :: natm, ia, ic
@@ -119,6 +119,30 @@ contains
          write (*, "(a,a)") "FAIL: ", error%get_message()
          n_bad = n_bad + 1
          return
+      end if
+
+      ! The blocked path, on a system small enough that it would never be
+      ! taken, and with a byte target small enough to force several blocks --
+      ! one block would exercise neither the loop over them nor the offset into
+      ! the two-particle density. The two paths build the same quantities from
+      ! different amounts of memory, so they have to agree.
+      call gradient_at(numbers, symbols, coords, basis, nelec, blocked, error, &
+                       block_bytes=1.0_dp)
+      if (error%has_error()) then
+         write (*, "(a,a)") "FAIL (blocked): ", error%get_message()
+         n_bad = n_bad + 1
+         return
+      end if
+      write (*, "(a,es14.4)") "  dense against blocked:                    ", &
+         maxval(abs(analytic - blocked))
+      ! Not bitwise: the blocked path screens its Fock builds and its response
+      ! solve on a Schwarz bound where the dense one reads a stored tensor, and
+      ! sums the two-electron terms in a different order. Both show up around
+      ! 1e-12 -- HCN is the worst of these five -- which is two orders below
+      ! where the gradient itself is validated.
+      if (maxval(abs(analytic - blocked)) > 1.0e-10_dp) then
+         write (*, "(a)") "  FAIL: the blocked path disagrees with the dense one"
+         n_bad = n_bad + 1
       end if
 
       call numeric_gradient(numbers, symbols, coords, basis, nelec, numeric, error)
@@ -156,7 +180,8 @@ contains
       end if
    end subroutine check_case
 
-   subroutine gradient_at(numbers, symbols, coords, basis, nelec, gradient, error)
+   subroutine gradient_at(numbers, symbols, coords, basis, nelec, gradient, error, &
+                          block_bytes)
       !! Converge an SCF, then the MP2 gradient over it
       integer, intent(in) :: numbers(:)
       character(len=*), intent(in) :: symbols(:)
@@ -165,6 +190,7 @@ contains
       integer, intent(in) :: nelec
       real(dp), allocatable, intent(out) :: gradient(:, :)
       type(error_t), intent(inout) :: error
+      real(dp), intent(in), optional :: block_bytes
 
       type(libcint_molecule_t) :: mol
       type(rhf_result_t) :: scf
@@ -174,7 +200,7 @@ contains
       call run_libcint_rhf(mol, nelec, 300, 1.0e-14_dp, 1.0e-12_dp, .false., scf, error)
       if (error%has_error()) return
       call libcint_mp2_gradient(mol, scf%orbitals, scf%orbital_energies, nelec/2, &
-                                gradient, error)
+                                gradient, error, block_bytes=block_bytes)
       call mol%destroy()
    end subroutine gradient_at
 

--- a/validation/check_mp2_gradient.f90
+++ b/validation/check_mp2_gradient.f90
@@ -99,6 +99,7 @@ contains
       integer, intent(inout) :: n_bad
 
       real(dp), allocatable :: analytic(:, :), numeric(:, :), blocked(:, :)
+      real(dp), allocatable :: split(:, :)
       real(dp) :: translation(3)
       real(dp) :: worst
       integer :: natm, ia, ic
@@ -121,27 +122,37 @@ contains
          return
       end if
 
-      ! The blocked path, on a system small enough that it would never be
-      ! taken, and with a byte target small enough to force several blocks --
-      ! one block would exercise neither the loop over them nor the offset into
-      ! the two-particle density. The two paths build the same quantities from
-      ! different amounts of memory, so they have to agree.
-      call gradient_at(numbers, symbols, coords, basis, nelec, blocked, error, &
+      ! The same gradient with every loop that can be blocked forced to its
+      ! smallest pass -- one shell of the first index, one occupied orbital at
+      ! a time -- and again through the blocked path, which these systems are
+      ! far too small to take on their own. All three build the same quantities
+      ! from different amounts of memory, so all three have to agree. A single
+      ! block exercises neither loop nor the offsets they carry, which is why
+      ! the target is one byte rather than merely small.
+      call gradient_at(numbers, symbols, coords, basis, nelec, split, error, &
                        block_bytes=1.0_dp)
+      if (error%has_error()) then
+         write (*, "(a,a)") "FAIL (dense, split over j): ", error%get_message()
+         n_bad = n_bad + 1
+         return
+      end if
+      call gradient_at(numbers, symbols, coords, basis, nelec, blocked, error, &
+                       block_bytes=1.0_dp, force_blocked=.true.)
       if (error%has_error()) then
          write (*, "(a,a)") "FAIL (blocked): ", error%get_message()
          n_bad = n_bad + 1
          return
       end if
-      write (*, "(a,es14.4)") "  dense against blocked:                    ", &
-         maxval(abs(analytic - blocked))
+      write (*, "(a,2es14.4)") "  dense against split, then blocked:        ", &
+         maxval(abs(analytic - split)), maxval(abs(analytic - blocked))
       ! Not bitwise: the blocked path screens its Fock builds and its response
       ! solve on a Schwarz bound where the dense one reads a stored tensor, and
       ! sums the two-electron terms in a different order. Both show up around
       ! 1e-12 -- HCN is the worst of these five -- which is two orders below
       ! where the gradient itself is validated.
-      if (maxval(abs(analytic - blocked)) > 1.0e-10_dp) then
-         write (*, "(a)") "  FAIL: the blocked path disagrees with the dense one"
+      if (max(maxval(abs(analytic - blocked)), &
+              maxval(abs(analytic - split))) > 1.0e-10_dp) then
+         write (*, "(a)") "  FAIL: a blocked pass disagrees with the whole one"
          n_bad = n_bad + 1
       end if
 
@@ -181,7 +192,7 @@ contains
    end subroutine check_case
 
    subroutine gradient_at(numbers, symbols, coords, basis, nelec, gradient, error, &
-                          block_bytes)
+                          block_bytes, force_blocked)
       !! Converge an SCF, then the MP2 gradient over it
       integer, intent(in) :: numbers(:)
       character(len=*), intent(in) :: symbols(:)
@@ -191,6 +202,7 @@ contains
       real(dp), allocatable, intent(out) :: gradient(:, :)
       type(error_t), intent(inout) :: error
       real(dp), intent(in), optional :: block_bytes
+      logical, intent(in), optional :: force_blocked
 
       type(libcint_molecule_t) :: mol
       type(rhf_result_t) :: scf
@@ -200,7 +212,8 @@ contains
       call run_libcint_rhf(mol, nelec, 300, 1.0e-14_dp, 1.0e-12_dp, .false., scf, error)
       if (error%has_error()) return
       call libcint_mp2_gradient(mol, scf%orbitals, scf%orbital_energies, nelec/2, &
-                                gradient, error, block_bytes=block_bytes)
+                                gradient, error, block_bytes=block_bytes, &
+                                force_blocked=force_blocked)
       call mol%destroy()
    end subroutine gradient_at
 

--- a/validation/check_mp2_gradient.f90
+++ b/validation/check_mp2_gradient.f90
@@ -1,0 +1,239 @@
+!! The MP2 analytic gradient, against finite differences of the MP2 energy
+program check_mp2_gradient
+   !! **Finite difference is the only check that can fail here.** Unlike the
+   !! variational gradients, an MP2 gradient has a term -- the orbital
+   !! relaxation -- with no counterpart in the energy expression, so agreeing
+   !! with a total energy says nothing at all about it. Differentiating this
+   !! program's own MP2 energy is what pins it.
+   !!
+   !! Translational invariance is printed because it is free, and is worth
+   !! exactly as much as it is elsewhere: it catches a missing Hellmann-Feynman
+   !! term and is blind to almost everything else. The relaxation term is
+   !! translationally invariant whether or not it is right.
+   !!
+   !! The printed values are for comparison against `pyscf.grad.mp2` fed this
+   !! repository's own basis JSON.
+   !!
+   !! Not a ctest case: one converged SCF and one MP2 per displaced geometry.
+   use pic_types, only: dp
+   use mqc_error, only: error_t
+   use mqc_libcint_integrals, only: libcint_molecule_t, build_libcint_molecule
+   use mqc_libcint_rhf, only: rhf_result_t, run_libcint_rhf
+   use mqc_libcint_mp2, only: mp2_result_t, run_libcint_mp2
+   use mqc_libcint_mp2_gradient, only: libcint_mp2_gradient
+   use omp_lib, only: omp_set_num_threads, omp_get_max_threads
+   use, intrinsic :: iso_fortran_env, only: output_unit
+   implicit none
+
+   integer, parameter :: N_DIM = 3
+   integer, parameter :: BENCH_THREADS = 4
+   real(dp), parameter :: STEP = 2.5e-3_dp
+      !! Bohr. Chosen by measurement rather than taste: at 5e-3 the HCN case
+      !! sat 2.17e-5 from the analytic gradient and at 2.5e-3 it sits 5.42e-6,
+      !! a factor of 4.0 for a halved step. That is the central difference's own
+      !! O(h^2) error being seen, which is what says the disagreement is the
+      !! difference formula and not the derivative.
+
+   integer :: n_bad
+   character(len=128) :: filter
+   integer :: filter_len, arg_status
+
+   call omp_set_num_threads(min(BENCH_THREADS, omp_get_max_threads()))
+
+   filter = ""
+   call get_command_argument(1, filter, length=filter_len, status=arg_status)
+   if (arg_status /= 0) filter = ""
+
+   n_bad = 0
+   write (*, "(a)") "== MP2 gradients"
+
+   call check_case("H2 / sto-3g", [1, 1], ["H", "H"], &
+                   reshape([0.0_dp, 0.0_dp, -0.7_dp, &
+                            0.0_dp, 0.0_dp, 0.7_dp], [N_DIM, 2]), &
+                   "sto-3g", 2, n_bad)
+
+   call check_case("H2O / sto-3g", [8, 1, 1], ["O", "H", "H"], &
+                   reshape([0.0_dp, 0.0_dp, 0.0_dp, &
+                            0.0_dp, -1.4308_dp, 1.1078_dp, &
+                            0.0_dp, 1.4308_dp, 1.1078_dp], [N_DIM, 3]), &
+                   "sto-3g", 10, n_bad)
+
+   ! Asymmetric, so a term that is wrong in a way symmetry cancels shows up.
+   call check_case("HCN / sto-3g", [1, 6, 7], ["H", "C", "N"], &
+                   reshape([0.0_dp, 0.0_dp, -2.0_dp, &
+                            0.0_dp, 0.0_dp, 0.0_dp, &
+                            0.0_dp, 0.0_dp, 2.2_dp], [N_DIM, 3]), &
+                   "sto-3g", 14, n_bad)
+
+   ! A general contraction with d functions, where the amplitudes stop being
+   ! a handful of numbers and the two-particle density has real structure.
+   call check_case("H2O / cc-pvdz", [8, 1, 1], ["O", "H", "H"], &
+                   reshape([0.0_dp, 0.0_dp, 0.0_dp, &
+                            0.0_dp, -1.4308_dp, 1.1078_dp, &
+                            0.0_dp, 1.4308_dp, 1.1078_dp], [N_DIM, 3]), &
+                   "cc-pvdz", 10, n_bad)
+
+   call check_case("H2O / 6-31g", [8, 1, 1], ["O", "H", "H"], &
+                   reshape([0.0_dp, 0.0_dp, 0.0_dp, &
+                            0.0_dp, -1.4308_dp, 1.1078_dp, &
+                            0.0_dp, 1.4308_dp, 1.1078_dp], [N_DIM, 3]), &
+                   "6-31g", 10, n_bad)
+
+   write (*, "(a)") ""
+   if (n_bad == 0) then
+      write (*, "(a)") "all MP2 gradient checks passed"
+   else
+      write (*, "(a,i0,a)") "FAILED: ", n_bad, " case(s)"
+      stop 1
+   end if
+
+contains
+
+   subroutine check_case(label, numbers, symbols, coords, basis, nelec, n_bad)
+      character(len=*), intent(in) :: label
+      integer, intent(in) :: numbers(:)
+      character(len=*), intent(in) :: symbols(:)
+      real(dp), intent(in) :: coords(:, :)
+      character(len=*), intent(in) :: basis
+      integer, intent(in) :: nelec
+      integer, intent(inout) :: n_bad
+
+      real(dp), allocatable :: analytic(:, :), numeric(:, :)
+      real(dp) :: translation(3)
+      real(dp) :: worst
+      integer :: natm, ia, ic
+      type(error_t) :: error
+
+      natm = size(numbers)
+
+      if (len_trim(filter) > 0) then
+         if (index(label, trim(filter)) == 0) return
+      end if
+
+      write (*, "(a)") ""
+      write (*, "(a,a)") "== ", label
+      flush (output_unit)
+
+      call gradient_at(numbers, symbols, coords, basis, nelec, analytic, error)
+      if (error%has_error()) then
+         write (*, "(a,a)") "FAIL: ", error%get_message()
+         n_bad = n_bad + 1
+         return
+      end if
+
+      call numeric_gradient(numbers, symbols, coords, basis, nelec, numeric, error)
+      if (error%has_error()) then
+         write (*, "(a,a)") "FAIL (finite difference): ", error%get_message()
+         n_bad = n_bad + 1
+         return
+      end if
+
+      write (*, "(a)") "  atom        analytic (x, y, z)                      finite difference"
+      do ia = 1, natm
+         write (*, "(i6,3f14.9,3x,3f14.9)") ia, analytic(:, ia), numeric(:, ia)
+      end do
+
+      worst = maxval(abs(analytic - numeric))
+      write (*, "(a,es14.4)") "  largest deviation from finite difference: ", worst
+      do ic = 1, 3
+         translation(ic) = sum(analytic(ic, :))
+      end do
+      write (*, "(a,es14.4)") "  |sum over atoms| (should be zero):        ", &
+         maxval(abs(translation))
+      flush (output_unit)
+
+      ! Loose against the analytic gradients' own accuracy, because it is the
+      ! difference formula being tolerated rather than the derivative: a
+      ! central difference at this step carries its own error of about this
+      ! size, which is why the printed columns matter more than the bound.
+      if (worst > 1.0e-5_dp) then
+         write (*, "(a)") "  FAIL: analytic and numeric disagree"
+         n_bad = n_bad + 1
+      end if
+      if (maxval(abs(translation)) > 1.0e-8_dp) then
+         write (*, "(a)") "  FAIL: the gradient does not sum to zero"
+         n_bad = n_bad + 1
+      end if
+   end subroutine check_case
+
+   subroutine gradient_at(numbers, symbols, coords, basis, nelec, gradient, error)
+      !! Converge an SCF, then the MP2 gradient over it
+      integer, intent(in) :: numbers(:)
+      character(len=*), intent(in) :: symbols(:)
+      real(dp), intent(in) :: coords(:, :)
+      character(len=*), intent(in) :: basis
+      integer, intent(in) :: nelec
+      real(dp), allocatable, intent(out) :: gradient(:, :)
+      type(error_t), intent(inout) :: error
+
+      type(libcint_molecule_t) :: mol
+      type(rhf_result_t) :: scf
+
+      call build_libcint_molecule(numbers, symbols, coords, basis, mol, error)
+      if (error%has_error()) return
+      call run_libcint_rhf(mol, nelec, 300, 1.0e-14_dp, 1.0e-12_dp, .false., scf, error)
+      if (error%has_error()) return
+      call libcint_mp2_gradient(mol, scf%orbitals, scf%orbital_energies, nelec/2, &
+                                gradient, error)
+      call mol%destroy()
+   end subroutine gradient_at
+
+   subroutine energy_at(numbers, symbols, coords, basis, nelec, energy, error)
+      !! One converged MP2 total energy, for the finite difference
+      integer, intent(in) :: numbers(:)
+      character(len=*), intent(in) :: symbols(:)
+      real(dp), intent(in) :: coords(:, :)
+      character(len=*), intent(in) :: basis
+      integer, intent(in) :: nelec
+      real(dp), intent(out) :: energy
+      type(error_t), intent(inout) :: error
+
+      type(libcint_molecule_t) :: mol
+      type(rhf_result_t) :: scf
+      type(mp2_result_t) :: mp2
+
+      energy = 0.0_dp
+      call build_libcint_molecule(numbers, symbols, coords, basis, mol, error)
+      if (error%has_error()) return
+      call run_libcint_rhf(mol, nelec, 200, 1.0e-12_dp, 1.0e-10_dp, .false., scf, error)
+      if (error%has_error()) return
+      call run_libcint_mp2(mol, scf%orbitals, scf%orbital_energies, nelec/2, &
+                           scf%energy, mp2, error)
+      if (error%has_error()) return
+      energy = mp2%total
+      call mol%destroy()
+   end subroutine energy_at
+
+   subroutine numeric_gradient(numbers, symbols, coords, basis, nelec, gradient, error)
+      !! Central differences of the MP2 total energy
+      integer, intent(in) :: numbers(:)
+      character(len=*), intent(in) :: symbols(:)
+      real(dp), intent(in) :: coords(:, :)
+      character(len=*), intent(in) :: basis
+      integer, intent(in) :: nelec
+      real(dp), allocatable, intent(out) :: gradient(:, :)
+      type(error_t), intent(inout) :: error
+
+      real(dp), allocatable :: shifted(:, :)
+      real(dp) :: plus, minus
+      integer :: natm, ia, ic
+
+      natm = size(numbers)
+      allocate (gradient(3, natm), shifted(3, natm))
+      gradient = 0.0_dp
+
+      do ia = 1, natm
+         do ic = 1, 3
+            shifted = coords
+            shifted(ic, ia) = coords(ic, ia) + STEP
+            call energy_at(numbers, symbols, shifted, basis, nelec, plus, error)
+            if (error%has_error()) return
+            shifted(ic, ia) = coords(ic, ia) - STEP
+            call energy_at(numbers, symbols, shifted, basis, nelec, minus, error)
+            if (error%has_error()) return
+            gradient(ic, ia) = (plus - minus)/(2.0_dp*STEP)
+         end do
+      end do
+   end subroutine numeric_gradient
+
+end program check_mp2_gradient

--- a/validation/inputs/cpu/mqc/gradient/cpu_nh3_6-31g_mp2_grad.json
+++ b/validation/inputs/cpu/mqc/gradient/cpu_nh3_6-31g_mp2_grad.json
@@ -1,0 +1,32 @@
+{
+    "schema": {
+        "name": "mqc-frag",
+        "version": "1.0"
+    },
+    "molecules": [
+        {
+            "xyz": "../../../sample_inputs/nh3.xyz",
+            "molecular_charge": 0,
+            "molecular_multiplicity": 1
+        }
+    ],
+    "model": {
+        "method": "mp2",
+        "basis": "6-31g"
+    },
+    "keywords": {
+        "scf": {
+            "maxiter": 100,
+            "tolerance": 1e-12
+        },
+        "correlation": {
+            "freeze_core": false
+        }
+    },
+    "system": {
+        "logger": {
+            "level": "Verbose"
+        }
+    },
+    "driver": "Gradient"
+}

--- a/validation/inputs/cpu/mqc/gradient/cpu_water_cc-pvdz_mp2_grad.json
+++ b/validation/inputs/cpu/mqc/gradient/cpu_water_cc-pvdz_mp2_grad.json
@@ -1,0 +1,32 @@
+{
+    "schema": {
+        "name": "mqc-frag",
+        "version": "1.0"
+    },
+    "molecules": [
+        {
+            "xyz": "../../../sample_inputs/w1.xyz",
+            "molecular_charge": 0,
+            "molecular_multiplicity": 1
+        }
+    ],
+    "model": {
+        "method": "mp2",
+        "basis": "cc-pvdz"
+    },
+    "keywords": {
+        "scf": {
+            "maxiter": 100,
+            "tolerance": 1e-12
+        },
+        "correlation": {
+            "freeze_core": false
+        }
+    },
+    "system": {
+        "logger": {
+            "level": "Verbose"
+        }
+    },
+    "driver": "Gradient"
+}

--- a/validation/inputs/cpu/mqc/gradient/cpu_water_sto-3g_mp2_grad.json
+++ b/validation/inputs/cpu/mqc/gradient/cpu_water_sto-3g_mp2_grad.json
@@ -1,0 +1,32 @@
+{
+    "schema": {
+        "name": "mqc-frag",
+        "version": "1.0"
+    },
+    "molecules": [
+        {
+            "xyz": "../../../sample_inputs/w1.xyz",
+            "molecular_charge": 0,
+            "molecular_multiplicity": 1
+        }
+    ],
+    "model": {
+        "method": "mp2",
+        "basis": "sto-3g"
+    },
+    "keywords": {
+        "scf": {
+            "maxiter": 100,
+            "tolerance": 1e-12
+        },
+        "correlation": {
+            "freeze_core": false
+        }
+    },
+    "system": {
+        "logger": {
+            "level": "Verbose"
+        }
+    },
+    "driver": "Gradient"
+}

--- a/validation/validation_tests_cpu.json
+++ b/validation/validation_tests_cpu.json
@@ -23,7 +23,7 @@
         {
             "name": "RHF BH3 sto-3g (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_bh3_sto-3g.json",
-            "expected_energy": -26.068995738524,
+            "expected_energy": -26.068995738523,
             "type": "unfragmented"
         },
         {
@@ -47,7 +47,7 @@
         {
             "name": "RHF HF sto-3g (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_hf_sto-3g.json",
-            "expected_energy": -98.570757663478,
+            "expected_energy": -98.570757663479,
             "type": "unfragmented"
         },
         {
@@ -101,7 +101,7 @@
         {
             "name": "RHF Ar sto-3g (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_ar_sto-3g.json",
-            "expected_energy": -521.222880803531,
+            "expected_energy": -521.22288080353,
             "type": "unfragmented"
         },
         {
@@ -185,7 +185,7 @@
         {
             "name": "RHF PH3 3-21g (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_ph3_3-21g.json",
-            "expected_energy": -340.703948109504,
+            "expected_energy": -340.703948109505,
             "type": "unfragmented"
         },
         {
@@ -377,7 +377,7 @@
         {
             "name": "RHF AlH3 cc-pvdz (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_alh3_cc-pvdz.json",
-            "expected_energy": -243.631755712985,
+            "expected_energy": -243.631755712986,
             "type": "unfragmented"
         },
         {
@@ -389,7 +389,7 @@
         {
             "name": "RHF PH3 cc-pvdz (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_ph3_cc-pvdz.json",
-            "expected_energy": -342.470428497942,
+            "expected_energy": -342.47042849794,
             "type": "unfragmented"
         },
         {
@@ -455,7 +455,7 @@
         {
             "name": "RHF Ne cc-pvtz (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_ne_cc-pvtz.json",
-            "expected_energy": -128.531861636321,
+            "expected_energy": -128.531861636322,
             "type": "unfragmented"
         },
         {
@@ -503,7 +503,7 @@
         {
             "name": "RHF H2S aug-cc-pvdz (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_h2s_aug-cc-pvdz.json",
-            "expected_energy": -398.698035963353,
+            "expected_energy": -398.698035963354,
             "type": "unfragmented"
         },
         {
@@ -557,7 +557,7 @@
         {
             "name": "RHF PH3 def2-svp (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_ph3_def2-svp.json",
-            "expected_energy": -342.363621833966,
+            "expected_energy": -342.363621833965,
             "type": "unfragmented"
         },
         {
@@ -569,7 +569,7 @@
         {
             "name": "RHF HCl def2-svp (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_hcl_def2-svp.json",
-            "expected_energy": -459.938287777444,
+            "expected_energy": -459.938287777443,
             "type": "unfragmented"
         },
         {
@@ -605,7 +605,7 @@
         {
             "name": "RHF CH4 def2-tzvp (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_ch4_def2-tzvp.json",
-            "expected_energy": -40.213055304865,
+            "expected_energy": -40.213055304866,
             "type": "unfragmented"
         },
         {
@@ -653,7 +653,7 @@
         {
             "name": "RHF SiH4 def2-tzvp (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_sih4_def2-tzvp.json",
-            "expected_energy": -291.257893577067,
+            "expected_energy": -291.257893577061,
             "type": "unfragmented"
         },
         {
@@ -665,7 +665,7 @@
         {
             "name": "RHF H2S def2-tzvp (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_h2s_def2-tzvp.json",
-            "expected_energy": -398.706600110122,
+            "expected_energy": -398.706600110124,
             "type": "unfragmented"
         },
         {
@@ -677,7 +677,7 @@
         {
             "name": "RHF Ar def2-tzvp (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_ar_def2-tzvp.json",
-            "expected_energy": -526.802760332527,
+            "expected_energy": -526.802760332526,
             "type": "unfragmented"
         },
         {
@@ -719,7 +719,7 @@
         {
             "name": "RHF H2O 6-31g* (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_water_6-31g_st_.json",
-            "expected_energy": -76.01031794597,
+            "expected_energy": -76.010317945971,
             "type": "unfragmented"
         },
         {
@@ -743,19 +743,19 @@
         {
             "name": "RHF MgH2 6-31g* (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_mgh2_6-31g_st_.json",
-            "expected_energy": -200.71545115388,
+            "expected_energy": -200.715451153879,
             "type": "unfragmented"
         },
         {
             "name": "RHF AlH3 6-31g* (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_alh3_6-31g_st_.json",
-            "expected_energy": -243.616255399696,
+            "expected_energy": -243.616255399695,
             "type": "unfragmented"
         },
         {
             "name": "RHF SiH4 6-31g* (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_sih4_6-31g_st_.json",
-            "expected_energy": -291.225102847644,
+            "expected_energy": -291.225102847642,
             "type": "unfragmented"
         },
         {
@@ -767,13 +767,13 @@
         {
             "name": "RHF H2S 6-31g* (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_h2s_6-31g_st_.json",
-            "expected_energy": -398.667070863969,
+            "expected_energy": -398.66707086397,
             "type": "unfragmented"
         },
         {
             "name": "RHF HCl 6-31g* (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_hcl_6-31g_st_.json",
-            "expected_energy": -460.059929876033,
+            "expected_energy": -460.059929876032,
             "type": "unfragmented"
         },
         {
@@ -857,7 +857,7 @@
         {
             "name": "RHF SiH4 6-31g** (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_sih4_6-31g_st__st_.json",
-            "expected_energy": -291.230819820065,
+            "expected_energy": -291.230819820064,
             "type": "unfragmented"
         },
         {
@@ -869,13 +869,13 @@
         {
             "name": "RHF H2S 6-31g** (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_h2s_6-31g_st__st_.json",
-            "expected_energy": -398.674799073107,
+            "expected_energy": -398.674799073106,
             "type": "unfragmented"
         },
         {
             "name": "RHF HCl 6-31g** (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_hcl_6-31g_st__st_.json",
-            "expected_energy": -460.066160564696,
+            "expected_energy": -460.066160564697,
             "type": "unfragmented"
         },
         {
@@ -914,12 +914,12 @@
             "expected_energy": -74.962005712275,
             "expected_gradient": [
                 [
-                    -0.0,
+                    0.0,
                     3.17e-10,
                     -0.067617391053
                 ],
                 [
-                    0.0,
+                    -0.0,
                     -0.016791268482,
                     0.033808695648
                 ],
@@ -939,9 +939,9 @@
             "expected_energy": -40.20167213402,
             "expected_gradient": [
                 [
+                    0.0,
                     -0.0,
-                    -0.0,
-                    -0.0
+                    0.0
                 ],
                 [
                     0.001437398944,
@@ -980,7 +980,7 @@
                 ],
                 [
                     0.005193307714,
-                    -0.0,
+                    0.0,
                     0.000685472868
                 ],
                 [
@@ -1005,13 +1005,13 @@
             "expected_gradient": [
                 [
                     0.0,
-                    0.0,
+                    -0.0,
                     -0.0
                 ],
                 [
                     -0.00167984256,
                     -0.0,
-                    -0.0
+                    0.0
                 ],
                 [
                     0.00083992128,
@@ -1034,7 +1034,7 @@
             "expected_energy": -76.027511701606,
             "expected_gradient": [
                 [
-                    0.0,
+                    -0.0,
                     2.31e-10,
                     0.01008181498
                 ],
@@ -1069,9 +1069,9 @@
                     0.013341940487
                 ],
                 [
-                    -0.0,
+                    0.0,
                     0.008465018345,
-                    0.013341940316
+                    0.013341940315
                 ]
             ],
             "gradient_tolerance": 1e-07,
@@ -1089,7 +1089,7 @@
                     -0.028383098209
                 ],
                 [
-                    -0.0,
+                    0.0,
                     -0.007020546936,
                     0.014191549189
                 ],
@@ -1114,7 +1114,7 @@
                     -0.018529027149
                 ],
                 [
-                    0.0,
+                    -0.0,
                     -0.001754068653,
                     0.009264513658
                 ],
@@ -1139,7 +1139,7 @@
                     -0.0
                 ],
                 [
-                    -0.013273613865,
+                    -0.013273613866,
                     -0.0,
                     -0.0
                 ],
@@ -1151,10 +1151,90 @@
                 [
                     0.006636869712,
                     0.011494995164,
-                    0.0
+                    -0.0
                 ]
             ],
             "gradient_tolerance": 1e-07,
+            "check_translation": true,
+            "type": "unfragmented"
+        },
+        {
+            "name": "MP2 gradient H2O sto-3g (CPU)",
+            "input": "inputs/cpu/mqc/gradient/cpu_water_sto-3g_mp2_grad.json",
+            "expected_energy": -74.997272482595,
+            "expected_gradient": [
+                [
+                    -0.0,
+                    3.09e-10,
+                    -0.100076085773
+                ],
+                [
+                    0.0,
+                    -0.031642651529,
+                    0.050038043008
+                ],
+                [
+                    0.0,
+                    0.03164265122,
+                    0.050038042766
+                ]
+            ],
+            "gradient_tolerance": 1e-08,
+            "check_translation": true,
+            "type": "unfragmented"
+        },
+        {
+            "name": "MP2 gradient H2O cc-pvdz (CPU)",
+            "input": "inputs/cpu/mqc/gradient/cpu_water_cc-pvdz_mp2_grad.json",
+            "expected_energy": -76.230274593244,
+            "expected_gradient": [
+                [
+                    -0.0,
+                    2.31e-10,
+                    -0.015697541357
+                ],
+                [
+                    0.0,
+                    0.002895680112,
+                    0.007848770765
+                ],
+                [
+                    0.0,
+                    -0.002895680344,
+                    0.007848770592
+                ]
+            ],
+            "gradient_tolerance": 1e-08,
+            "check_translation": true,
+            "type": "unfragmented"
+        },
+        {
+            "name": "MP2 gradient NH3 6-31g (CPU)",
+            "input": "inputs/cpu/mqc/gradient/cpu_nh3_6-31g_mp2_grad.json",
+            "expected_energy": -56.277979006773,
+            "expected_gradient": [
+                [
+                    -0.0,
+                    -0.0,
+                    -0.014957403197
+                ],
+                [
+                    -0.011578310831,
+                    0.0,
+                    0.004985801066
+                ],
+                [
+                    0.005789155416,
+                    -0.010027111313,
+                    0.004985801066
+                ],
+                [
+                    0.005789155416,
+                    0.010027111313,
+                    0.004985801066
+                ]
+            ],
+            "gradient_tolerance": 1e-08,
             "check_translation": true,
             "type": "unfragmented"
         },
@@ -1255,7 +1335,7 @@
         {
             "name": "MP2 H2O def2-svp frozen 1 (CPU)",
             "input": "inputs/cpu/mqc/mp2/cpu_water_def2-svp_mp2_f1.json",
-            "expected_energy": -76.161689337977,
+            "expected_energy": -76.161689337976,
             "type": "unfragmented"
         },
         {
@@ -1291,13 +1371,13 @@
         {
             "name": "CCSD(T) H2O cc-pvdz frozen 1 (CPU)",
             "input": "inputs/cpu/mqc/ccsd-t/cpu_water_cc-pvdz_ccsdt_f1.json",
-            "expected_energy": -76.240549582968,
+            "expected_energy": -76.240549582971,
             "type": "unfragmented"
         },
         {
             "name": "CCSD(T) CH4 sto-3g frozen 1 (CPU)",
             "input": "inputs/cpu/mqc/ccsd-t/cpu_ch4_sto-3g_ccsdt_f1.json",
-            "expected_energy": -39.805169969925,
+            "expected_energy": -39.805169969887,
             "type": "unfragmented"
         },
         {
@@ -1444,7 +1524,7 @@
         {
             "name": "RI-MP2 H2O def2-svp/def2-svp-rifit frozen 1 (CPU)",
             "input": "inputs/cpu/mqc/ri-mp2/cpu_water_def2-svp_rimp2_f1.json",
-            "expected_energy": -76.161602884778,
+            "expected_energy": -76.161602884779,
             "type": "unfragmented"
         },
         {


### PR DESCRIPTION
Block the half-transformed amplitudes too

The last commit left one array unbounded: the amplitudes with both
virtual indices transformed, at n_o^2 n_ao^2. Smaller than n_ao^4 by
(n_o/n_ao)^2, and past a few hundred functions it -- not the block target
-- was the footprint.

`j` is the index to cut on, because it is contracted last, against
C_occ. A range of it therefore contributes an addend to the two-particle
density rather than a slice of one, so the second gemm accumulates and
nothing downstream changes. Both builders do it, dense and blocked, on
the same target: the dense path's own intermediate was n_ao^3 n_o and is
now n_ao^3 per occupied orbital in the pass.

Costs nothing when it fits. The block is the whole occupied range unless
the target says otherwise, which is one pass and exactly the previous
code. Measured on a quiet machine, the dense path is 0.028 / 0.586 /
0.349 s for water cc-pVDZ, water cc-pVTZ and the water dimer -- the same
figures as before this change, and the same as two commits ago, which
also settles that the doubling seen while writing that commit was another
user taking the machine to a load average of 119 rather than anything in
the code. The blocked path is 0.056 / 0.593 / 0.560 s on the same three.

**The harness now runs three passes per case, not two.** Whole; dense
with a one-byte target, which splits the occupied loop to a single
orbital per pass; and blocked with the same, which splits the first index
to a single shell as well. Two passes were not enough: the previous
commit's knob forced the blocked path, so the dense path's own occupied
blocking would have shipped untested. All three agree to between 3e-16
and 1.3e-12, the spread being accumulation order across the passes.

That leaves nothing in this routine growing faster than the block target
except the two `n_ao^2` one-particle matrices and the amplitudes
themselves.

207 CPU cases, 59 unit tests, five finite-difference cases three ways.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>