### PR TITLE
rimp2 grads

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -512,6 +512,13 @@ if(MQC_ENABLE_LIBCINT)
   target_link_libraries(check_scf_gradient PRIVATE ${main_lib} cint_fortran
                                                    cint)
 
+  add_executable(bench_ri_mp2_gradient
+                 ${PROJECT_SOURCE_DIR}/validation/bench_ri_mp2_gradient.f90)
+  target_include_directories(bench_ri_mp2_gradient
+                             PRIVATE "${CMAKE_BINARY_DIR}/modules")
+  target_link_libraries(bench_ri_mp2_gradient PRIVATE ${main_lib} cint_fortran
+                                                      cint)
+
   add_executable(check_df_cphf
                  ${PROJECT_SOURCE_DIR}/validation/check_df_cphf.f90)
   target_include_directories(check_df_cphf

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -512,6 +512,12 @@ if(MQC_ENABLE_LIBCINT)
   target_link_libraries(check_scf_gradient PRIVATE ${main_lib} cint_fortran
                                                    cint)
 
+  add_executable(check_df_cphf
+                 ${PROJECT_SOURCE_DIR}/validation/check_df_cphf.f90)
+  target_include_directories(check_df_cphf
+                             PRIVATE "${CMAKE_BINARY_DIR}/modules")
+  target_link_libraries(check_df_cphf PRIVATE ${main_lib} cint_fortran cint)
+
   add_executable(check_ri_mp2_gradient
                  ${PROJECT_SOURCE_DIR}/validation/check_ri_mp2_gradient.f90)
   target_include_directories(check_ri_mp2_gradient

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -512,6 +512,13 @@ if(MQC_ENABLE_LIBCINT)
   target_link_libraries(check_scf_gradient PRIVATE ${main_lib} cint_fortran
                                                    cint)
 
+  add_executable(check_ri_mp2_gradient
+                 ${PROJECT_SOURCE_DIR}/validation/check_ri_mp2_gradient.f90)
+  target_include_directories(check_ri_mp2_gradient
+                             PRIVATE "${CMAKE_BINARY_DIR}/modules")
+  target_link_libraries(check_ri_mp2_gradient PRIVATE ${main_lib} cint_fortran
+                                                      cint)
+
   add_executable(bench_mp2_gradient
                  ${PROJECT_SOURCE_DIR}/validation/bench_mp2_gradient.f90)
   target_include_directories(bench_mp2_gradient

--- a/GRADIENTS_PICKUP.md
+++ b/GRADIENTS_PICKUP.md
@@ -1,0 +1,195 @@
+# Analytic gradients — pickup notes
+
+Written 2026-08-14. For starting a fresh session without re-deriving what was
+already settled. Delete when the ladder is finished.
+
+## Where things stand
+
+**Pushed, rebased onto current main, all green:**
+
+| branch | tip | contents |
+|---|---|---|
+| `feat/cpu-gradients` | `50d750e6d` | libcint pin bump, RHF + UHF gradients, threading/symmetry |
+| `feat/cpu-gradients-df` | `b7eb16303` | DF-RHF gradient |
+| `feat/cpu-gradients-dft` | `5a76bd7a2` | RKS/UKS **LDA** |
+| `feat/cpu-gradients-gga` | `2deae8294` | AO 2nd derivatives, then GGA + hybrid-GGA |
+
+Linear stack, each contains the previous. Ready for stacked PRs.
+
+**Current branch: `feat/cpu-gradients-mp2`**, branched off `-gga`.
+Working tree has **uncommitted** harness edits to `validation/check_scf_gradient.f90`
+(see "Fix first" below). Nothing else outstanding.
+
+`mqc-geoopt` is a separate, already-pushed stack (the DL-FIND geometry
+optimizer). Jorge rebased it onto main and added HDLC residues — refetch
+before touching it.
+
+Also pushed separately: `JorgeG94/libcint` `develop` at `3c78069`, which added
+the Fortran bindings for `int1e_ipkin/ipnuc/iprinv`, `int3c2e_ip1/ip2`,
+`int2c2e_ip1` and their optimizers. mqc pins that commit.
+
+## Done since (branch `feat/cpu-gradients-validation`, tip `7ffa9d80c`)
+
+Branched off `-gga`, was briefly named `-mp2`. Not pushed yet.
+
+- **The gradient is reachable from a deck.** `run_libcint_hf` refused
+  `driver: Gradient`; it now calls `libcint_scf_gradient` after the SCF, for
+  every combination the SCF supports. Post-HF alongside a gradient is refused.
+- **The output JSON carries the components**, Hartree/Bohr, one `[x, y, z]` per
+  atom, at all four writer sites. `gradient_norm` stays.
+- **`run_validation.py` compares element by element** against
+  `expected_gradient` (`gradient_tolerance`, default 1e-7) and reports the
+  translational residual for anything with components -- a failure only where
+  the deck sets `check_translation`.
+- **Ten generated CPU gradient cases**, one per code path, in
+  `GRADIENT_CASES` / `GRADIENT_FRAGMENTED_CASES` in `tools/cpu_validation`.
+  204 CPU + 20 xTB + 59 unit tests pass.
+- **Compiler**: GCC 13 works (`build-g13`), configured with the source dirs
+  reused from `/home/jorge/dev/metalquicha/build/_deps`. The `build` and
+  `build-xc` trees still refuse to configure -- the shared dftd4 checkout moved
+  to v4.2.0, which rejects gfortran 15.1.
+- **The check_scf_gradient filter was never broken** -- the binary under test
+  was stale. It now also covers the unrestricted DF branch case.
+
+Two things learned that are worth keeping:
+
+- **PySCF's KS gradient omits the grid-weight derivative by default.** Set
+  `grid_response = True` or the two codes differ by ~1e-4 with nothing wrong.
+- **The SCF stopping point enters a gradient linearly.** At the suite default
+  of 1e-8 the cases sat ~1e-7 from PySCF; at 1e-11, 4e-12 to 7e-9.
+
+## Done: MP2 (branch `feat/cpu-gradients-mp2`, tip `8d356e82b`, pushed)
+
+`backends/libcint/mqc_libcint_mp2_gradient.f90`, wired into the bridge, three
+generated validation cases, and `validation/check_mp2_gradient.f90` for finite
+differences. Agrees with PySCF to 3e-11..2e-9 and with finite difference to
+9e-7..5e-6.
+
+Two things from it that generalise:
+
+- **PySCF's MP2 gradient is itself ~4e-8 wrong** on water/cc-pVDZ, because its
+  Z-vector goes through `pyscf.scf.cphf.solve`, whose Krylov solver carries
+  error `tol` does not control. `dense_zvector` in `tools/cpu_validation` is the
+  monkeypatch. Without it the disagreement reads as a missing term on our side.
+- **The t2 = 0 limit is the cheapest test there is.** It must reproduce the
+  Hartree-Fock gradient exactly, and it isolated two bugs in the shared
+  skeleton that the correlation algebra would have masked.
+
+## In progress: RI-MP2 (branch `feat/cpu-gradients-ri-mp2`, off `-mp2`)
+
+**The reference does not exist.** `pyscf.mp.dfmp2.DFMP2.nuc_grad_method` and
+`dfmp2_native`'s both `raise NotImplementedError`, and there is no
+`pyscf/grad/dfmp2.py` or `pyscf/df/grad/mp2.py`. Every gradient in this ladder
+so far was pinned component-wise against PySCF to ~1e-9; this one cannot be.
+That changes the discipline rather than lowering it:
+
+1. **Finite difference of mqc's own RI-MP2 energy is now the primary check**,
+   not the corroborating one. It is good to ~1e-6 with the step scaling
+   verified (halve the step, the deviation must fall by four).
+2. **The `t2 = 0` limit must reproduce the Hartree-Fock gradient exactly.** The
+   reference here is an exact-ERI RHF -- RI-MP2 decks fit only the correlation
+   (`aux_only` in the generator) -- so the whole one-particle skeleton is the
+   already-validated one, and this check is free.
+3. **Translational invariance**, as always, and worth as little as always.
+4. **The conventional MP2 gradient is the limit of this one** as the auxiliary
+   basis saturates. Not a tolerance, but the difference should sit at the size
+   of the fitting error in the energy (a few tenths of a millihartree on a
+   matched RIFIT set), and a wrong dJ term will not.
+
+Write the finite-difference harness first and check it against the
+*conventional* MP2 gradient, where the answer is known. A reference that is
+itself unvalidated is worse than none.
+
+**What changes and what does not.** The reference is exact, so `doo`, `dvv`,
+the Lagrangian's `veff` term, the Z-vector, the relaxed density, the
+energy-weighted density, and every one-electron and Hartree-Fock two-electron
+term are structurally identical to `mqc_libcint_mp2_gradient`. Three things
+change:
+
+- the amplitudes come from `(ia|jb) = sum_P B^P_ia B^P_jb`, which
+  `run_libcint_ri_mp2` already builds through `build_df_tensor`;
+- the two-particle density never becomes a four-index AO object. It stays as
+  `Gamma3^P_ia = sum_jb Gamma_iajb B^P_jb`, which is `n_o n_v n_aux`;
+- that object contracts against `three_centre_deriv` (both `which=1` and
+  `which=2`) and `two_centre_deriv`, all three already on
+  `feat/cpu-gradients-df` and PySCF-validated in isolation.
+
+The derivative to be careful with is the metric's:
+`d(ia|jb) = 2 sum [d(ia|P)] c^P_jb - sum c^P_ia dJ_PQ c^Q_jb`, with
+`c = J^-1 (·|·)`. The factor of two is the `(ia)<->(jb)` symmetry of `Gamma`,
+which holds because `t2_ijab = t2_jiba`. Getting the metric term's sign or
+factor wrong is invisible to translational invariance and to a matching energy,
+and finite difference is what catches it -- which is the whole reason for
+point 1 above.
+
+Memory: `Gamma_iajb` is `n_o^2 n_v^2`, which is the ceiling here and is not the
+`n_ao^4` the conventional path had. Block over `i` when it matters.
+
+## Validation discipline — do not skip
+
+Three checks, because they fail differently. This is not ceremony; each one
+caught something the others missed.
+
+1. **Finite difference of mqc's own energy.** The only check that cannot be
+   fooled by a misunderstanding shared with PySCF. Consider step-scaling: if the
+   deviation falls by 4x per halving of the step, the residual is the difference
+   formula and not the derivative.
+2. **PySCF component-wise**, fed *this repo's* basis JSON via
+   `sys.path.insert(0, "tools/cpu_validation"); from gen_cpu_validation import bse_to_pyscf`.
+   PySCF's own basis tables differ in the 8th decimal on Pople sets and it looks
+   exactly like a gradient bug. Python: `/home/jorge/dev/metalquicha/.venv/bin/python`.
+   Note `mf.Gradients()` raises NotImplementedError unless you import the grad
+   module explicitly (`from pyscf.grad import rhf as rhf_grad`).
+3. **Translational invariance**, `sum_A dE/dR_A = 0`. Cheap, and it caught a
+   missing Hellmann-Feynman term in the HF gradient. **But it is structurally
+   blind to exchange-correlation terms** — it passed at 2e-15 over an LDA
+   weight-derivative error worth 0.77 Hartree/Bohr, and again over a GGA index
+   pairing wrong by 6%. Never treat it passing as evidence a new XC term is right.
+
+**A matching total energy proves nothing about a gradient.** In both XC failures
+the converged energy agreed with PySCF to all ten printed digits while the
+gradient was badly wrong.
+
+**Validate a new integral layer on its own before building on it.** The
+three-centre derivatives and the AO second derivatives were each checked
+against PySCF in isolation first. An ordering or normalisation error there does
+not announce itself in an assembled gradient — it produces a plausible number
+that disagrees with finite differences for reasons that could be anywhere.
+
+**Compare error floors, not absolute tolerances.** The AO second derivatives
+agree with PySCF to 3.53e-7 relative, and the pre-existing AO *values* agree to
+3.52e-7 — the documented basis-normalisation floor. Landing *on* the existing
+floor rather than above it is what says a new quantity adds no error of its own.
+
+## Known gaps, deliberately left
+
+- **DF-UHF does not exist.** `run_libcint_uhf` has no `aux` argument and says so
+  ("No density fitting here yet"). The unrestricted DF *gradient* branch is
+  written and its channel weights are pinned to 9e-16 by driving a closed shell
+  through it as two half-filled channels, but genuinely open-shell behaviour is
+  unexercised and will stay that way until the SCF exists. Not a basis-set issue.
+- **DF gradient memory.** `df_two_electron_gradient` builds full
+  `(nao, nao, naux)` intermediates. That is a memory ceiling before it is a speed
+  problem — block over the auxiliary index. Belongs as a follow-up commit on
+  `feat/cpu-gradients-df`, which means rebasing the branches above it.
+- **No prescreening on the exact-ERI gradient.** Every quartet is computed
+  however negligible. mqc is at parity with PySCF single-threaded and ~6x faster
+  on 40 threads at (H2O)x3/cc-pVDZ, but that advantage narrows and then inverts
+  on a large sparse system where PySCF's Schwarz screening changes the scaling.
+  The ordinary Schwarz bound is **not** rigorous for a differentiated integral —
+  the bound needs rederiving, which is why it was not bolted on.
+- **CCSD gradients need Λ equations**, which mqc does not have at all (zero
+  occurrences of "lambda" in the CC module). That is its own project, comparable
+  in size to the T solver, before a gradient is even started.
+
+## Workflow (Jorge's, follow it)
+
+- One branch per gradient, branched from the branch carrying the machinery it
+  builds on — not from main.
+- **Commit only after PySCF validation.** Speed work — threading, permutational
+  symmetry, screening — goes in a **separate follow-up commit**, never mixed into
+  the correctness commit.
+- Run `pre-commit` before pushing; cmake-format and fprettify rewrite files, and
+  the fixes must be staged *into* the commit (re-check with
+  `pre-commit run --from-ref HEAD~1 --to-ref HEAD`).
+- No Claude session links in commit messages. `Co-Authored-By` stays.

--- a/backends/libcint/CMakeLists.txt
+++ b/backends/libcint/CMakeLists.txt
@@ -28,6 +28,7 @@ target_sources(
           mqc_libcint_rhf.f90
           mqc_libcint_mp2.f90
           mqc_libcint_mp2_gradient.f90
+          mqc_libcint_ri_mp2_gradient.f90
           mqc_libcint_cc.f90
           mqc_libcint_ao_data.f90
           mqc_libcint_ao.f90

--- a/backends/libcint/mqc_libcint_bridge.f90
+++ b/backends/libcint/mqc_libcint_bridge.f90
@@ -30,6 +30,7 @@ module mqc_libcint_bridge
    use mqc_libcint_xc, only: xc_context_t, xc_context_create, xc_available
    use mqc_libcint_gradient, only: libcint_scf_gradient
    use mqc_libcint_mp2_gradient, only: libcint_mp2_gradient
+   use mqc_libcint_ri_mp2_gradient, only: libcint_ri_mp2_gradient
    use mqc_libcint_mp2, only: mp2_result_t, run_libcint_mp2, run_libcint_ri_mp2
    use mqc_libcint_cc, only: cc_result_t, run_libcint_ccsd
    use mqc_program_limits, only: MAX_LINE_LENGTH
@@ -213,9 +214,11 @@ contains
       if (do_gradient .and. settings%run_mp2) then
          if (settings%density_fitting) then
             call result%error%set(ERROR_VALIDATION, "the MP2 gradient differentiates an "// &
-                                  "exact-ERI reference: with density_fitting on it would "// &
-                                  "be the derivative of an energy nothing computed. Run "// &
-                                  "the MP2 gradient without density fitting.")
+                                  "exact-ERI reference: with keywords.scf.density_fitting "// &
+                                  "on it would be the derivative of an energy nothing "// &
+                                  "computed. Fitting the correlation instead -- an "// &
+                                  "`ri-mp2` method, which fits nothing in the SCF -- is "// &
+                                  "implemented and differentiated exactly.")
             result%has_error = .true.
             return
          end if
@@ -608,9 +611,29 @@ contains
                   call mol%destroy()
                   return
                end if
-               call libcint_mp2_gradient(mol, scf%orbitals, scf%orbital_energies, &
-                                         fragment%nelec/2, result%gradient, error, &
-                                         n_frozen=frozen)
+               ! Fitted correlation gets the fitted gradient. Not a refinement:
+               ! `run_libcint_ri_mp2` above computed a fitted energy, and the
+               ! conventional gradient is the derivative of a different one.
+               ! The auxiliary basis is rebuilt here rather than held from the
+               ! energy step, so each branch owns and destroys its own and no
+               ! error return in between has to remember to.
+               if (settings%corr_density_fitting) then
+                  call correlation_aux_basis(settings, fragment, symbols, corr_aux, error)
+                  if (error%has_error()) then
+                     call result%error%set(ERROR_VALIDATION, error%get_message())
+                     result%has_error = .true.
+                     call mol%destroy()
+                     return
+                  end if
+                  call libcint_ri_mp2_gradient(mol, corr_aux, scf%orbitals, &
+                                               scf%orbital_energies, fragment%nelec/2, &
+                                               result%gradient, error, n_frozen=frozen)
+                  call corr_aux%destroy()
+               else
+                  call libcint_mp2_gradient(mol, scf%orbitals, scf%orbital_energies, &
+                                            fragment%nelec/2, result%gradient, error, &
+                                            n_frozen=frozen)
+               end if
                if (error%has_error()) then
                   call result%error%set(ERROR_VALIDATION, "MP2 gradient: "// &
                                         error%get_message())

--- a/backends/libcint/mqc_libcint_cphf.f90
+++ b/backends/libcint/mqc_libcint_cphf.f90
@@ -136,7 +136,7 @@ contains
 
    subroutine cphf_solve(mol, orbitals, orbital_energies, n_occ, perturbations, &
                          response, error, max_iter, tol, iterations, in_core, mo_rhs, &
-                         eri_in)
+                         eri_in, bmat)
       !! Solve the coupled-perturbed equations for one or more perturbations
       type(libcint_molecule_t), intent(in) :: mol
       real(dp), intent(in) :: orbitals(:, :)          !! MO coefficients, (n_ao, n_mo)
@@ -164,6 +164,13 @@ contains
          !! Implies `in_core`. A caller that has the tensor for its own reasons --
          !! the MP2 gradient contracts it against the two-particle density --
          !! would otherwise pay for a second identical build.
+      real(dp), intent(in), optional :: bmat(:, :)
+         !! The fitted tensor `B(mu nu, P)`, in place of any four-index
+         !! integrals. This is not a storage choice like `in_core` and it is not
+         !! a speed one: it makes the operator the fitted reference's own. Give
+         !! it when, and only when, the SCF whose response this is was itself
+         !! fitted -- solving the exact equations against a fitted reference
+         !! answers a question nobody asked, and so does the reverse.
       real(dp), intent(in), optional :: mo_rhs(:, :, :)
          !! The right-hand side already in the occupied-virtual MO block,
          !! `(n_vir, n_occ, n_perturbations)`. The Z-vector equation of an MP2
@@ -247,7 +254,21 @@ contains
       direct = .true.
       if (present(in_core)) direct = .not. in_core
       if (present(eri_in)) direct = .false.
-      if (present(eri_in)) then
+      if (present(bmat)) then
+         ! Neither stored nor direct: fitting removes the four-index integrals
+         ! rather than choosing where to keep them, so both of the others are
+         ! left empty and `response_operator` takes the third path.
+         if (present(eri_in)) then
+            call error%set(ERROR_VALIDATION, "CPHF: given both a fitted tensor and an "// &
+                           "exact one. They are different operators, not two routes to "// &
+                           "the same one; pass whichever the reference was built with.")
+            return
+         end if
+         direct = .false.
+         allocate (eri_own(0, 0, 0, 0))
+         eri => eri_own
+         allocate (bounds(0, 0))
+      else if (present(eri_in)) then
          ! Pointed at, not copied: the tensor is the largest object either side
          ! of this call has, and duplicating it to pass it would cost more than
          ! the solve.
@@ -302,8 +323,13 @@ contains
 
          iter = 0
          do iter = 1, limit
-            call response_operator(mol, direct, eri, bounds, zero_h, c_occ, c_vir, &
-                                   gaps, p, ap, error)
+            if (present(bmat)) then
+               call response_operator(mol, direct, eri, bounds, zero_h, c_occ, c_vir, &
+                                      gaps, p, ap, error, bmat=bmat)
+            else
+               call response_operator(mol, direct, eri, bounds, zero_h, c_occ, c_vir, &
+                                      gaps, p, ap, error)
+            end if
             if (error%has_error()) return
             pap = sum(p*ap)
             if (pap <= 0.0_dp) then
@@ -340,7 +366,7 @@ contains
    end subroutine cphf_solve
 
    subroutine response_operator(mol, direct, eri, bounds, zero_h, c_occ, c_vir, &
-                                gaps, u, au, error)
+                                gaps, u, au, error, bmat)
       !! Apply the coupled-perturbed operator to a trial rotation
       type(libcint_molecule_t), intent(in) :: mol
       logical, intent(in) :: direct          !! Recompute integrals rather than store them
@@ -352,6 +378,11 @@ contains
       real(dp), intent(in) :: u(:, :)
       real(dp), intent(out) :: au(:, :)
       type(error_t), intent(inout) :: error
+      real(dp), intent(in), optional :: bmat(:, :)
+         !! The fitted tensor `B(mu nu, P)`. Present, the operator is built from
+         !! it and neither `eri` nor the direct build is touched -- see
+         !! `response_operator_df` for why that is a third path rather than a
+         !! flavour of the other two.
 
       real(dp), allocatable :: dtilde(:, :), g(:, :), half(:, :), work(:, :)
       type(direct_stats_t) :: stats
@@ -368,7 +399,11 @@ contains
       call pic_gemm(half, c_occ, dtilde, transb="T")
       dtilde = dtilde + transpose(dtilde)
 
-      if (direct) then
+      if (present(bmat)) then
+         ! `half` is C_vir U, which is exactly the factor the fitted build
+         ! wants: it never assembles Dt at all.
+         call response_operator_df(bmat, half, c_occ, dtilde, g)
+      else if (direct) then
          ! density_screen=.false. is not optional here. `dtilde` is the trial
          ! rotation the CG solver drives towards zero, so the default
          ! density-weighted screen would tighten as the solve converges and this
@@ -388,6 +423,63 @@ contains
 
       deallocate (dtilde, g, half, work)
    end subroutine response_operator
+
+   subroutine response_operator_df(b, x, c_occ, dtilde, g)
+      !! `J - K/2` for a response density, from the fitted tensor
+      !!
+      !! **Why this is not `build_fock_df`.** That one takes its exchange
+      !! through the occupied orbitals, which is a factor of n/n_occ cheaper and
+      !! is the reason the fitted path is worth having -- but it gets them by
+      !! assuming `D = 2 sum_i C_ui C_vi`, an idempotent SCF density. A response
+      !! density is not one. It is symmetric but *indefinite*, so it has no such
+      !! orbitals, and `density_pseudo_orbitals` cannot supply them either: that
+      !! takes a square root of every eigenvalue and drops what comes out
+      !! negative, which for a response density is half of them.
+      !!
+      !! It needs no factorization of its own, though, because it arrives
+      !! already factored. The trial rotation gives
+      !!
+      !!     Dt = X C_occ^T + C_occ X^T,     X = C_vir U
+      !!
+      !! a rank-2 n_occ form for free, and substituting it into
+      !! `K_uv = sum_P sum_ls B(ul,P) Dt_ls B(sv,P)` leaves
+      !!
+      !!     K = sum_P [ (B_P X)(B_P C_occ)^T + (B_P C_occ)(B_P X)^T ]
+      !!
+      !! which is two n^2 n_occ products per auxiliary function -- the same cost
+      !! as the SCF build, with no diagonalisation and no approximation beyond
+      !! the fitting itself. `Dt` is still passed, but only for the Coulomb
+      !! term, where any density will do.
+      real(dp), intent(in) :: b(:, :)        !! `B(mu nu, P)`, (n_ao^2, naux)
+      real(dp), intent(in) :: x(:, :)        !! `C_vir U`, (n_ao, n_occ)
+      real(dp), intent(in) :: c_occ(:, :)    !! (n_ao, n_occ)
+      real(dp), intent(in) :: dtilde(:, :)   !! The assembled response density, for J
+      real(dp), intent(out) :: g(:, :)
+
+      real(dp), allocatable :: coul(:, :), exch(:, :), bx(:, :), bc(:, :)
+      real(dp) :: c_p
+      integer :: n, n_occ, naux, p
+
+      n = size(c_occ, 1)
+      n_occ = size(c_occ, 2)
+      naux = size(b, 2)
+      allocate (coul(n, n), exch(n, n), bx(n, n_occ), bc(n, n_occ))
+
+      coul = 0.0_dp
+      exch = 0.0_dp
+      do p = 1, naux
+         associate (b_p => reshape(b(:, p), [n, n]))
+            c_p = sum(b_p*dtilde)
+            coul = coul + c_p*b_p
+            call pic_gemm(b_p, x, bx)
+            call pic_gemm(b_p, c_occ, bc)
+            call pic_gemm(bx, bc, exch, transb="T", alpha=1.0_dp, beta=1.0_dp)
+            call pic_gemm(bc, bx, exch, transb="T", alpha=1.0_dp, beta=1.0_dp)
+         end associate
+      end do
+
+      g = coul - 0.5_dp*exch
+   end subroutine response_operator_df
 
    subroutine response_operator_minus(mol, direct, eri, bounds, zero_h, c_occ, c_vir, &
                                       gaps, u, au, error)

--- a/backends/libcint/mqc_libcint_gradient.f90
+++ b/backends/libcint/mqc_libcint_gradient.f90
@@ -1209,8 +1209,18 @@ contains
       deriv = 0.0_dp
 
       mx = max(largest_shell(orb), largest_shell(aux))
-      allocate (buf(mx**3*3))
 
+      ! Threaded over the first orbital shell. Each (ish, jsh, ksh) writes its
+      ! own block of `deriv` and reads nothing another writes, so the only
+      ! shared state is the output array and no reduction is needed. `buf` is
+      ! allocated inside the region because libcint writes into it per quartet,
+      ! which makes it the one genuinely private object here.
+      !$omp parallel default(none) &
+      !$omp    shared(deriv, orb, aux, bas, env, dummy, nbas_orb, nbas_aux, mx, which) &
+      !$omp    private(ish, jsh, ksh, di, dj, dk, io, jo, ko, i, j, k, comp, ret, idx, &
+      !$omp            shls, buf)
+      allocate (buf(mx**3*3))
+      !$omp do schedule(dynamic)
       do ish = 1, nbas_orb
          di = shell_dim(orb%cartesian, ish - 1, bas)
          io = orb%shell_offset(ish)
@@ -1254,6 +1264,9 @@ contains
             end do
          end do
       end do
+      !$omp end do
+      deallocate (buf)
+      !$omp end parallel
    end subroutine three_centre_deriv
 
    subroutine two_centre_deriv(aux, deriv)

--- a/backends/libcint/mqc_libcint_mp2_gradient.f90
+++ b/backends/libcint/mqc_libcint_mp2_gradient.f90
@@ -54,6 +54,11 @@ module mqc_libcint_mp2_gradient
    private
 
    public :: libcint_mp2_gradient
+   ! Shared with the fitted gradient next door, which differs from this one in
+   ! the two-particle term and the Lagrangian and in nothing else.
+   public :: gamma1_intermediates
+   public :: two_electron_potential
+   public :: two_electron_mp2_terms
 
    real(dp), parameter :: BLOCK_TARGET = 5.0e8_dp
       !! Bytes the blocked path aims to hold in its two live block arrays. Not a
@@ -836,7 +841,7 @@ contains
    end subroutine contract_gamma_eri
 
    subroutine two_electron_mp2_terms(mol, gamma_ao, hf_density, de2, vhf1, &
-                                     ish_lo, ish_hi, p_offset, eri_blk)
+                                     ish_lo, ish_hi, p_offset, eri_blk, with_gamma)
       !! The differentiated integrals, contracted twice
       !!
       !! Once against the two-particle density, which gives a gradient
@@ -854,9 +859,17 @@ contains
       !! symmetric in that pair, so `k` and `l` exchanged is a different
       !! contraction rather than the same number twice.
       type(libcint_molecule_t), intent(in) :: mol
-      real(dp), intent(in) :: gamma_ao(:, :, :, :), hf_density(:, :)
+      real(dp), intent(in) :: gamma_ao(:, :, :, :)
+         !! Required, but ignored when `with_gamma` is false -- pass a
+         !! zero-sized array then. Not optional, because an absent optional
+         !! cannot be named in a data-sharing clause and this one has to be:
+         !! routing it through a pointer instead was tried and still faulted.
+      real(dp), intent(in) :: hf_density(:, :)
       real(dp), intent(inout) :: de2(:, :)        !! (3, natm), accumulated into
       real(dp), intent(inout) :: vhf1(:, :, :, :)  !! (nao, nao, 3, natm), likewise
+      logical, intent(in), optional :: with_gamma
+         !! False skips the two-particle contraction and builds only the
+         !! reference-density matrices, which is what the fitted gradient wants.
       integer, intent(in), optional :: ish_lo, ish_hi
          !! Shells to differentiate over. Absent means all of them, which is the
          !! dense path; present is one block of the first index.
@@ -880,7 +893,7 @@ contains
       real(dp) :: g, g0
       real(dp), allocatable :: eri_local(:)
       real(dp), pointer :: eri_out(:, :, :, :)
-      logical :: want_eri
+      logical :: want_eri, want_gamma
 
       nao = mol%nao
       nbas = mol%nbas
@@ -908,6 +921,8 @@ contains
       ! cannot appear in a data-sharing clause, and naming it there costs more
       ! than the branch it saves.
       want_eri = present(eri_blk)
+      want_gamma = .true.
+      if (present(with_gamma)) want_gamma = with_gamma
       eri_out => null()
       if (want_eri) eri_out => eri_blk
 
@@ -920,7 +935,7 @@ contains
 
       !$omp parallel default(none) &
       !$omp    shared(mol, gamma_ao, hf_density, de2, vhf1, opt, mx, nao, nbas, natm, &
-      !$omp           shell_atom, first, last, off, want_eri, eri_out) &
+      !$omp           shell_atom, first, last, off, want_eri, want_gamma, eri_out) &
       !$omp    private(ish, jsh, ksh, lsh, di, dj, dk, dl, io, jo, ko, lo, &
       !$omp            i, j, k, l, comp, ret, idx, g, g0, gi, shls, ia, buf, &
       !$omp            de_local, vhf_local, eri_local)
@@ -990,8 +1005,8 @@ contains
                                  idx = i + di*(j - 1 + dj*(k - 1 + dk*(l - 1 + dl*(comp - 1))))
                                  g = buf(idx)
 
-                                 de_local(comp, ia) = de_local(comp, ia) &
-                                                      - 2.0_dp*g*gamma_ao(io + i - off, jo + j, ko + k, lo + l)
+                                 if (want_gamma) de_local(comp, ia) = de_local(comp, ia) &
+                                                                 - 2.0_dp*g*gamma_ao(io + i - off, jo + j, ko + k, lo + l)
 
                                  vhf_local(ko + k, lo + l, comp, ia) = &
                                     vhf_local(ko + k, lo + l, comp, ia) &
@@ -1011,8 +1026,8 @@ contains
                                  ! diagonal, where it is the quartet already
                                  ! counted.
                                  if (lsh /= ksh) then
-                                    de_local(comp, ia) = de_local(comp, ia) &
-                                                         - 2.0_dp*g*gamma_ao(io + i - off, jo + j, lo + l, ko + k)
+                                    if (want_gamma) de_local(comp, ia) = de_local(comp, ia) &
+                                                                 - 2.0_dp*g*gamma_ao(io + i - off, jo + j, lo + l, ko + k)
                                     vhf_local(lo + l, ko + k, comp, ia) = &
                                        vhf_local(lo + l, ko + k, comp, ia) &
                                        + g*hf_density(io + i, jo + j)

--- a/backends/libcint/mqc_libcint_mp2_gradient.f90
+++ b/backends/libcint/mqc_libcint_mp2_gradient.f90
@@ -66,7 +66,7 @@ module mqc_libcint_mp2_gradient
       !! one-particle quantities sit outside it -- but it is what sets the block
       !! size, and it is the number to raise on a machine with room.
 
-   real(dp), parameter :: IN_CORE_LIMIT = 4.0e9_dp
+   real(dp), parameter, public :: IN_CORE_LIMIT = 4.0e9_dp
       !! Bytes. The same ceiling `mqc_libcint_cphf` applies to its own stored
       !! tensor, for the same reason and deliberately not a different number.
 

--- a/backends/libcint/mqc_libcint_ri_mp2_gradient.f90
+++ b/backends/libcint/mqc_libcint_ri_mp2_gradient.f90
@@ -1,0 +1,513 @@
+!! The RI-MP2 nuclear gradient over a closed-shell reference
+module mqc_libcint_ri_mp2_gradient
+   !! **What is differentiated.** An exact-ERI restricted Hartree-Fock
+   !! reference with a *fitted* correlation energy -- which is what an `ri-mp2`
+   !! deck asks for, the auxiliary basis naming the correlation fit and not the
+   !! SCF. That is why the four-centre coupling tensor and the Fock derivative
+   !! below are never fitted: approximating them would differentiate an energy
+   !! nobody computed.
+   !!
+   !! The formulation is Stocks, Palethorpe and Barca, J. Chem. Theory Comput.
+   !! 2024, 20, 2505, section 3. Only two things differ from the conventional
+   !! MP2 gradient next door:
+   !!
+   !! * the two-particle density stays three-index, `Gamma^P_ia`, and contracts
+   !!   against three- and two-centre derivative integrals rather than against
+   !!   four-centre ones; and
+   !! * the Lagrangian is built from `(pq|P)` instead of from a four-index
+   !!   density.
+   !!
+   !! Everything one-particle -- the relaxed density, the energy-weighted
+   !! density, the Z-vector, and the core-Hamiltonian, overlap and
+   !! Hartree-Fock two-electron derivative terms -- is
+   !! `mqc_libcint_mp2_gradient`'s, reused rather than rewritten.
+   !!
+   !! **Conventions that cost a day to establish**, none of them in the paper,
+   !! all of them settled against the numpy prototype in
+   !! `tools/cpu_validation/ri_mp2_gradient.py`:
+   !!
+   !! 1. The paper's `L'` and `L''` index the Lagrangian's own index first; the
+   !!    assembly this feeds carries it second, so `imat` is their transpose.
+   !!    The diagonals and the norms agree either way -- only the full matrix
+   !!    comparison shows it.
+   !! 2. The paper's `A_pqrs` contracted with a density is *twice* the response
+   !!    operator the conventional assembly uses.
+   !! 3. Terms 3 and 4 stayed wrong through three revisions while translational
+   !!    invariance held at 1e-15. It is blind to every one of these.
+   use pic_types, only: dp
+   use pic_blas_interfaces, only: pic_gemm
+   use mqc_error, only: error_t, ERROR_VALIDATION
+   use mqc_libcint_integrals, only: libcint_molecule_t, atom_ao_blocks, &
+                                    build_df_mo_tensor, three_centre, two_centre, &
+                                    metric_inverse_sqrt
+   use mqc_libcint_cphf, only: cphf_solve
+   use mqc_libcint_gradient, only: nuclear_repulsion_gradient, one_electron_deriv, &
+                                   iprinv_deriv_at, three_centre_deriv, &
+                                   two_centre_deriv, DERIV_OVLP, DERIV_KIN, DERIV_NUC
+   use mqc_libcint_mp2_gradient, only: gamma1_intermediates, two_electron_potential, &
+                                       two_electron_mp2_terms
+   implicit none
+   private
+
+   public :: libcint_ri_mp2_gradient
+
+contains
+
+   subroutine libcint_ri_mp2_gradient(mol, aux, coeff, orbital_energies, n_occ, &
+                                      gradient, error, n_frozen)
+      !! dE(RI-MP2)/dR for a closed-shell reference, in Hartree/Bohr
+      type(libcint_molecule_t), intent(in) :: mol
+      type(libcint_molecule_t), intent(in) :: aux   !! Auxiliary basis, same atoms
+      real(dp), intent(in) :: coeff(:, :)
+      real(dp), intent(in) :: orbital_energies(:)
+      integer, intent(in) :: n_occ
+      real(dp), allocatable, intent(out) :: gradient(:, :)
+      type(error_t), intent(inout) :: error
+      integer, intent(in), optional :: n_frozen
+
+      real(dp), allocatable :: bia(:, :, :), bia_raw(:, :, :), metric(:, :), jm12(:, :)
+      real(dp), allocatable :: t2(:, :, :, :), xbar(:, :, :, :)
+      real(dp), allocatable :: gamma(:, :, :), gamma_pq(:, :), gamma_ao(:, :, :)
+      real(dp), allocatable :: doo(:, :), dvv(:, :), dm1mo(:, :), zeta(:, :)
+      real(dp), allocatable :: imat(:, :), im1(:, :), im1_t(:, :)
+      real(dp), allocatable :: lag_o(:, :), lag_v(:, :), pq_p(:, :, :)
+      real(dp), allocatable :: c_occ(:, :), c_vir(:, :)
+      real(dp), allocatable :: hf_density(:, :), dm1(:, :), dm1_total(:, :), dm1p(:, :)
+      real(dp), allocatable :: veff(:, :), xvo(:, :, :), zvec(:, :, :)
+      real(dp), allocatable :: work(:, :), work_t(:, :), p_occ(:, :), vhf_s1occ(:, :)
+      real(dp), allocatable :: s1(:, :, :), h1(:, :, :), kin(:, :, :), zero_h(:, :)
+      real(dp), allocatable :: vrinv(:, :, :), hcore_a(:, :, :)
+      real(dp), allocatable :: de2(:, :), vhf1(:, :, :, :), eri(:, :, :, :)
+      real(dp), allocatable :: bounds(:, :), gamma_null(:, :, :, :)
+      integer, allocatable :: offsets(:), counts(:)
+      integer :: n_ao, n_mo, n_o, n_v, n_aux, frozen
+      integer :: i, j, a, b, p, q, iatom, comp, p0, p1
+      real(dp) :: denom
+
+      n_ao = mol%nao
+      n_mo = size(coeff, 2)
+      n_o = n_occ
+      n_v = n_mo - n_occ
+
+      frozen = 0
+      if (present(n_frozen)) frozen = n_frozen
+      if (frozen /= 0) then
+         call error%set(ERROR_VALIDATION, "the RI-MP2 gradient does not implement a "// &
+                        "frozen core: the relaxed density gains occupied-frozen and "// &
+                        "virtual-frozen blocks, which are not built here.")
+         return
+      end if
+      if (n_v < 1 .or. n_o < 1) then
+         call error%set(ERROR_VALIDATION, "the RI-MP2 gradient needs both occupied "// &
+                        "and virtual orbitals")
+         return
+      end if
+
+      allocate (c_occ(n_ao, n_o), c_vir(n_ao, n_v))
+      c_occ = coeff(:, 1:n_o)
+      c_vir = coeff(:, n_o + 1:n_mo)
+
+      ! ---- the fitted integrals, and the amplitudes over them --------------
+      ! `build_df_mo_tensor` lays its result out `(a, P, i)`, the shape the
+      ! energy's gemms want. Everything below indexes `(i, a, P)` instead,
+      ! matching the equations and the numpy reference, so it is repacked once
+      ! here rather than transposed at every use.
+      call build_df_mo_tensor(mol, aux, c_occ, c_vir, bia_raw, error)
+      if (error%has_error()) return
+      n_aux = size(bia_raw, 2)
+      allocate (bia(n_o, n_v, n_aux))
+      do p = 1, n_aux
+         do i = 1, n_o
+            bia(i, :, p) = bia_raw(:, p, i)
+         end do
+      end do
+      deallocate (bia_raw)
+
+      call two_centre(aux, metric)
+      call metric_inverse_sqrt(metric, jm12, error)
+      if (error%has_error()) return
+
+      allocate (t2(n_o, n_o, n_v, n_v))
+      do b = 1, n_v
+         do a = 1, n_v
+            do j = 1, n_o
+               do i = 1, n_o
+                  denom = orbital_energies(i) + orbital_energies(j) &
+                          - orbital_energies(n_occ + a) - orbital_energies(n_occ + b)
+                  t2(i, j, a, b) = sum(bia(i, a, :)*bia(j, b, :))/denom
+               end do
+            end do
+         end do
+      end do
+
+      ! ---- the three- and two-index densities (eqs 8, 10) ------------------
+      allocate (xbar(n_o, n_o, n_v, n_v))
+      xbar = 2.0_dp*t2
+      do b = 1, n_v
+         do a = 1, n_v
+            xbar(:, :, a, b) = xbar(:, :, a, b) - t2(:, :, b, a)
+         end do
+      end do
+
+      call build_gamma(xbar, bia, jm12, n_o, n_v, n_aux, gamma)
+      call build_gamma_metric(gamma, bia, jm12, n_o, n_v, n_aux, gamma_pq)
+      deallocate (xbar)
+
+      ! ---- the unrelaxed one-particle blocks -------------------------------
+      call gamma1_intermediates(t2, n_o, n_v, doo, dvv)
+      deallocate (t2)
+
+      allocate (dm1mo(n_mo, n_mo))
+      dm1mo = 0.0_dp
+      dm1mo(1:n_o, 1:n_o) = doo + transpose(doo)
+      dm1mo(n_o + 1:n_mo, n_o + 1:n_mo) = dvv + transpose(dvv)
+
+      ! ---- the Lagrangian (eqs 13, 14) -------------------------------------
+      !
+      ! `(pq|P)` over every molecular orbital, so the three-centre integrals are
+      ! transformed in full rather than only to the occupied-virtual block.
+      call three_centre(mol, aux, work)
+      allocate (pq_p(n_mo, n_mo, n_aux))
+      call transform_three_centre(work, coeff, n_ao, n_mo, n_aux, pq_p)
+      deallocate (work)
+
+      allocate (lag_o(n_o, n_mo), lag_v(n_v, n_mo))
+      lag_o = 0.0_dp
+      lag_v = 0.0_dp
+      do q = 1, n_mo
+         do a = 1, n_v
+            do i = 1, n_o
+               lag_o(i, q) = lag_o(i, q) &
+                             + 2.0_dp*sum(gamma(:, i, a)*pq_p(q, n_o + a, :))
+            end do
+         end do
+         do a = 1, n_v
+            do i = 1, n_o
+               lag_v(a, q) = lag_v(a, q) &
+                             + 2.0_dp*sum(gamma(:, i, a)*pq_p(i, q, :))
+            end do
+         end do
+      end do
+      deallocate (pq_p)
+
+      ! Transposed into the slot: the paper indexes the Lagrangian's own index
+      ! first, the assembly below carries it second.
+      allocate (imat(n_mo, n_mo))
+      imat(:, 1:n_o) = -transpose(lag_o)
+      imat(:, n_o + 1:n_mo) = -transpose(lag_v)
+
+      ! ---- the Z-vector ----------------------------------------------------
+      allocate (hf_density(n_ao, n_ao))
+      hf_density = 2.0_dp*matmul(c_occ, transpose(c_occ))
+
+      call mol%eris(eri)
+      allocate (bounds(0, 0))
+      allocate (zero_h(n_ao, n_ao), veff(n_ao, n_ao))
+      zero_h = 0.0_dp
+
+      allocate (dm1(n_ao, n_ao))
+      dm1 = matmul(coeff, matmul(dm1mo, transpose(coeff)))
+      call two_electron_potential(.true., mol, eri, bounds, zero_h, dm1, veff, error)
+      if (error%has_error()) return
+      veff = 2.0_dp*veff
+
+      allocate (xvo(n_v, n_o, 1))
+      xvo(:, :, 1) = matmul(transpose(c_vir), matmul(veff, c_occ))
+      do i = 1, n_o
+         do a = 1, n_v
+            xvo(a, i, 1) = xvo(a, i, 1) + imat(i, n_o + a) - imat(n_o + a, i)
+         end do
+      end do
+
+      call cphf_solve(mol, coeff, orbital_energies, n_occ, response=zvec, &
+                      error=error, mo_rhs=xvo, tol=1.0e-12_dp, max_iter=200, &
+                      eri_in=eri)
+      if (error%has_error()) return
+
+      dm1mo(n_o + 1:n_mo, 1:n_o) = dm1mo(n_o + 1:n_mo, 1:n_o) + zvec(:, :, 1)
+      dm1mo(1:n_o, n_o + 1:n_mo) = dm1mo(1:n_o, n_o + 1:n_mo) + transpose(zvec(:, :, 1))
+
+      imat(n_o + 1:n_mo, 1:n_o) = transpose(imat(1:n_o, n_o + 1:n_mo))
+      allocate (im1(n_ao, n_ao))
+      im1 = matmul(coeff, matmul(imat, transpose(coeff)))
+
+      ! ---- the energy-weighted density -------------------------------------
+      allocate (zeta(n_mo, n_mo))
+      do q = 1, n_mo
+         do p = 1, n_mo
+            zeta(p, q) = 0.5_dp*(orbital_energies(p) + orbital_energies(q))
+         end do
+      end do
+      do i = 1, n_o
+         do a = 1, n_v
+            zeta(n_o + a, i) = orbital_energies(i)
+            zeta(i, n_o + a) = orbital_energies(i)
+         end do
+      end do
+      zeta = zeta*dm1mo
+      allocate (work(n_ao, n_ao))
+      work = matmul(coeff, matmul(zeta, transpose(coeff)))
+      deallocate (zeta)
+
+      dm1 = matmul(coeff, matmul(dm1mo, transpose(coeff)))
+      allocate (p_occ(n_ao, n_ao))
+      p_occ = matmul(c_occ, transpose(c_occ))
+      call two_electron_potential(.true., mol, eri, bounds, zero_h, &
+                                  dm1 + transpose(dm1), veff, error)
+      if (error%has_error()) return
+      allocate (vhf_s1occ(n_ao, n_ao))
+      vhf_s1occ = matmul(p_occ, matmul(veff, p_occ))
+
+      allocate (dm1p(n_ao, n_ao), dm1_total(n_ao, n_ao))
+      dm1p = hf_density + 2.0_dp*dm1
+      dm1_total = hf_density + dm1
+
+      do i = 1, n_o
+         do q = 1, n_ao
+            do p = 1, n_ao
+               work(p, q) = work(p, q) + 2.0_dp*orbital_energies(i)*c_occ(p, i)*c_occ(q, i)
+            end do
+         end do
+      end do
+
+      ! ---- assembly --------------------------------------------------------
+      allocate (gradient(3, mol%natm))
+      gradient = 0.0_dp
+      call nuclear_repulsion_gradient(mol, gradient)
+
+      allocate (de2(3, mol%natm), vhf1(n_ao, n_ao, 3, mol%natm))
+      de2 = 0.0_dp
+      vhf1 = 0.0_dp
+      ! Only the reference-density matrices: the fitted two-particle density
+      ! contracts against three-centre derivatives instead, below.
+      allocate (gamma_null(0, 0, 0, 0))
+      call two_electron_mp2_terms(mol, gamma_null, hf_density, de2, vhf1, &
+                                  with_gamma=.false.)
+
+      call build_gamma_ao(gamma, c_occ, c_vir, n_ao, n_o, n_v, n_aux, gamma_ao)
+      call fitted_two_particle_gradient(mol, aux, gamma_ao, gamma_pq, gradient)
+
+      call one_electron_deriv(mol, s1, DERIV_OVLP)
+      s1 = -s1
+      call one_electron_deriv(mol, kin, DERIV_KIN)
+      call one_electron_deriv(mol, h1, DERIV_NUC)
+      h1 = -(kin + h1)
+      deallocate (kin)
+
+      allocate (offsets(mol%natm), counts(mol%natm))
+      call atom_ao_blocks(mol, offsets, counts)
+      allocate (vrinv(n_ao, n_ao, 3), hcore_a(n_ao, n_ao, 3))
+      allocate (im1_t(n_ao, n_ao), work_t(n_ao, n_ao))
+      im1_t = transpose(im1)
+      work_t = transpose(work)
+
+      do iatom = 1, mol%natm
+         p0 = offsets(iatom) + 1
+         p1 = offsets(iatom) + counts(iatom)
+
+         call iprinv_deriv_at(mol, iatom, vrinv)
+         vrinv = -mol%charges(iatom)*vrinv
+         if (counts(iatom) > 0) then
+            vrinv(p0:p1, :, :) = vrinv(p0:p1, :, :) + h1(p0:p1, :, :)
+         end if
+         do comp = 1, 3
+            hcore_a(:, :, comp) = vrinv(:, :, comp) + transpose(vrinv(:, :, comp))
+            gradient(comp, iatom) = gradient(comp, iatom) &
+                                    + sum(hcore_a(:, :, comp)*dm1_total) &
+                                    - sum(vhf1(:, :, comp, iatom)*dm1p)
+         end do
+
+         if (counts(iatom) == 0) cycle
+         do comp = 1, 3
+            gradient(comp, iatom) = gradient(comp, iatom) &
+                                    + sum(s1(p0:p1, :, comp)*im1(p0:p1, :)) &
+                                    + sum(s1(p0:p1, :, comp)*im1_t(p0:p1, :)) &
+                                    - sum(s1(p0:p1, :, comp)*work(p0:p1, :)) &
+                                    - sum(s1(p0:p1, :, comp)*work_t(p0:p1, :)) &
+                                    - 2.0_dp*sum(s1(p0:p1, :, comp)*vhf_s1occ(p0:p1, :))
+         end do
+      end do
+
+   end subroutine libcint_ri_mp2_gradient
+
+   subroutine build_gamma(xbar, bia, jm12, n_o, n_v, n_aux, gamma)
+      !! `Gamma^P_ia = sum_{bjQ} (2 X^ab_ij - X^ba_ij) B^Q_jb J^{-1/2}_PQ` (eq 8)
+      real(dp), intent(in) :: xbar(:, :, :, :), bia(:, :, :), jm12(:, :)
+      integer, intent(in) :: n_o, n_v, n_aux
+      real(dp), allocatable, intent(out) :: gamma(:, :, :)
+
+      real(dp), allocatable :: half(:, :, :)
+      integer :: i, j, a, b, qq
+
+      allocate (half(n_aux, n_o, n_v), gamma(n_aux, n_o, n_v))
+      half = 0.0_dp
+      !$omp parallel do collapse(2) default(none) &
+      !$omp    shared(half, xbar, bia, n_o, n_v, n_aux) private(i, a, j, b, qq)
+      do a = 1, n_v
+         do i = 1, n_o
+            do b = 1, n_v
+               do j = 1, n_o
+                  do qq = 1, n_aux
+                     half(qq, i, a) = half(qq, i, a) + xbar(i, j, a, b)*bia(j, b, qq)
+                  end do
+               end do
+            end do
+         end do
+      end do
+      !$omp end parallel do
+
+      do a = 1, n_v
+         do i = 1, n_o
+            gamma(:, i, a) = matmul(jm12, half(:, i, a))
+         end do
+      end do
+      deallocate (half)
+   end subroutine build_gamma
+
+   subroutine build_gamma_metric(gamma, bia, jm12, n_o, n_v, n_aux, gamma_pq)
+      !! `gamma_PQ = sum_{iaR} Gamma^P_ia B^R_ia J^{-1/2}_QR` (eq 10)
+      real(dp), intent(in) :: gamma(:, :, :), bia(:, :, :), jm12(:, :)
+      integer, intent(in) :: n_o, n_v, n_aux
+      real(dp), allocatable, intent(out) :: gamma_pq(:, :)
+
+      real(dp), allocatable :: half(:, :)
+      integer :: i, a
+
+      allocate (half(n_aux, n_aux), gamma_pq(n_aux, n_aux))
+      half = 0.0_dp
+      do a = 1, n_v
+         do i = 1, n_o
+            call outer_accumulate(gamma(:, i, a), bia(i, a, :), half)
+         end do
+      end do
+      gamma_pq = matmul(half, transpose(jm12))
+      deallocate (half)
+   end subroutine build_gamma_metric
+
+   subroutine outer_accumulate(u, v, m)
+      !! `m = m + u v^T`
+      real(dp), intent(in) :: u(:), v(:)
+      real(dp), intent(inout) :: m(:, :)
+      integer :: k
+
+      do k = 1, size(v)
+         m(:, k) = m(:, k) + u*v(k)
+      end do
+   end subroutine outer_accumulate
+
+   subroutine build_gamma_ao(gamma, c_occ, c_vir, n_ao, n_o, n_v, n_aux, gamma_ao)
+      !! `Gamma^P_munu`, the three-index density back-transformed
+      real(dp), intent(in) :: gamma(:, :, :), c_occ(:, :), c_vir(:, :)
+      integer, intent(in) :: n_ao, n_o, n_v, n_aux
+      real(dp), allocatable, intent(out) :: gamma_ao(:, :, :)
+
+      integer :: pp
+
+      allocate (gamma_ao(n_ao, n_ao, n_aux))
+      !$omp parallel do default(none) &
+      !$omp    shared(gamma_ao, gamma, c_occ, c_vir, n_aux) private(pp)
+      do pp = 1, n_aux
+         gamma_ao(:, :, pp) = matmul(c_occ, matmul(gamma(pp, :, :), transpose(c_vir)))
+      end do
+      !$omp end parallel do
+   end subroutine build_gamma_ao
+
+   subroutine transform_three_centre(three, coeff, n_ao, n_mo, n_aux, pq_p)
+      !! `(mu nu|P)` to `(pq|P)`, both molecular indices
+      real(dp), intent(in) :: three(:, :), coeff(:, :)
+      integer, intent(in) :: n_ao, n_mo, n_aux
+      real(dp), intent(out) :: pq_p(:, :, :)
+
+      real(dp), allocatable :: block(:, :)
+      integer :: pp
+
+      allocate (block(n_ao, n_ao))
+      !$omp parallel do default(none) &
+      !$omp    shared(pq_p, three, coeff, n_ao, n_aux) private(pp, block)
+      do pp = 1, n_aux
+         block = reshape(three(:, pp), [n_ao, n_ao])
+         pq_p(:, :, pp) = matmul(transpose(coeff), matmul(block, coeff))
+      end do
+      !$omp end parallel do
+      deallocate (block)
+   end subroutine transform_three_centre
+
+   subroutine fitted_two_particle_gradient(mol, aux, gamma_ao, gamma_pq, gradient)
+      !! The first two terms of eq 6, the only ones the fitting changes
+      !!
+      !! `4 sum Gamma^P_munu (P|munu)^xi` over both the orbital centres and the
+      !! auxiliary one, then `-2 sum gamma_PQ (P|Q)^xi`. libcint's `ip`
+      !! integrals differentiate the electronic coordinate, so the derivative
+      !! with respect to a nucleus carrying that function is minus them.
+      type(libcint_molecule_t), intent(in) :: mol, aux
+      real(dp), intent(in) :: gamma_ao(:, :, :), gamma_pq(:, :)
+      real(dp), intent(inout) :: gradient(:, :)
+
+      real(dp), allocatable :: ip1(:, :, :, :), ip2(:, :, :, :), j1(:, :, :)
+      integer, allocatable :: offsets(:), counts(:), aux_offsets(:), aux_counts(:)
+      integer :: iatom, comp, p0, p1, q0, q1
+
+      allocate (offsets(mol%natm), counts(mol%natm))
+      allocate (aux_offsets(aux%natm), aux_counts(aux%natm))
+      call atom_ao_blocks(mol, offsets, counts)
+      call atom_ao_blocks(aux, aux_offsets, aux_counts)
+
+      call three_centre_deriv(mol, aux, 1, ip1)
+      do iatom = 1, mol%natm
+         p0 = offsets(iatom) + 1
+         p1 = offsets(iatom) + counts(iatom)
+         if (counts(iatom) == 0) cycle
+         do comp = 1, 3
+            ! The bra index on this atom, and then the ket: `(mu nu|P)` is
+            ! symmetric in mu and nu, so the second is the first transposed.
+            gradient(comp, iatom) = gradient(comp, iatom) &
+                                    - 4.0_dp*sum(ip1(p0:p1, :, :, comp) &
+                                                 *gamma_ao(p0:p1, :, :)) &
+                                    - 4.0_dp*sum(ip1(p0:p1, :, :, comp) &
+                                                 *transpose_first_two(gamma_ao, p0, p1))
+         end do
+      end do
+      deallocate (ip1)
+
+      call three_centre_deriv(mol, aux, 2, ip2)
+      do iatom = 1, aux%natm
+         q0 = aux_offsets(iatom) + 1
+         q1 = aux_offsets(iatom) + aux_counts(iatom)
+         if (aux_counts(iatom) == 0) cycle
+         do comp = 1, 3
+            gradient(comp, iatom) = gradient(comp, iatom) &
+                                    - 4.0_dp*sum(ip2(:, :, q0:q1, comp) &
+                                                 *gamma_ao(:, :, q0:q1))
+         end do
+      end do
+      deallocate (ip2)
+
+      call two_centre_deriv(aux, j1)
+      do iatom = 1, aux%natm
+         q0 = aux_offsets(iatom) + 1
+         q1 = aux_offsets(iatom) + aux_counts(iatom)
+         if (aux_counts(iatom) == 0) cycle
+         do comp = 1, 3
+            gradient(comp, iatom) = gradient(comp, iatom) &
+                                    + 2.0_dp*sum(j1(q0:q1, :, comp)*gamma_pq(q0:q1, :)) &
+                                    + 2.0_dp*sum(j1(q0:q1, :, comp) &
+                                                 *transpose(gamma_pq(:, q0:q1)))
+         end do
+      end do
+      deallocate (j1)
+   end subroutine fitted_two_particle_gradient
+
+   function transpose_first_two(g, p0, p1) result(t)
+      !! `g(nu, mu, P)` for `mu` in a block, as the ket-side contraction needs
+      real(dp), intent(in) :: g(:, :, :)
+      integer, intent(in) :: p0, p1
+      real(dp), allocatable :: t(:, :, :)
+      integer :: pp
+
+      allocate (t(p1 - p0 + 1, size(g, 1), size(g, 3)))
+      do pp = 1, size(g, 3)
+         t(:, :, pp) = transpose(g(:, p0:p1, pp))
+      end do
+   end function transpose_first_two
+
+end module mqc_libcint_ri_mp2_gradient

--- a/backends/libcint/mqc_libcint_ri_mp2_gradient.f90
+++ b/backends/libcint/mqc_libcint_ri_mp2_gradient.f90
@@ -44,8 +44,9 @@ module mqc_libcint_ri_mp2_gradient
    use mqc_libcint_gradient, only: nuclear_repulsion_gradient, one_electron_deriv, &
                                    iprinv_deriv_at, three_centre_deriv, &
                                    two_centre_deriv, DERIV_OVLP, DERIV_KIN, DERIV_NUC
+   use mqc_libcint_direct, only: schwarz_bounds
    use mqc_libcint_mp2_gradient, only: gamma1_intermediates, two_electron_potential, &
-                                       two_electron_mp2_terms
+                                       two_electron_mp2_terms, IN_CORE_LIMIT
    implicit none
    private
 
@@ -54,7 +55,7 @@ module mqc_libcint_ri_mp2_gradient
 contains
 
    subroutine libcint_ri_mp2_gradient(mol, aux, coeff, orbital_energies, n_occ, &
-                                      gradient, error, n_frozen)
+                                      gradient, error, n_frozen, force_direct)
       !! dE(RI-MP2)/dR for a closed-shell reference, in Hartree/Bohr
       type(libcint_molecule_t), intent(in) :: mol
       type(libcint_molecule_t), intent(in) :: aux   !! Auxiliary basis, same atoms
@@ -64,6 +65,11 @@ contains
       real(dp), allocatable, intent(out) :: gradient(:, :)
       type(error_t), intent(inout) :: error
       integer, intent(in), optional :: n_frozen
+      logical, intent(in), optional :: force_direct
+         !! Recompute the reference integrals rather than storing them, whatever
+         !! the size. The check harness passes it so both paths are exercised on
+         !! a case small enough to take either -- a threshold nothing ever
+         !! crosses in a test is a threshold nothing ever tests.
 
       real(dp), allocatable :: bia(:, :, :), bia_raw(:, :, :), metric(:, :), jm12(:, :)
       real(dp), allocatable :: t2(:, :, :, :), xbar(:, :, :, :)
@@ -83,6 +89,7 @@ contains
       integer :: n_ao, n_mo, n_o, n_v, n_aux, frozen
       integer :: i, j, a, b, p, q, iatom, comp, p0, p1
       real(dp) :: denom
+      logical :: dense
 
       n_ao = mol%nao
       n_mo = size(coeff, 2)
@@ -101,6 +108,21 @@ contains
          call error%set(ERROR_VALIDATION, "the RI-MP2 gradient needs both occupied "// &
                         "and virtual orbitals")
          return
+      end if
+
+      ! Stored or recomputed, for the *reference* integrals only -- the ones the
+      ! Z-vector's operator and the reference potential are built from. Those
+      ! stay exact whatever the correlation is fitted with, because an `ri-mp2`
+      ! energy fits nothing in its SCF, so the response has to be the exact
+      ! reference's or it answers a question nobody asked.
+      !
+      ! What is fitted is not what makes this decision. Storing `n_ao^4` doubles
+      ! would put the ceiling of a method chosen to avoid `n_ao^4` back where RI
+      ! removed it, so past the limit the same integrals are recomputed instead
+      ! and nothing about the answer changes.
+      dense = real(n_ao, dp)**4*8.0_dp <= IN_CORE_LIMIT
+      if (present(force_direct)) then
+         if (force_direct) dense = .false.
       end if
 
       allocate (c_occ(n_ao, n_o), c_vir(n_ao, n_v))
@@ -200,14 +222,20 @@ contains
       allocate (hf_density(n_ao, n_ao))
       hf_density = 2.0_dp*matmul(c_occ, transpose(c_occ))
 
-      call mol%eris(eri)
-      allocate (bounds(0, 0))
+      if (dense) then
+         call mol%eris(eri)
+         allocate (bounds(0, 0))
+      else
+         allocate (eri(0, 0, 0, 0))
+         call schwarz_bounds(mol, bounds, error)
+         if (error%has_error()) return
+      end if
       allocate (zero_h(n_ao, n_ao), veff(n_ao, n_ao))
       zero_h = 0.0_dp
 
       allocate (dm1(n_ao, n_ao))
       dm1 = matmul(coeff, matmul(dm1mo, transpose(coeff)))
-      call two_electron_potential(.true., mol, eri, bounds, zero_h, dm1, veff, error)
+      call two_electron_potential(dense, mol, eri, bounds, zero_h, dm1, veff, error)
       if (error%has_error()) return
       veff = 2.0_dp*veff
 
@@ -219,9 +247,19 @@ contains
          end do
       end do
 
-      call cphf_solve(mol, coeff, orbital_energies, n_occ, response=zvec, &
-                      error=error, mo_rhs=xvo, tol=1.0e-12_dp, max_iter=200, &
-                      eri_in=eri)
+      ! Tighter than the solver's default, for the reason the conventional
+      ! gradient gives: the Z-vector residual enters the answer directly rather
+      ! than quadratically. Handing over the tensor when there is one saves a
+      ! second identical pass; when there is not, the solver goes direct with
+      ! the same Schwarz bound the potentials above used.
+      if (dense) then
+         call cphf_solve(mol, coeff, orbital_energies, n_occ, response=zvec, &
+                         error=error, mo_rhs=xvo, tol=1.0e-12_dp, max_iter=200, &
+                         eri_in=eri)
+      else
+         call cphf_solve(mol, coeff, orbital_energies, n_occ, response=zvec, &
+                         error=error, mo_rhs=xvo, tol=1.0e-12_dp, max_iter=200)
+      end if
       if (error%has_error()) return
 
       dm1mo(n_o + 1:n_mo, 1:n_o) = dm1mo(n_o + 1:n_mo, 1:n_o) + zvec(:, :, 1)
@@ -252,7 +290,7 @@ contains
       dm1 = matmul(coeff, matmul(dm1mo, transpose(coeff)))
       allocate (p_occ(n_ao, n_ao))
       p_occ = matmul(c_occ, transpose(c_occ))
-      call two_electron_potential(.true., mol, eri, bounds, zero_h, &
+      call two_electron_potential(dense, mol, eri, bounds, zero_h, &
                                   dm1 + transpose(dm1), veff, error)
       if (error%has_error()) return
       allocate (vhf_s1occ(n_ao, n_ao))

--- a/backends/libcint/mqc_libcint_ri_mp2_gradient.f90
+++ b/backends/libcint/mqc_libcint_ri_mp2_gradient.f90
@@ -71,8 +71,9 @@ contains
          !! a case small enough to take either -- a threshold nothing ever
          !! crosses in a test is a threshold nothing ever tests.
 
-      real(dp), allocatable :: bia(:, :, :), bia_raw(:, :, :), metric(:, :), jm12(:, :)
-      real(dp), allocatable :: t2(:, :, :, :), xbar(:, :, :, :)
+      real(dp), allocatable :: bmat(:, :), bia_raw(:, :, :), metric(:, :), jm12(:, :)
+      real(dp), allocatable :: ovov(:, :), xm(:, :)
+      real(dp), allocatable :: t2(:, :, :, :)
       real(dp), allocatable :: gamma(:, :, :), gamma_pq(:, :), gamma_ao(:, :, :)
       real(dp), allocatable :: doo(:, :), dvv(:, :), dm1mo(:, :), zeta(:, :)
       real(dp), allocatable :: imat(:, :), im1(:, :), im1_t(:, :)
@@ -86,7 +87,7 @@ contains
       real(dp), allocatable :: de2(:, :), vhf1(:, :, :, :), eri(:, :, :, :)
       real(dp), allocatable :: bounds(:, :), gamma_null(:, :, :, :)
       integer, allocatable :: offsets(:), counts(:)
-      integer :: n_ao, n_mo, n_o, n_v, n_aux, frozen
+      integer :: n_ao, n_mo, n_o, n_v, n_aux, n_ov, frozen
       integer :: i, j, a, b, p, q, iatom, comp, p0, p1
       real(dp) :: denom
       logical :: dense
@@ -137,10 +138,11 @@ contains
       call build_df_mo_tensor(mol, aux, c_occ, c_vir, bia_raw, error)
       if (error%has_error()) return
       n_aux = size(bia_raw, 2)
-      allocate (bia(n_o, n_v, n_aux))
+      n_ov = n_o*n_v
+      allocate (bmat(n_ov, n_aux))
       do p = 1, n_aux
          do i = 1, n_o
-            bia(i, :, p) = bia_raw(:, p, i)
+            bmat(i:n_ov:n_o, p) = bia_raw(:, p, i)
          end do
       end do
       deallocate (bia_raw)
@@ -149,6 +151,14 @@ contains
       call metric_inverse_sqrt(metric, jm12, error)
       if (error%has_error()) return
 
+      ! `(ia|jb)_RI = sum_P B^P_ia B^P_jb` is one gemm once `B` is held as a
+      ! matrix in the compound `(i,a)` index, which is the shape the repack
+      ! above produces. Written as `n_o^2 n_v^2` separate dot products it is the
+      ! same arithmetic against `B`'s longest stride, and it was the second most
+      ! expensive step in the routine.
+      allocate (ovov(n_ov, n_ov))
+      call pic_gemm(bmat, bmat, ovov, transb="T")
+
       allocate (t2(n_o, n_o, n_v, n_v))
       do b = 1, n_v
          do a = 1, n_v
@@ -156,24 +166,31 @@ contains
                do i = 1, n_o
                   denom = orbital_energies(i) + orbital_energies(j) &
                           - orbital_energies(n_occ + a) - orbital_energies(n_occ + b)
-                  t2(i, j, a, b) = sum(bia(i, a, :)*bia(j, b, :))/denom
+                  t2(i, j, a, b) = ovov(i + (a - 1)*n_o, j + (b - 1)*n_o)/denom
+               end do
+            end do
+         end do
+      end do
+      deallocate (ovov)
+
+      ! ---- the three- and two-index densities (eqs 8, 10) ------------------
+      ! `2 X^ab_ij - X^ba_ij`, in the two compound indices, so that eq 8 is a
+      ! gemm rather than the five-deep loop it reads as.
+      allocate (xm(n_ov, n_ov))
+      do b = 1, n_v
+         do a = 1, n_v
+            do j = 1, n_o
+               do i = 1, n_o
+                  xm(i + (a - 1)*n_o, j + (b - 1)*n_o) = &
+                     2.0_dp*t2(i, j, a, b) - t2(i, j, b, a)
                end do
             end do
          end do
       end do
 
-      ! ---- the three- and two-index densities (eqs 8, 10) ------------------
-      allocate (xbar(n_o, n_o, n_v, n_v))
-      xbar = 2.0_dp*t2
-      do b = 1, n_v
-         do a = 1, n_v
-            xbar(:, :, a, b) = xbar(:, :, a, b) - t2(:, :, b, a)
-         end do
-      end do
-
-      call build_gamma(xbar, bia, jm12, n_o, n_v, n_aux, gamma)
-      call build_gamma_metric(gamma, bia, jm12, n_o, n_v, n_aux, gamma_pq)
-      deallocate (xbar)
+      call build_gamma(xm, bmat, jm12, n_o, n_v, n_aux, gamma)
+      call build_gamma_metric(gamma, bmat, jm12, n_o, n_v, n_aux, gamma_pq)
+      deallocate (xm)
 
       ! ---- the unrelaxed one-particle blocks -------------------------------
       call gamma1_intermediates(t2, n_o, n_v, doo, dvv)
@@ -368,70 +385,68 @@ contains
 
    end subroutine libcint_ri_mp2_gradient
 
-   subroutine build_gamma(xbar, bia, jm12, n_o, n_v, n_aux, gamma)
+   subroutine build_gamma(xm, bmat, jm12, n_o, n_v, n_aux, gamma)
       !! `Gamma^P_ia = sum_{bjQ} (2 X^ab_ij - X^ba_ij) B^Q_jb J^{-1/2}_PQ` (eq 8)
-      real(dp), intent(in) :: xbar(:, :, :, :), bia(:, :, :), jm12(:, :)
+      !!
+      !! Two gemms over the compound `(i,a)` index. The `sum_{jb}` is the first
+      !! and the metric contraction is the second, and neither needs the rank-4
+      !! form the equation is written in -- which is the whole reason `xm` and
+      !! `bmat` are built as matrices upstream rather than reshaped here.
+      real(dp), intent(in) :: xm(:, :)      !! `2X - X^swap` as `((i,a), (j,b))`
+      real(dp), intent(in) :: bmat(:, :)    !! `B` as `((j,b), P)`
+      real(dp), intent(in) :: jm12(:, :)
       integer, intent(in) :: n_o, n_v, n_aux
       real(dp), allocatable, intent(out) :: gamma(:, :, :)
 
-      real(dp), allocatable :: half(:, :, :)
-      integer :: i, j, a, b, qq
+      real(dp), allocatable :: half(:, :), gm(:, :)
+      integer :: i, a, qq, n_ov
 
-      allocate (half(n_aux, n_o, n_v), gamma(n_aux, n_o, n_v))
-      half = 0.0_dp
-      !$omp parallel do collapse(2) default(none) &
-      !$omp    shared(half, xbar, bia, n_o, n_v, n_aux) private(i, a, j, b, qq)
+      n_ov = n_o*n_v
+      allocate (half(n_ov, n_aux), gm(n_ov, n_aux))
+      call pic_gemm(xm, bmat, half)
+      call pic_gemm(half, jm12, gm, transb="T")
+      deallocate (half)
+
+      ! Back to `(P, i, a)`, the layout the Lagrangian and the AO
+      ! back-transform read. One `n_ov` by `n_aux` transpose against two gemms
+      ! of `n_ov^2 n_aux` and `n_ov n_aux^2`.
+      allocate (gamma(n_aux, n_o, n_v))
       do a = 1, n_v
          do i = 1, n_o
-            do b = 1, n_v
-               do j = 1, n_o
-                  do qq = 1, n_aux
-                     half(qq, i, a) = half(qq, i, a) + xbar(i, j, a, b)*bia(j, b, qq)
-                  end do
-               end do
+            do qq = 1, n_aux
+               gamma(qq, i, a) = gm(i + (a - 1)*n_o, qq)
             end do
          end do
       end do
-      !$omp end parallel do
-
-      do a = 1, n_v
-         do i = 1, n_o
-            gamma(:, i, a) = matmul(jm12, half(:, i, a))
-         end do
-      end do
-      deallocate (half)
+      deallocate (gm)
    end subroutine build_gamma
 
-   subroutine build_gamma_metric(gamma, bia, jm12, n_o, n_v, n_aux, gamma_pq)
+   subroutine build_gamma_metric(gamma, bmat, jm12, n_o, n_v, n_aux, gamma_pq)
       !! `gamma_PQ = sum_{iaR} Gamma^P_ia B^R_ia J^{-1/2}_QR` (eq 10)
-      real(dp), intent(in) :: gamma(:, :, :), bia(:, :, :), jm12(:, :)
+      !!
+      !! Two gemms, in place of the `n_o n_v` rank-one updates this was: the
+      !! `sum_ia` is an inner product over the compound index and the metric
+      !! contraction follows it.
+      real(dp), intent(in) :: gamma(:, :, :), bmat(:, :), jm12(:, :)
       integer, intent(in) :: n_o, n_v, n_aux
       real(dp), allocatable, intent(out) :: gamma_pq(:, :)
 
-      real(dp), allocatable :: half(:, :)
-      integer :: i, a
+      real(dp), allocatable :: half(:, :), gflat(:, :)
+      integer :: i, a, qq, n_ov
 
-      allocate (half(n_aux, n_aux), gamma_pq(n_aux, n_aux))
-      half = 0.0_dp
+      n_ov = n_o*n_v
+      allocate (gflat(n_ov, n_aux), half(n_aux, n_aux), gamma_pq(n_aux, n_aux))
       do a = 1, n_v
          do i = 1, n_o
-            call outer_accumulate(gamma(:, i, a), bia(i, a, :), half)
+            do qq = 1, n_aux
+               gflat(i + (a - 1)*n_o, qq) = gamma(qq, i, a)
+            end do
          end do
       end do
-      gamma_pq = matmul(half, transpose(jm12))
-      deallocate (half)
+      call pic_gemm(gflat, bmat, half, transa="T")
+      call pic_gemm(half, jm12, gamma_pq, transb="T")
+      deallocate (half, gflat)
    end subroutine build_gamma_metric
-
-   subroutine outer_accumulate(u, v, m)
-      !! `m = m + u v^T`
-      real(dp), intent(in) :: u(:), v(:)
-      real(dp), intent(inout) :: m(:, :)
-      integer :: k
-
-      do k = 1, size(v)
-         m(:, k) = m(:, k) + u*v(k)
-      end do
-   end subroutine outer_accumulate
 
    subroutine build_gamma_ao(gamma, c_occ, c_vir, n_ao, n_o, n_v, n_aux, gamma_ao)
       !! `Gamma^P_munu`, the three-index density back-transformed
@@ -482,6 +497,7 @@ contains
       real(dp), intent(inout) :: gradient(:, :)
 
       real(dp), allocatable :: ip1(:, :, :, :), ip2(:, :, :, :), j1(:, :, :)
+      real(dp), allocatable :: gt(:, :, :)
       integer, allocatable :: offsets(:), counts(:), aux_offsets(:), aux_counts(:)
       integer :: iatom, comp, p0, p1, q0, q1
 
@@ -495,15 +511,19 @@ contains
          p0 = offsets(iatom) + 1
          p1 = offsets(iatom) + counts(iatom)
          if (counts(iatom) == 0) cycle
+         ! Hoisted out of the component loop: it depends on the atom block and
+         ! not on which Cartesian direction is being differentiated, so inside
+         ! it was the same transpose and the same allocation done three times.
+         gt = transpose_first_two(gamma_ao, p0, p1)
          do comp = 1, 3
             ! The bra index on this atom, and then the ket: `(mu nu|P)` is
             ! symmetric in mu and nu, so the second is the first transposed.
             gradient(comp, iatom) = gradient(comp, iatom) &
                                     - 4.0_dp*sum(ip1(p0:p1, :, :, comp) &
                                                  *gamma_ao(p0:p1, :, :)) &
-                                    - 4.0_dp*sum(ip1(p0:p1, :, :, comp) &
-                                                 *transpose_first_two(gamma_ao, p0, p1))
+                                    - 4.0_dp*sum(ip1(p0:p1, :, :, comp)*gt)
          end do
+         deallocate (gt)
       end do
       deallocate (ip1)
 

--- a/mqc_docs/source/capabilities.rst
+++ b/mqc_docs/source/capabilities.rst
@@ -175,8 +175,18 @@ Gradient Calculations
 
 On the CPU backend the analytic gradient covers Hartree-Fock restricted and
 unrestricted, density-fitted restricted Hartree-Fock, Kohn-Sham through LDA,
-GGA and hybrid GGA, and MP2 over a restricted reference. What is refused rather
-than approximated, and why:
+GGA and hybrid GGA, and MP2 over a restricted reference -- both the
+conventional one and ``ri-mp2``, where the correlation is fitted and the
+reference is not.
+
+Those last two are different energies and get different gradients: an
+``ri-mp2`` deck is differentiated by the fitted formulation, whose two-particle
+density stays three-index and contracts against three- and two-centre
+derivative integrals. Asking for a gradient with ``keywords.scf.density_fitting``
+on is a third thing, and is still refused -- there the *reference* is fitted,
+and nothing here differentiates that.
+
+What is refused rather than approximated, and why:
 
 .. list-table::
    :header-rows: 1
@@ -188,9 +198,10 @@ than approximated, and why:
      - The kinetic energy density brings a term of its own, which is not built
    * - Range-separated hybrids
      - Needs a second exchange derivative at the screened omega
-   * - Density-fitted MP2
-     - Would differentiate an energy nothing computed
-   * - Frozen-core MP2
+   * - MP2 over a fitted reference (``keywords.scf.density_fitting``)
+     - Would differentiate an energy nothing computed. Fitting only the
+       correlation, which is what ``ri-mp2`` means, is implemented
+   * - Frozen-core MP2 and RI-MP2
      - The relaxed density gains occupied-frozen and virtual-frozen blocks
    * - Spin-scaled MP2 (SCS, SOS)
      - The amplitudes enter the response equations, where the two spin cases

--- a/tools/cpu_validation/gen_cpu_validation.py
+++ b/tools/cpu_validation/gen_cpu_validation.py
@@ -426,6 +426,28 @@ GRADIENT_MP2_CASES = [
     ("nh3", "6-31g"),
 ]
 
+# RI-MP2 gradients, as (molecule, basis, aux). The reference for these is not
+# PySCF: it implements no RI-MP2 gradient at all -- both
+# `pyscf.mp.dfmp2.DFMP2.nuc_grad_method` and `dfmp2_native`'s raise
+# NotImplementedError -- so `ri_mp2_gradient.py` next door is it. That is a
+# weaker guarantee than the rest of the suite carries and it is worth naming:
+# an independent implementation of the same equations, checked against finite
+# differences of its own energy, rather than a third party's. What it does not
+# do is catch a misreading of the paper shared by both. Finite difference in
+# `validation/check_ri_mp2_gradient.f90` is what covers that.
+#
+# No Cartesian case, unlike the gradients above it. Every RIFIT set in
+# `basis_sets/` is spherical, and a fitting integral whose orbital and
+# auxiliary centres disagree is refused rather than built -- libcint puts all
+# three centres of one in the same form. So a Cartesian orbital basis has no
+# auxiliary to pair with, and that refusal is exercised by the energy path
+# already.
+GRADIENT_RI_MP2_CASES = [
+    ("water", "sto-3g", "cc-pvdz-rifit"),
+    ("water", "cc-pvdz", "cc-pvdz-rifit"),
+    ("nh3", "def2-svp", "def2-svp-rifit"),   # a second auxiliary family
+]
+
 # The same gradient through the many-body expansion, as
 # (molecule, basis, fragments). Its reference is the supermolecule and that is
 # exact rather than tolerated: over two fragments the expansion collapses term
@@ -904,6 +926,21 @@ def pyscf_mp2_gradient(atoms, basis):
     return float(mf.e_tot + pt.e_corr), pt.Gradients().kernel().tolist(), mol.nao
 
 
+def mqc_ri_mp2_gradient(atoms, basis, aux):
+    """Reference RI-MP2 energy and analytic gradient, from `ri_mp2_gradient.py`.
+
+    The one reference in this file that is not a third party's, because there
+    is no third party to ask -- see `GRADIENT_RI_MP2_CASES` for what that costs
+    and what covers it instead.
+    """
+    from ri_mp2_gradient import build, ri_mp2_energy, ri_mp2_gradient
+
+    mol, auxmol = build(atoms, basis, aux, unit="Angstrom")
+    energy, mf = ri_mp2_energy(mol, auxmol)
+    gradient = ri_mp2_gradient(mol, auxmol, mf)
+    return float(energy), gradient.tolist(), mol.nao
+
+
 def pyscf_gradient(atoms, basis, aux="", functional="", multiplicity=1,
                    level=GRADIENT_GRID_LEVEL):
     """Reference energy and analytic nuclear gradient, in Hartree/Bohr.
@@ -1122,6 +1159,34 @@ def main():
         })
         norm = math.sqrt(sum(c*c for atom in gradient for c in atom))
         print(f"{mol.label:6s} {basis:12s} {'MP2':8s} grad |g|={norm:.10f} "
+              f"nao={nao:4d} E={energy:.12f}", flush=True)
+
+    for name, basis, aux in GRADIENT_RI_MP2_CASES:
+        mol = MOLECULES[name]
+        energy, gradient, nao = mqc_ri_mp2_gradient(mol.atoms, basis, aux)
+        deck = deck_for(f"{CPU_MQC}/gradient",
+                        f"cpu_{name}_{normalize_basis_name(basis)}_rimp2_grad")
+        written.add(str((VALIDATION / deck).relative_to(INPUTS)))
+        if not args.dry_run:
+            # `aux_only`: the auxiliary fits the correlation and not the SCF.
+            # Without it the deck asks for a fitted reference too, which the
+            # gradient refuses -- correctly, and that is a different energy.
+            d = deck_json(xyz_for(mol), basis, aux=aux, method="ri-mp2",
+                          correlation={"freeze_core": False}, aux_only=True)
+            d["keywords"]["scf"]["tolerance"] = 1e-12
+            d["driver"] = "Gradient"
+            _write_deck(VALIDATION / deck, json.dumps(d, indent=4) + "\n")
+        tests.append({
+            "name": f"RI-MP2 gradient {mol.label} {basis}/{aux} (CPU)",
+            "input": deck,
+            "expected_energy": round(energy, 12),
+            "expected_gradient": [[round(c, 12) for c in atom] for atom in gradient],
+            "gradient_tolerance": GRADIENT_TOLERANCE,
+            "check_translation": True,
+            "type": "unfragmented",
+        })
+        norm = math.sqrt(sum(c*c for atom in gradient for c in atom))
+        print(f"{mol.label:6s} {basis:12s} {'RI-MP2':8s} grad |g|={norm:.10f} "
               f"nao={nao:4d} E={energy:.12f}", flush=True)
 
     for name, basis, fragments in GRADIENT_FRAGMENTED_CASES:

--- a/tools/cpu_validation/ri_mp2_gradient.py
+++ b/tools/cpu_validation/ri_mp2_gradient.py
@@ -1,0 +1,421 @@
+#!/usr/bin/env python3
+"""A reference RI-MP2 analytic nuclear gradient, in numpy over PySCF integrals.
+
+PySCF has no RI-MP2 gradient -- both `pyscf.mp.dfmp2.DFMP2.nuc_grad_method` and
+`dfmp2_native`'s raise NotImplementedError -- so there is nothing to check a
+Fortran implementation against. This is that missing reference, written first
+because a factor resolved here costs minutes and the same factor resolved in
+Fortran costs an afternoon.
+
+The formulation follows Stocks, Palethorpe and Barca, J. Chem. Theory Comput.
+2024, 20, 2505 (doi:10.1021/acs.jctc.3c01424), section 3; equation numbers below
+are theirs. See ``rimp2grad.md`` in the repository root.
+
+What is differentiated, precisely: an *exact-ERI* restricted Hartree-Fock
+reference with a *fitted* correlation energy. That is what our RI-MP2 decks ask
+for, and it is why the four-centre coupling tensor and the Fock derivative below
+are never fitted -- the paper makes the same point for the same reason.
+
+Run it directly to check against finite differences::
+
+    python tools/cpu_validation/ri_mp2_gradient.py
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from pyscf import df, gto, lib, scf
+
+
+# --------------------------------------------------------------------------
+# energy, so the finite difference differentiates exactly what the analytic
+# gradient claims to
+# --------------------------------------------------------------------------
+
+def ri_mp2_energy(mol, auxmol, conv_tol=1e-13):
+    """Exact-ERI RHF plus a fitted MP2 correlation energy."""
+    mf = scf.RHF(mol)
+    mf.conv_tol = conv_tol
+    mf.kernel()
+    if not mf.converged:
+        raise SystemExit("RHF did not converge")
+    b, _, _ = fitted_tensor(mol, auxmol, mf.mo_coeff, mol.nelectron // 2)
+    x, ovov = amplitudes(b, mf.mo_energy, mol.nelectron // 2)
+    e_corr = np.einsum("ijab,ijab->", x, 2 * ovov - ovov.transpose(0, 1, 3, 2))
+    return mf.e_tot + e_corr, mf
+
+
+def fitted_tensor(mol, auxmol, mo_coeff, nocc):
+    """B^P_ia (eq 5), together with the metric and its inverse square root.
+
+    The inverse square root is returned rather than rebuilt by the caller: a
+    different eigenvalue threshold would fit a different energy, and the
+    gradient has to differentiate the one that was computed.
+    """
+    nao = mol.nao
+    orbo = mo_coeff[:, :nocc]
+    orbv = mo_coeff[:, nocc:]
+
+    three = df.incore.aux_e2(mol, auxmol, intor="int3c2e", aosym="s1")
+    three = three.reshape(nao, nao, -1)
+    metric = auxmol.intor("int2c2e")
+
+    # (ia|Q)
+    ia_q = np.einsum("ui,uvQ,va->iaQ", orbo, three, orbv, optimize=True)
+    jm12 = metric_inverse_sqrt(metric)
+    b = np.einsum("iaQ,QP->Pia", ia_q, jm12, optimize=True)
+    return b, metric, jm12
+
+
+def metric_inverse_sqrt(metric, threshold=1e-10):
+    """J^(-1/2) through the eigendecomposition, dropping near-null modes."""
+    w, v = np.linalg.eigh(metric)
+    keep = w > threshold
+    return (v[:, keep] / np.sqrt(w[keep])) @ v[:, keep].T
+
+
+def amplitudes(b, mo_energy, nocc):
+    """X^ab_ij (eq 9) and the fitted integrals it came from (eq 4)."""
+    e_o = mo_energy[:nocc]
+    e_v = mo_energy[nocc:]
+    ovov = np.einsum("Pia,Pjb->iajb", b, b, optimize=True)
+    ovov = ovov.transpose(0, 2, 1, 3)          # (i, j, a, b)
+    denom = (e_o[:, None, None, None] + e_o[None, :, None, None]
+             - e_v[None, None, :, None] - e_v[None, None, None, :])
+    return ovov / denom, ovov
+
+
+# --------------------------------------------------------------------------
+# the gradient
+# --------------------------------------------------------------------------
+
+def ri_mp2_gradient(mol, auxmol, mf, verbose=False):
+    """dE/dR for exact RHF plus fitted MP2, in Hartree/Bohr.
+
+    **The assembly is not a fresh expansion of eq 7.** Everything one-particle
+    here -- the relaxed density, the energy-weighted density, and the
+    core-Hamiltonian, overlap and Hartree-Fock two-electron derivative terms --
+    is the conventional MP2 gradient's, in the arrangement `pyscf.grad.mp2`
+    uses and our own Fortran reproduces to 1e-9. Only two things are replaced:
+
+    * the two-particle density contracted with four-centre derivatives becomes
+      the three- and two-centre terms of eq 6, and
+    * the Lagrangian `Imat` is built from `L'` and `L''` (eqs 13, 14) instead of
+      from a four-index density.
+
+    Re-deriving the rest was tried and produced a term-3 error of about ten
+    times the answer, invisible to translational invariance. The reference
+    gradient lives *inside* this block -- `D_SCF` appears in the densities --
+    so the Hartree-Fock gradient is not added separately.
+    """
+    nocc = mol.nelectron // 2
+    nao, nmo = mf.mo_coeff.shape
+    nvir = nmo - nocc
+    mo, e_mo = mf.mo_coeff, mf.mo_energy
+    orbo, orbv = mo[:, :nocc], mo[:, nocc:]
+
+    b, metric, jm12 = fitted_tensor(mol, auxmol, mo, nocc)
+    x, _ = amplitudes(b, e_mo, nocc)
+
+    # ---- three- and two-index densities (eqs 8, 10) ----------------------
+    xbar = 2 * x - x.transpose(0, 1, 3, 2)             # 2X^ab_ij - X^ba_ij
+    gamma = np.einsum("ijab,Qjb,PQ->Pia", xbar, b, jm12, optimize=True)
+    gamma_pq = np.einsum("Pia,Ria,QR->PQ", gamma, b, jm12, optimize=True)
+
+    three = df.incore.aux_e2(mol, auxmol, intor="int3c2e", aosym="s1")
+    three = three.reshape(nao, nao, -1)
+
+    # Two exact identities, and the cheapest gates in the whole routine. Both
+    # follow from sum_P (ia|P) J^{-1/2}_PQ = B^Q_ia:
+    #
+    #   sum_{P,ia} Gamma^P_ia (ia|P) = E_corr,   sum_PQ gamma_PQ J_PQ = E_corr
+    #
+    # A factor slipped between the paper's `2X - X^swap` and the conventional
+    # `4X - 2X^swap` shows up here and in no later quantity.
+    if verbose:
+        ia_p = np.einsum("ui,uvP,va->iaP", orbo, three, orbv, optimize=True)
+        print("  E_corr from Gamma^P (ia|P): %.12f   from gamma_PQ J_PQ: %.12f"
+              % (np.einsum("Pia,iaP->", gamma, ia_p),
+                 np.einsum("PQ,PQ->", gamma_pq, metric)))
+
+    # ---- the unrelaxed one-particle blocks (eqs 17, 18) ------------------
+    #
+    # In the form our conventional MP2 gradient uses, checked element-wise
+    # against pyscf.mp.mp2._gamma1_intermediates; eq 17 scanned ambiguously and
+    # this is the same object.
+    doo = -(2 * np.einsum("kiab,kjab->ij", x, x, optimize=True)
+            - np.einsum("kiab,kjba->ij", x, x, optimize=True))
+    dvv = (2 * np.einsum("ijca,ijcb->ba", x, x, optimize=True)
+           - np.einsum("ijca,ijbc->ba", x, x, optimize=True))
+
+    dm1mo = np.zeros((nmo, nmo))
+    dm1mo[:nocc, :nocc] = doo + doo.T
+    dm1mo[nocc:, nocc:] = dvv + dvv.T
+
+    # ---- the Lagrangian, from the fitted integrals (eqs 13, 14) ----------
+    #
+    # `(pq|P)` over all molecular orbitals, which is why the three-centre
+    # integrals are transformed in full rather than only to `(ia|P)`.
+    #
+    # The sign is what makes this drop into the conventional assembly's slot:
+    # there the occupied-virtual blocks of `Imat` enter the Z-vector
+    # right-hand side as `Imat[i,a]^T - Imat[a,i]`, and eq 21 wants
+    # `L''_ai - L'_ia`, so `Imat = -L`.
+    pq_p = np.einsum("up,uvP,vq->pqP", mo, three, mo, optimize=True)
+    lag_o = 2 * np.einsum("Pia,qaP->iq", gamma, pq_p[:, nocc:, :], optimize=True)
+    lag_v = 2 * np.einsum("Pia,iqP->aq", gamma, pq_p[:nocc, :, :], optimize=True)
+
+    # Transposed into the slot. `L'_iq` and `L''_aq` are indexed with the
+    # Lagrangian's own index first; the conventional assembly's `Imat` carries
+    # it second. Verified numerically against a saturated-auxiliary
+    # `pyscf.grad.mp2` Lagrangian: the two agree to 3.8e-7, which is the
+    # fitting error, and disagree by 0.012 without the transpose -- with
+    # matching diagonals and matching norms either way, so neither of those is
+    # evidence.
+    imat = np.zeros((nmo, nmo))
+    imat[:, :nocc] = -lag_o.T
+    imat[:, nocc:] = -lag_v.T
+
+    # ---- the Z-vector ----------------------------------------------------
+    hf_dm = mf.make_rdm1()
+    dm1_ao = mo @ dm1mo @ mo.T
+    vhf = veff(mf, mol, dm1_ao) * 2
+    xvo = orbv.T @ vhf @ orbo + imat[:nocc, nocc:].T - imat[nocc:, :nocc]
+
+    dvo = solve_z_vector(mol, mf, xvo, nocc, nvir)
+    dm1mo[nocc:, :nocc] += dvo
+    dm1mo[:nocc, nocc:] += dvo.T
+
+    imat[nocc:, :nocc] = imat[:nocc, nocc:].T
+    im1 = mo @ imat @ mo.T
+
+    # ---- the energy-weighted density -------------------------------------
+    zeta = (e_mo[:, None] + e_mo[None, :]) * 0.5
+    zeta[nocc:, :nocc] = e_mo[:nocc]
+    zeta[:nocc, nocc:] = e_mo[:nocc][:, None]
+    zeta = mo @ (zeta * dm1mo) @ mo.T
+
+    dm1_ao = mo @ dm1mo @ mo.T
+    p_occ = orbo @ orbo.T
+    vhf_s1occ = p_occ @ veff(mf, mol, dm1_ao + dm1_ao.T) @ p_occ
+
+    dm1p = hf_dm + dm1_ao * 2
+    dm1_total = hf_dm + dm1_ao
+    zeta += (orbo * e_mo[:nocc]) @ orbo.T * 2.0
+
+    # ---- assembly --------------------------------------------------------
+    grad = mf.nuc_grad_method()
+    hcore_deriv = grad.hcore_generator(mol)
+    s1 = grad.get_ovlp(mol)
+    vhf1 = hf_two_electron_deriv(mol, hf_dm)
+    aoslices = mol.aoslice_by_atom()
+
+    de = np.zeros((mol.natm, 3))
+    de += gradient_three_centre(mol, auxmol, gamma, mo, nocc)
+    de += gradient_two_centre(auxmol, gamma_pq, mol)
+    for a in range(mol.natm):
+        p0, p1 = aoslices[a, 2], aoslices[a, 3]
+        de[a] += np.einsum("xij,ij->x", s1[:, p0:p1], im1[p0:p1])
+        de[a] += np.einsum("xij,ij->x", s1[:, p0:p1], im1.T[p0:p1])
+        de[a] += np.einsum("xij,ji->x", hcore_deriv(a), dm1_total)
+        de[a] -= np.einsum("xij,ij->x", s1[:, p0:p1], zeta[p0:p1])
+        de[a] -= np.einsum("xij,ij->x", s1[:, p0:p1], zeta.T[p0:p1])
+        de[a] -= 2 * np.einsum("xij,ij->x", s1[:, p0:p1], vhf_s1occ[p0:p1])
+        de[a] -= np.einsum("xij,ij->x", vhf1[a], dm1p)
+    de += grad.grad_nuc()
+
+    if verbose:
+        print("  |gamma| %.4e  |z| %.4e  |D| %.4e  |Imat| %.4e"
+              % (abs(gamma).sum(), abs(dvo).sum(), abs(dm1_ao).sum(),
+                 abs(imat).sum()))
+    return de
+
+
+def veff(mf, mol, dm):
+    """J - K/2 from a symmetric density, the SCF's own combination."""
+    vj, vk = mf.get_jk(mol, dm)
+    return vj - vk * 0.5
+
+
+def hf_two_electron_deriv(mol, hf_dm):
+    """Per-atom (3, nao, nao) matrices the reference density contracts with.
+
+    The four accumulations are the four positions an atomic orbital on the
+    differentiated centre can take in a quartet; `int2e_ip1` differentiates the
+    first index only, so the other three are reached by the integral's
+    permutational symmetry.
+    """
+    nao = mol.nao
+    eri1 = mol.intor("int2e_ip1").reshape(3, nao, nao, nao, nao)
+    aoslices = mol.aoslice_by_atom()
+    out = np.zeros((mol.natm, 3, nao, nao))
+    for a in range(mol.natm):
+        p0, p1 = aoslices[a, 2], aoslices[a, 3]
+        blk = eri1[:, p0:p1]
+        out[a] += np.einsum("xijkl,ij->xkl", blk, hf_dm[p0:p1])
+        out[a] -= np.einsum("xijkl,il->xkj", blk, hf_dm[p0:p1]) * 0.5
+        out[a][:, p0:p1] += np.einsum("xijkl,kl->xij", blk, hf_dm)
+        out[a][:, p0:p1] -= np.einsum("xijkl,jk->xil", blk, hf_dm) * 0.5
+    return out
+
+
+def solve_z_vector(mol, mf, xvo, nocc, nvir):
+    """Solve (eps_a - eps_i) D_ai + sum_bj A_aibj D_bj = L_ai, densely.
+
+    Densely on purpose. PySCF's Krylov CPHF carries error its `tol` does not
+    control -- it is what put 4e-8 between our conventional MP2 gradient and
+    `pyscf.grad.mp2` -- and at reference sizes the operator is small enough to
+    build column by column and hand to LAPACK.
+    """
+    mo = mf.mo_coeff
+    orbo, orbv = mo[:, :nocc], mo[:, nocc:]
+    e_mo = mf.mo_energy
+    gaps = (e_mo[nocc:, None] - e_mo[None, :nocc]).ravel()
+
+    n = nvir * nocc
+
+    # The response operator in the *conventional* assembly's normalisation:
+    # `2 C_v^T (J - K/2) C_o`, not the paper's `A`, which is twice it. Mixing
+    # the two doubles the coupling and leaves the answer wrong by a few percent
+    # in a way translational invariance cannot see.
+    def apply(vec):
+        d = orbv @ vec.reshape(nvir, nocc) @ orbo.T
+        vj, vk = mf.get_jk(mol, d + d.T)
+        return 2 * (orbv.T @ (vj - vk * 0.5) @ orbo).ravel()
+
+    operator = np.zeros((n, n))
+    basis = np.zeros(n)
+    for k in range(n):
+        basis[:] = 0.0
+        basis[k] = 1.0
+        operator[:, k] = apply(basis)
+    operator += np.diag(gaps)
+    # `A z = -X`, the sign the conventional assembly's right-hand side carries.
+    return np.linalg.solve(operator, -xvo.ravel()).reshape(nvir, nocc)
+
+
+# --------------------------------------------------------------------------
+# the four gradient terms of eq 6
+# --------------------------------------------------------------------------
+
+def gradient_three_centre(mol, auxmol, gamma, mo, nocc):
+    """4 sum_{munuP} Gamma^P_munu (P|munu)^xi -- the first term of eq 6."""
+    nao = mol.nao
+    orbo, orbv = mo[:, :nocc], mo[:, nocc:]
+    gamma_ao = np.einsum("Pia,ui,va->Puv", gamma, orbo, orbv, optimize=True)
+
+    de = np.zeros((mol.natm, 3))
+    aoslices = mol.aoslice_by_atom()
+    auxslices = auxmol.aoslice_by_atom()
+
+    # d/dR of the orbital centres, through int3c2e_ip1. (mu nu|P) is symmetric
+    # in mu and nu, so the nu derivative is the mu one transposed.
+    ip1 = df.incore.aux_e2(mol, auxmol, intor="int3c2e_ip1", aosym="s1", comp=3)
+    ip1 = ip1.reshape(3, nao, nao, -1)
+    for a in range(mol.natm):
+        p0, p1 = aoslices[a, 2], aoslices[a, 3]
+        de[a] -= 4 * np.einsum("xuvP,Puv->x", ip1[:, p0:p1], gamma_ao[:, p0:p1, :])
+        de[a] -= 4 * np.einsum("xuvP,Pvu->x", ip1[:, p0:p1], gamma_ao[:, :, p0:p1])
+
+    # d/dR of the auxiliary centre, through int3c2e_ip2.
+    ip2 = df.incore.aux_e2(mol, auxmol, intor="int3c2e_ip2", aosym="s1", comp=3)
+    ip2 = ip2.reshape(3, nao, nao, -1)
+    for a in range(mol.natm):
+        q0, q1 = auxslices[a, 2], auxslices[a, 3]
+        de[a] -= 4 * np.einsum("xuvP,Puv->x", ip2[:, :, :, q0:q1],
+                               gamma_ao[q0:q1])
+    return de
+
+
+def gradient_two_centre(auxmol, gamma_pq, mol):
+    """-2 sum_PQ gamma_PQ (P|Q)^xi -- the second term of eq 6."""
+    de = np.zeros((mol.natm, 3))
+    ip1 = auxmol.intor("int2c2e_ip1", comp=3)
+    auxslices = auxmol.aoslice_by_atom()
+    for a in range(mol.natm):
+        q0, q1 = auxslices[a, 2], auxslices[a, 3]
+        de[a] += 2 * np.einsum("xPQ,PQ->x", ip1[:, q0:q1], gamma_pq[q0:q1])
+        de[a] += 2 * np.einsum("xQP,PQ->x", ip1[:, q0:q1], gamma_pq[:, q0:q1])
+    return de
+
+
+# --------------------------------------------------------------------------
+# checking
+# --------------------------------------------------------------------------
+
+def finite_difference(atoms, basis, auxbasis, step=2.5e-3):
+    """Central differences of the same energy the analytic gradient claims."""
+    de = np.zeros((len(atoms), 3))
+    for a in range(len(atoms)):
+        for c in range(3):
+            plus = [list(x) for x in atoms]
+            minus = [list(x) for x in atoms]
+            plus[a][1 + c] += step
+            minus[a][1 + c] -= step
+            e_plus = ri_mp2_energy(*build(plus, basis, auxbasis))[0]
+            e_minus = ri_mp2_energy(*build(minus, basis, auxbasis))[0]
+            de[a, c] = (e_plus - e_minus) / (2 * step)
+    return de
+
+
+def build(atoms, basis, auxbasis):
+    """The two molecules, both bases read out of ``basis_sets/``.
+
+    Not PySCF's own tables. They and this repository's JSON differ around the
+    eighth decimal of an exponent, which puts about 3e-8 between the two codes'
+    energies -- comfortably more than the difference between two correct
+    gradients, so a comparison built on PySCF's tables cannot tell a real
+    discrepancy from a basis one. Reading the same file both codes read removes
+    the question.
+    """
+    from gen_cpu_validation import bse_to_pyscf
+
+    symbols = {a[0] for a in atoms}
+    mol = gto.Mole()
+    mol.atom = [(s, (x, y, z)) for s, x, y, z in atoms]
+    mol.unit = "Bohr"
+    mol.basis = {s: bse_to_pyscf(basis, s) for s in symbols}
+    mol.verbose = 0
+    mol.build()
+    auxmol = df.addons.make_auxmol(
+        mol, {s: bse_to_pyscf(auxbasis, s) for s in symbols})
+    return mol, auxmol
+
+
+def main():
+    lib.num_threads(8)
+    cases = [
+        ("H2 / sto-3g", [["H", 0.0, 0.0, -0.7], ["H", 0.0, 0.0, 0.7]],
+         "sto-3g", "cc-pvdz-rifit"),
+        ("H2O / sto-3g", [["O", 0.0, 0.0, 0.0], ["H", 0.0, -1.4308, 1.1078],
+                          ["H", 0.0, 1.4308, 1.1078]],
+         "sto-3g", "cc-pvdz-rifit"),
+        ("HCN / sto-3g", [["H", 0.0, 0.0, -2.0], ["C", 0.0, 0.0, 0.0],
+                          ["N", 0.0, 0.0, 2.2]],
+         "sto-3g", "cc-pvdz-rifit"),
+    ]
+
+    worst_overall = 0.0
+    for label, atoms, basis, auxbasis in cases:
+        mol, auxmol = build(atoms, basis, auxbasis)
+        energy, mf = ri_mp2_energy(mol, auxmol)
+        analytic = ri_mp2_gradient(mol, auxmol, mf, verbose=True)
+        numeric = finite_difference(atoms, basis, auxbasis)
+
+        print(f"== {label}   E(RI-MP2) = {energy:.12f}")
+        for a in range(mol.natm):
+            print("   %2d  analytic %16.11f %16.11f %16.11f   fd %16.11f %16.11f %16.11f"
+                  % (a + 1, *analytic[a], *numeric[a]))
+        worst = np.abs(analytic - numeric).max()
+        worst_overall = max(worst_overall, worst)
+        print(f"   largest deviation from finite difference: {worst:.4e}")
+        print(f"   |sum over atoms|:                         "
+              f"{np.abs(analytic.sum(axis=0)).max():.4e}")
+
+    print()
+    print("worst over all cases: %.4e" % worst_overall)
+    return 0 if worst_overall < 1e-5 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/cpu_validation/ri_mp2_gradient.py
+++ b/tools/cpu_validation/ri_mp2_gradient.py
@@ -358,7 +358,7 @@ def finite_difference(atoms, basis, auxbasis, step=2.5e-3):
     return de
 
 
-def build(atoms, basis, auxbasis):
+def build(atoms, basis, auxbasis, unit="Bohr"):
     """The two molecules, both bases read out of ``basis_sets/``.
 
     Not PySCF's own tables. They and this repository's JSON differ around the
@@ -368,13 +368,29 @@ def build(atoms, basis, auxbasis):
     discrepancy from a basis one. Reading the same file both codes read removes
     the question.
     """
-    from gen_cpu_validation import bse_to_pyscf
+    from gen_cpu_validation import CARTESIAN, bse_to_pyscf, molecule_form
 
     symbols = {a[0] for a in atoms}
+
+    # `make_auxmol` inherits `mol.cart`, so PySCF will quietly build a
+    # spherical auxiliary set in Cartesian form if asked. metalquicha refuses
+    # that combination outright -- libcint builds all three centres of a
+    # fitting integral in one form -- so a reference for it would be a
+    # reference for a deck that cannot run. Refuse it here too, and for the
+    # same reason.
+    orbital_form = molecule_form(basis, symbols)
+    aux_form = molecule_form(auxbasis, symbols)
+    if CARTESIAN in (orbital_form, aux_form) and orbital_form != aux_form:
+        raise SystemExit(
+            f"{basis} is {orbital_form} and {auxbasis} is {aux_form}; "
+            "metalquicha refuses a fitting integral whose centres disagree, so "
+            "there is nothing here to be a reference for")
+
     mol = gto.Mole()
     mol.atom = [(s, (x, y, z)) for s, x, y, z in atoms]
-    mol.unit = "Bohr"
+    mol.unit = unit
     mol.basis = {s: bse_to_pyscf(basis, s) for s in symbols}
+    mol.cart = orbital_form == CARTESIAN
     mol.verbose = 0
     mol.build()
     auxmol = df.addons.make_auxmol(

--- a/validation/bench_ri_mp2_gradient.f90
+++ b/validation/bench_ri_mp2_gradient.f90
@@ -1,0 +1,131 @@
+!! Where the time goes in the RI-MP2 gradient
+program bench_ri_mp2_gradient
+   !! Warm and on a wall clock, for the reasons `bench_mp2_gradient` gives: a
+   !! cold call measures lazy symbol resolution and first-touch allocation, and
+   !! `cpu_time` sums over threads so a threaded routine appears to slow down as
+   !! it speeds up.
+   !!
+   !! Two costs are mixed together in every number below, and it is worth
+   !! knowing which is which. The fitted work -- the amplitudes, the three-index
+   !! density and the Lagrangian -- is `n_occ^2 n_vir^2 n_aux`. The reference
+   !! work -- the exact integrals for the Z-vector and the differentiated
+   !! quartets -- is `n_ao^4`, and is shared with the conventional gradient next
+   !! door.
+   !!
+   !! **The reference work dominates at every size in this file**, measured
+   !! rather than assumed: on water/cc-pVTZ the Z-vector solve alone is a third
+   !! of the wall clock and the fitted steps together are about a tenth. That is
+   !! what these molecules are, not what the method is -- they have twenty
+   !! electrons and a large basis each, and growing the basis at a fixed
+   !! electron count is precisely the regime where `n_ao^4` outruns
+   !! `n_occ^2 n_vir^2 n_aux`. A case with more electrons rather than more
+   !! functions per electron would invert it, and none is cheap enough to sit
+   !! in a benchmark that has to finish.
+   use pic_types, only: dp, int64
+   use mqc_error, only: error_t
+   use mqc_libcint_integrals, only: libcint_molecule_t, build_libcint_molecule
+   use mqc_libcint_rhf, only: rhf_result_t, run_libcint_rhf
+   use mqc_libcint_ri_mp2_gradient, only: libcint_ri_mp2_gradient
+   use omp_lib, only: omp_get_max_threads
+   use, intrinsic :: iso_fortran_env, only: output_unit
+   implicit none
+
+   integer, parameter :: N_DIM = 3
+
+   write (*, "(a,i0,a)") "== RI-MP2 gradient, ", omp_get_max_threads(), " threads"
+
+   call bench_case("H2O / cc-pvdz", [8, 1, 1], ["O", "H", "H"], &
+                   reshape([0.0_dp, 0.0_dp, 0.0_dp, &
+                            0.0_dp, -1.4308_dp, 1.1078_dp, &
+                            0.0_dp, 1.4308_dp, 1.1078_dp], [N_DIM, 3]), &
+                   "cc-pvdz", "cc-pvdz-rifit", 10)
+
+   call bench_case("H2O / cc-pvtz", [8, 1, 1], ["O", "H", "H"], &
+                   reshape([0.0_dp, 0.0_dp, 0.0_dp, &
+                            0.0_dp, -1.4308_dp, 1.1078_dp, &
+                            0.0_dp, 1.4308_dp, 1.1078_dp], [N_DIM, 3]), &
+                   "cc-pvtz", "cc-pvtz-rifit", 10)
+
+   call bench_case("(H2O)2 / cc-pvdz", [8, 1, 1, 8, 1, 1], &
+                   ["O", "H", "H", "O", "H", "H"], &
+                   reshape([0.0_dp, 0.0_dp, 0.0_dp, &
+                            0.0_dp, -1.4308_dp, 1.1078_dp, &
+                            0.0_dp, 1.4308_dp, 1.1078_dp, &
+                            0.0_dp, 0.0_dp, 5.6_dp, &
+                            0.0_dp, -1.4308_dp, 6.7078_dp, &
+                            0.0_dp, 1.4308_dp, 6.7078_dp], [N_DIM, 6]), &
+                   "cc-pvdz", "cc-pvdz-rifit", 20)
+
+   ! The largest case here, and it does *not* make the fitted work dominant --
+   ! measured, not assumed. Growing the basis at a fixed electron count grows
+   ! `n_ao^4` faster than `n_occ^2 n_vir^2 n_aux`, so the reference terms take a
+   ! larger share here than at cc-pVDZ, not a smaller one. What would move the
+   ! balance is more electrons rather than more functions per electron, and no
+   ! case in this file has them.
+   call bench_case("(H2O)2 / cc-pvtz", [8, 1, 1, 8, 1, 1], &
+                   ["O", "H", "H", "O", "H", "H"], &
+                   reshape([0.0_dp, 0.0_dp, 0.0_dp, &
+                            0.0_dp, -1.4308_dp, 1.1078_dp, &
+                            0.0_dp, 1.4308_dp, 1.1078_dp, &
+                            0.0_dp, 0.0_dp, 5.6_dp, &
+                            0.0_dp, -1.4308_dp, 6.7078_dp, &
+                            0.0_dp, 1.4308_dp, 6.7078_dp], [N_DIM, 6]), &
+                   "cc-pvtz", "cc-pvtz-rifit", 20)
+
+contains
+
+   subroutine bench_case(label, numbers, symbols, coords, basis, aux_basis, nelec)
+      character(len=*), intent(in) :: label
+      integer, intent(in) :: numbers(:)
+      character(len=*), intent(in) :: symbols(:)
+      real(dp), intent(in) :: coords(:, :)
+      character(len=*), intent(in) :: basis, aux_basis
+      integer, intent(in) :: nelec
+
+      type(libcint_molecule_t) :: mol, aux
+      type(rhf_result_t) :: scf
+      type(error_t) :: error
+      real(dp), allocatable :: gradient(:, :)
+      integer(int64) :: t0, t1, rate
+      real(dp) :: seconds
+
+      call build_libcint_molecule(numbers, symbols, coords, basis, mol, error)
+      if (error%has_error()) then
+         write (*, "(a,a)") "FAIL: ", error%get_message()
+         return
+      end if
+      call build_libcint_molecule(numbers, symbols, coords, aux_basis, aux, error)
+      if (error%has_error()) then
+         write (*, "(a,a)") "FAIL: ", error%get_message()
+         return
+      end if
+      call run_libcint_rhf(mol, nelec, 200, 1.0e-11_dp, 1.0e-9_dp, .false., scf, error)
+      if (error%has_error()) then
+         write (*, "(a,a)") "FAIL: ", error%get_message()
+         return
+      end if
+
+      ! Warm-up, discarded.
+      call libcint_ri_mp2_gradient(mol, aux, scf%orbitals, scf%orbital_energies, &
+                                   nelec/2, gradient, error)
+      if (error%has_error()) then
+         write (*, "(a,a)") "FAIL: ", error%get_message()
+         return
+      end if
+      deallocate (gradient)
+
+      call system_clock(t0, rate)
+      call libcint_ri_mp2_gradient(mol, aux, scf%orbitals, scf%orbital_energies, &
+                                   nelec/2, gradient, error)
+      call system_clock(t1)
+      seconds = real(t1 - t0, dp)/real(rate, dp)
+
+      write (*, "(a,a,a,i0,a,i0,a,f9.3,a,es12.4)") "  ", label, "  nao=", mol%nao, &
+         "  naux=", aux%nao, "   ", seconds, " s   |g|=", sqrt(sum(gradient**2))
+      flush (output_unit)
+      deallocate (gradient)
+      call mol%destroy()
+      call aux%destroy()
+   end subroutine bench_case
+
+end program bench_ri_mp2_gradient

--- a/validation/check_df_cphf.f90
+++ b/validation/check_df_cphf.f90
@@ -1,0 +1,183 @@
+!! The fitted coupled-perturbed operator, against the exact one on the same integrals
+program check_df_cphf
+   !! **What is being asserted, and what is not.**
+   !!
+   !! `response_operator_df` never assembles the response density's exchange
+   !! from a density. It substitutes the factorization the trial rotation
+   !! already carries, `Dt = X C_occ^T + C_occ X^T`, and contracts through the
+   !! auxiliary index instead. That rearrangement is either right or wrong as
+   !! algebra, and how good density fitting is has nothing to do with which.
+   !!
+   !! So the check here is exact rather than tolerated: form the fitted
+   !! integrals in four-index form, `(uv|ls)_RI = sum_P B(uv,P) B(ls,P)`, hand
+   !! *those* to the ordinary exact-ERI solver, and require the two responses to
+   !! agree to rounding. Any factor, transpose or missing permutation in the
+   !! factored build shows up immediately, on a case small enough to form the
+   !! four-index object at all.
+   !!
+   !! The distance from the *exact* response is printed alongside, and is a
+   !! different quantity entirely -- that one is the fitting error, and it is
+   !! meant to be small rather than zero. Confusing the two is how a wrong
+   !! operator gets excused as "within the fitting error".
+   use pic_types, only: dp
+   use mqc_error, only: error_t
+   use mqc_libcint_integrals, only: libcint_molecule_t, build_libcint_molecule, &
+                                    build_df_tensor
+   use mqc_libcint_rhf, only: rhf_result_t, run_libcint_rhf
+   use mqc_libcint_cphf, only: cphf_solve
+   use, intrinsic :: iso_fortran_env, only: output_unit
+   implicit none
+
+   integer, parameter :: N_DIM = 3
+
+   integer :: n_bad
+
+   n_bad = 0
+   write (*, "(a)") "== the fitted CPHF operator"
+
+   call check_case("H2O / sto-3g", [8, 1, 1], ["O", "H", "H"], &
+                   reshape([0.0_dp, 0.0_dp, 0.0_dp, &
+                            0.0_dp, -1.4308_dp, 1.1078_dp, &
+                            0.0_dp, 1.4308_dp, 1.1078_dp], [N_DIM, 3]), &
+                   "sto-3g", "def2-universal-jkfit", 10, n_bad)
+
+   ! Asymmetric, so a transposed factor cannot hide behind symmetry.
+   call check_case("HCN / sto-3g", [1, 6, 7], ["H", "C", "N"], &
+                   reshape([0.0_dp, 0.0_dp, -2.0_dp, &
+                            0.0_dp, 0.0_dp, 0.0_dp, &
+                            0.0_dp, 0.0_dp, 2.2_dp], [N_DIM, 3]), &
+                   "sto-3g", "def2-universal-jkfit", 14, n_bad)
+
+   call check_case("H2O / cc-pvdz", [8, 1, 1], ["O", "H", "H"], &
+                   reshape([0.0_dp, 0.0_dp, 0.0_dp, &
+                            0.0_dp, -1.4308_dp, 1.1078_dp, &
+                            0.0_dp, 1.4308_dp, 1.1078_dp], [N_DIM, 3]), &
+                   "cc-pvdz", "def2-universal-jkfit", 10, n_bad)
+
+   write (*, "(a)") ""
+   if (n_bad == 0) then
+      write (*, "(a)") "all fitted CPHF checks passed"
+   else
+      write (*, "(a,i0,a)") "FAILED: ", n_bad, " case(s)"
+      stop 1
+   end if
+
+contains
+
+   subroutine check_case(label, numbers, symbols, coords, basis, aux_basis, nelec, n_bad)
+      character(len=*), intent(in) :: label
+      integer, intent(in) :: numbers(:)
+      character(len=*), intent(in) :: symbols(:)
+      real(dp), intent(in) :: coords(:, :)
+      character(len=*), intent(in) :: basis, aux_basis
+      integer, intent(in) :: nelec
+      integer, intent(inout) :: n_bad
+
+      type(libcint_molecule_t) :: mol, aux
+      type(rhf_result_t) :: scf
+      type(error_t) :: error
+      real(dp), allocatable :: bmat(:, :), eri_ri(:, :, :, :), eri(:, :, :, :)
+      real(dp), allocatable :: rhs(:, :, :)
+      real(dp), allocatable :: u_fitted(:, :, :), u_refitted(:, :, :), u_exact(:, :, :)
+      integer :: n_ao, n_occ, n_vir, naux, u, v, l, s, p, a, i
+      real(dp) :: algebra, fitting
+
+      write (*, "(a)") ""
+      write (*, "(a,a)") "== ", label
+      flush (output_unit)
+
+      call build_libcint_molecule(numbers, symbols, coords, basis, mol, error)
+      if (fail(error, n_bad)) return
+      call build_libcint_molecule(numbers, symbols, coords, aux_basis, aux, error)
+      if (fail(error, n_bad)) return
+      call run_libcint_rhf(mol, nelec, 300, 1.0e-14_dp, 1.0e-12_dp, .false., scf, error)
+      if (fail(error, n_bad)) return
+
+      n_ao = mol%nao
+      n_occ = nelec/2
+
+      call build_df_tensor(mol, aux, bmat, error)
+      if (fail(error, n_bad)) return
+      naux = size(bmat, 2)
+
+      ! One right-hand side is enough -- the operator is what is being tested,
+      ! not the perturbation -- and a fixed pattern in the occupied-virtual
+      ! block is both reproducible and free of any symmetry that could let a
+      ! transposed term cancel.
+      n_vir = size(scf%orbitals, 2) - n_occ
+      allocate (rhs(n_vir, n_occ, 1))
+      do i = 1, n_occ
+         do a = 1, n_vir
+            rhs(a, i, 1) = 1.0_dp/real(a + 2*i, dp)
+         end do
+      end do
+
+      ! The fitted integrals, in four-index form. Only ever affordable because
+      ! these cases are small -- which is the point of the case list.
+      allocate (eri_ri(n_ao, n_ao, n_ao, n_ao))
+      eri_ri = 0.0_dp
+      do p = 1, naux
+         do s = 1, n_ao
+            do l = 1, n_ao
+               do v = 1, n_ao
+                  do u = 1, n_ao
+                     eri_ri(u, v, l, s) = eri_ri(u, v, l, s) &
+                                          + bmat(u + (v - 1)*n_ao, p) &
+                                          *bmat(l + (s - 1)*n_ao, p)
+                  end do
+               end do
+            end do
+         end do
+      end do
+
+      call cphf_solve(mol, scf%orbitals, scf%orbital_energies, n_occ, response=u_fitted, &
+                      error=error, mo_rhs=rhs, tol=1.0e-12_dp, max_iter=200, bmat=bmat)
+      if (fail(error, n_bad)) return
+
+      call cphf_solve(mol, scf%orbitals, scf%orbital_energies, n_occ, &
+                      response=u_refitted, error=error, mo_rhs=rhs, tol=1.0e-12_dp, &
+                      max_iter=200, eri_in=eri_ri)
+      if (fail(error, n_bad)) return
+
+      call mol%eris(eri)
+      call cphf_solve(mol, scf%orbitals, scf%orbital_energies, n_occ, response=u_exact, &
+                      error=error, mo_rhs=rhs, tol=1.0e-12_dp, max_iter=200, eri_in=eri)
+      if (fail(error, n_bad)) return
+
+      algebra = maxval(abs(u_fitted - u_refitted))
+      fitting = maxval(abs(u_fitted - u_exact))
+      write (*, "(a,i0,a,i0)") "  n_ao = ", n_ao, "   naux = ", naux
+      write (*, "(a,es14.4)") "  factored against four-index, same integrals: ", algebra
+      write (*, "(a,es14.4)") "  fitted against exact (the fitting error):    ", fitting
+      flush (output_unit)
+
+      ! The first is an identity and is held to rounding. The second is an
+      ! approximation and is only sanity-checked: a JKFIT set that moved the
+      ! response by more than a percent would mean the tensor is not what it
+      ! claims to be, which is a different failure from a wrong operator.
+      if (algebra > 1.0e-9_dp) then
+         write (*, "(a)") "  FAIL: the factored build is not the fitted operator"
+         n_bad = n_bad + 1
+      end if
+      if (fitting > 1.0e-2_dp*maxval(abs(u_exact))) then
+         write (*, "(a)") "  FAIL: the fitting error is too large to be fitting error"
+         n_bad = n_bad + 1
+      end if
+
+      call mol%destroy()
+      call aux%destroy()
+   end subroutine check_case
+
+   function fail(error, n_bad) result(bad)
+      type(error_t), intent(inout) :: error
+      integer, intent(inout) :: n_bad
+      logical :: bad
+
+      bad = error%has_error()
+      if (bad) then
+         write (*, "(a,a)") "FAIL: ", error%get_message()
+         n_bad = n_bad + 1
+      end if
+   end function fail
+
+end program check_df_cphf

--- a/validation/check_ri_mp2_gradient.f90
+++ b/validation/check_ri_mp2_gradient.f90
@@ -78,7 +78,7 @@ contains
       integer, intent(in) :: nelec
       integer, intent(inout) :: n_bad
 
-      real(dp), allocatable :: analytic(:, :), numeric(:, :)
+      real(dp), allocatable :: analytic(:, :), direct(:, :), numeric(:, :)
       real(dp) :: translation(3)
       real(dp) :: worst, energy
       integer :: natm, ia, ic
@@ -93,11 +93,31 @@ contains
       write (*, "(a,a)") "== ", label
       flush (output_unit)
 
-      call gradient_at(numbers, symbols, coords, basis, aux_basis, nelec, analytic, error)
+      call gradient_at(numbers, symbols, coords, basis, aux_basis, nelec, analytic, &
+                       .false., error)
       if (error%has_error()) then
          write (*, "(a,a)") "FAIL: ", error%get_message()
          n_bad = n_bad + 1
          return
+      end if
+
+      ! The same gradient with the reference integrals recomputed instead of
+      ! stored. Past the in-core limit that is the only path there is, and the
+      ! limit is far above anything a test case reaches -- so it is forced here
+      ! rather than waited for. The two differ only in where the integrals came
+      ! from, so they have to agree to rounding, not to a tolerance.
+      call gradient_at(numbers, symbols, coords, basis, aux_basis, nelec, direct, &
+                       .true., error)
+      if (error%has_error()) then
+         write (*, "(a,a)") "FAIL (direct): ", error%get_message()
+         n_bad = n_bad + 1
+         return
+      end if
+      write (*, "(a,es14.4)") "  stored against recomputed integrals:       ", &
+         maxval(abs(analytic - direct))
+      if (maxval(abs(analytic - direct)) > 1.0e-10_dp) then
+         write (*, "(a)") "  FAIL: the two integral paths disagree"
+         n_bad = n_bad + 1
       end if
 
       call numeric_gradient(numbers, symbols, coords, basis, aux_basis, nelec, &
@@ -146,13 +166,14 @@ contains
    end subroutine check_case
 
    subroutine gradient_at(numbers, symbols, coords, basis, aux_basis, nelec, &
-                          gradient, error)
+                          gradient, force_direct, error)
       integer, intent(in) :: numbers(:)
       character(len=*), intent(in) :: symbols(:)
       real(dp), intent(in) :: coords(:, :)
       character(len=*), intent(in) :: basis, aux_basis
       integer, intent(in) :: nelec
       real(dp), allocatable, intent(out) :: gradient(:, :)
+      logical, intent(in) :: force_direct
       type(error_t), intent(inout) :: error
 
       type(libcint_molecule_t) :: mol, aux
@@ -165,7 +186,8 @@ contains
       call run_libcint_rhf(mol, nelec, 300, 1.0e-14_dp, 1.0e-12_dp, .false., scf, error)
       if (error%has_error()) return
       call libcint_ri_mp2_gradient(mol, aux, scf%orbitals, scf%orbital_energies, &
-                                   nelec/2, gradient, error)
+                                   nelec/2, gradient, error, &
+                                   force_direct=force_direct)
       call mol%destroy()
       call aux%destroy()
    end subroutine gradient_at

--- a/validation/check_ri_mp2_gradient.f90
+++ b/validation/check_ri_mp2_gradient.f90
@@ -1,0 +1,233 @@
+!! The RI-MP2 analytic gradient, against finite differences of its own energy
+program check_ri_mp2_gradient
+   !! No external analytic reference exists for this one: PySCF implements no
+   !! RI-MP2 gradient at all. What plays that role is
+   !! `tools/cpu_validation/ri_mp2_gradient.py`, a numpy reference written
+   !! against the same formulation and itself checked against finite
+   !! differences -- so the printed components here are meant to be compared
+   !! with it component by component, at machine precision rather than at the
+   !! 1e-6 a difference formula can offer.
+   !!
+   !! Finite difference of this program's own RI-MP2 energy is what this file
+   !! asserts, and it is the check that cannot be fooled by a misunderstanding
+   !! shared between the two implementations.
+   !!
+   !! Translational invariance is printed and is worth what it is worth
+   !! elsewhere: during development of the numpy reference the one-particle
+   !! terms were wrong through three revisions while it held at 1e-15.
+   use pic_types, only: dp
+   use mqc_error, only: error_t
+   use mqc_libcint_integrals, only: libcint_molecule_t, build_libcint_molecule
+   use mqc_libcint_rhf, only: rhf_result_t, run_libcint_rhf
+   use mqc_libcint_mp2, only: mp2_result_t, run_libcint_ri_mp2
+   use mqc_libcint_ri_mp2_gradient, only: libcint_ri_mp2_gradient
+   use omp_lib, only: omp_set_num_threads, omp_get_max_threads
+   use, intrinsic :: iso_fortran_env, only: output_unit
+   implicit none
+
+   integer, parameter :: N_DIM = 3
+   integer, parameter :: BENCH_THREADS = 4
+   real(dp), parameter :: STEP = 2.5e-3_dp
+
+   integer :: n_bad
+   character(len=128) :: filter
+   integer :: filter_len, arg_status
+
+   call omp_set_num_threads(min(BENCH_THREADS, omp_get_max_threads()))
+   filter = ""
+   call get_command_argument(1, filter, length=filter_len, status=arg_status)
+   if (arg_status /= 0) filter = ""
+
+   n_bad = 0
+   write (*, "(a)") "== RI-MP2 gradients"
+
+   call check_case("H2 / sto-3g", [1, 1], ["H", "H"], &
+                   reshape([0.0_dp, 0.0_dp, -0.7_dp, &
+                            0.0_dp, 0.0_dp, 0.7_dp], [N_DIM, 2]), &
+                   "sto-3g", "cc-pvdz-rifit", 2, n_bad)
+
+   call check_case("H2O / sto-3g", [8, 1, 1], ["O", "H", "H"], &
+                   reshape([0.0_dp, 0.0_dp, 0.0_dp, &
+                            0.0_dp, -1.4308_dp, 1.1078_dp, &
+                            0.0_dp, 1.4308_dp, 1.1078_dp], [N_DIM, 3]), &
+                   "sto-3g", "cc-pvdz-rifit", 10, n_bad)
+
+   ! Asymmetric, so a term wrong in a way symmetry cancels shows up.
+   call check_case("HCN / sto-3g", [1, 6, 7], ["H", "C", "N"], &
+                   reshape([0.0_dp, 0.0_dp, -2.0_dp, &
+                            0.0_dp, 0.0_dp, 0.0_dp, &
+                            0.0_dp, 0.0_dp, 2.2_dp], [N_DIM, 3]), &
+                   "sto-3g", "cc-pvdz-rifit", 14, n_bad)
+
+   write (*, "(a)") ""
+   if (n_bad == 0) then
+      write (*, "(a)") "all RI-MP2 gradient checks passed"
+   else
+      write (*, "(a,i0,a)") "FAILED: ", n_bad, " case(s)"
+      stop 1
+   end if
+
+contains
+
+   subroutine check_case(label, numbers, symbols, coords, basis, aux_basis, nelec, n_bad)
+      character(len=*), intent(in) :: label
+      integer, intent(in) :: numbers(:)
+      character(len=*), intent(in) :: symbols(:)
+      real(dp), intent(in) :: coords(:, :)
+      character(len=*), intent(in) :: basis, aux_basis
+      integer, intent(in) :: nelec
+      integer, intent(inout) :: n_bad
+
+      real(dp), allocatable :: analytic(:, :), numeric(:, :)
+      real(dp) :: translation(3)
+      real(dp) :: worst, energy
+      integer :: natm, ia, ic
+      type(error_t) :: error
+
+      natm = size(numbers)
+      if (len_trim(filter) > 0) then
+         if (index(label, trim(filter)) == 0) return
+      end if
+
+      write (*, "(a)") ""
+      write (*, "(a,a)") "== ", label
+      flush (output_unit)
+
+      call gradient_at(numbers, symbols, coords, basis, aux_basis, nelec, analytic, error)
+      if (error%has_error()) then
+         write (*, "(a,a)") "FAIL: ", error%get_message()
+         n_bad = n_bad + 1
+         return
+      end if
+
+      call numeric_gradient(numbers, symbols, coords, basis, aux_basis, nelec, &
+                            numeric, error)
+      if (error%has_error()) then
+         write (*, "(a,a)") "FAIL (finite difference): ", error%get_message()
+         n_bad = n_bad + 1
+         return
+      end if
+
+      ! Printed so the components can be read against
+      ! `tools/cpu_validation/ri_mp2_gradient.py`, which is the only
+      ! machine-precision reference there is. The energy goes with them: the
+      ! two codes take their basis data from different places, and a gradient
+      ! of an energy that differs in the ninth decimal differs in the eighth.
+      call energy_at(numbers, symbols, coords, basis, aux_basis, nelec, energy, error)
+      if (error%has_error()) then
+         write (*, "(a,a)") "FAIL (energy): ", error%get_message()
+         n_bad = n_bad + 1
+         return
+      end if
+      write (*, "(a,f18.12)") "  E(RI-MP2) = ", energy
+
+      write (*, "(a)") "  atom        analytic (x, y, z)                            finite difference"
+      do ia = 1, natm
+         write (*, "(i6,3f16.11,3x,3f16.11)") ia, analytic(:, ia), numeric(:, ia)
+      end do
+
+      worst = maxval(abs(analytic - numeric))
+      write (*, "(a,es14.4)") "  largest deviation from finite difference: ", worst
+      do ic = 1, 3
+         translation(ic) = sum(analytic(ic, :))
+      end do
+      write (*, "(a,es14.4)") "  |sum over atoms| (should be zero):        ", &
+         maxval(abs(translation))
+      flush (output_unit)
+
+      if (worst > 1.0e-5_dp) then
+         write (*, "(a)") "  FAIL: analytic and numeric disagree"
+         n_bad = n_bad + 1
+      end if
+      if (maxval(abs(translation)) > 1.0e-8_dp) then
+         write (*, "(a)") "  FAIL: the gradient does not sum to zero"
+         n_bad = n_bad + 1
+      end if
+   end subroutine check_case
+
+   subroutine gradient_at(numbers, symbols, coords, basis, aux_basis, nelec, &
+                          gradient, error)
+      integer, intent(in) :: numbers(:)
+      character(len=*), intent(in) :: symbols(:)
+      real(dp), intent(in) :: coords(:, :)
+      character(len=*), intent(in) :: basis, aux_basis
+      integer, intent(in) :: nelec
+      real(dp), allocatable, intent(out) :: gradient(:, :)
+      type(error_t), intent(inout) :: error
+
+      type(libcint_molecule_t) :: mol, aux
+      type(rhf_result_t) :: scf
+
+      call build_libcint_molecule(numbers, symbols, coords, basis, mol, error)
+      if (error%has_error()) return
+      call build_libcint_molecule(numbers, symbols, coords, aux_basis, aux, error)
+      if (error%has_error()) return
+      call run_libcint_rhf(mol, nelec, 300, 1.0e-14_dp, 1.0e-12_dp, .false., scf, error)
+      if (error%has_error()) return
+      call libcint_ri_mp2_gradient(mol, aux, scf%orbitals, scf%orbital_energies, &
+                                   nelec/2, gradient, error)
+      call mol%destroy()
+      call aux%destroy()
+   end subroutine gradient_at
+
+   subroutine energy_at(numbers, symbols, coords, basis, aux_basis, nelec, energy, error)
+      integer, intent(in) :: numbers(:)
+      character(len=*), intent(in) :: symbols(:)
+      real(dp), intent(in) :: coords(:, :)
+      character(len=*), intent(in) :: basis, aux_basis
+      integer, intent(in) :: nelec
+      real(dp), intent(out) :: energy
+      type(error_t), intent(inout) :: error
+
+      type(libcint_molecule_t) :: mol, aux
+      type(rhf_result_t) :: scf
+      type(mp2_result_t) :: mp2
+
+      energy = 0.0_dp
+      call build_libcint_molecule(numbers, symbols, coords, basis, mol, error)
+      if (error%has_error()) return
+      call build_libcint_molecule(numbers, symbols, coords, aux_basis, aux, error)
+      if (error%has_error()) return
+      call run_libcint_rhf(mol, nelec, 300, 1.0e-14_dp, 1.0e-12_dp, .false., scf, error)
+      if (error%has_error()) return
+      call run_libcint_ri_mp2(mol, aux, scf%orbitals, scf%orbital_energies, nelec/2, &
+                              scf%energy, mp2, error)
+      if (error%has_error()) return
+      energy = mp2%total
+      call mol%destroy()
+      call aux%destroy()
+   end subroutine energy_at
+
+   subroutine numeric_gradient(numbers, symbols, coords, basis, aux_basis, nelec, &
+                               gradient, error)
+      integer, intent(in) :: numbers(:)
+      character(len=*), intent(in) :: symbols(:)
+      real(dp), intent(in) :: coords(:, :)
+      character(len=*), intent(in) :: basis, aux_basis
+      integer, intent(in) :: nelec
+      real(dp), allocatable, intent(out) :: gradient(:, :)
+      type(error_t), intent(inout) :: error
+
+      real(dp), allocatable :: shifted(:, :)
+      real(dp) :: plus, minus
+      integer :: natm, ia, ic
+
+      natm = size(numbers)
+      allocate (gradient(3, natm), shifted(3, natm))
+      gradient = 0.0_dp
+
+      do ia = 1, natm
+         do ic = 1, 3
+            shifted = coords
+            shifted(ic, ia) = coords(ic, ia) + STEP
+            call energy_at(numbers, symbols, shifted, basis, aux_basis, nelec, plus, error)
+            if (error%has_error()) return
+            shifted(ic, ia) = coords(ic, ia) - STEP
+            call energy_at(numbers, symbols, shifted, basis, aux_basis, nelec, minus, error)
+            if (error%has_error()) return
+            gradient(ic, ia) = (plus - minus)/(2.0_dp*STEP)
+         end do
+      end do
+   end subroutine numeric_gradient
+
+end program check_ri_mp2_gradient

--- a/validation/inputs/cpu/mqc/gradient/cpu_nh3_def2-svp_rimp2_grad.json
+++ b/validation/inputs/cpu/mqc/gradient/cpu_nh3_def2-svp_rimp2_grad.json
@@ -1,0 +1,33 @@
+{
+    "schema": {
+        "name": "mqc-frag",
+        "version": "1.0"
+    },
+    "molecules": [
+        {
+            "xyz": "../../../sample_inputs/nh3.xyz",
+            "molecular_charge": 0,
+            "molecular_multiplicity": 1
+        }
+    ],
+    "model": {
+        "method": "ri-mp2",
+        "basis": "def2-svp",
+        "aux_basis": "def2-svp-rifit"
+    },
+    "keywords": {
+        "scf": {
+            "maxiter": 100,
+            "tolerance": 1e-12
+        },
+        "correlation": {
+            "freeze_core": false
+        }
+    },
+    "system": {
+        "logger": {
+            "level": "Verbose"
+        }
+    },
+    "driver": "Gradient"
+}

--- a/validation/inputs/cpu/mqc/gradient/cpu_water_cc-pvdz_rimp2_grad.json
+++ b/validation/inputs/cpu/mqc/gradient/cpu_water_cc-pvdz_rimp2_grad.json
@@ -1,0 +1,33 @@
+{
+    "schema": {
+        "name": "mqc-frag",
+        "version": "1.0"
+    },
+    "molecules": [
+        {
+            "xyz": "../../../sample_inputs/w1.xyz",
+            "molecular_charge": 0,
+            "molecular_multiplicity": 1
+        }
+    ],
+    "model": {
+        "method": "ri-mp2",
+        "basis": "cc-pvdz",
+        "aux_basis": "cc-pvdz-rifit"
+    },
+    "keywords": {
+        "scf": {
+            "maxiter": 100,
+            "tolerance": 1e-12
+        },
+        "correlation": {
+            "freeze_core": false
+        }
+    },
+    "system": {
+        "logger": {
+            "level": "Verbose"
+        }
+    },
+    "driver": "Gradient"
+}

--- a/validation/inputs/cpu/mqc/gradient/cpu_water_sto-3g_rimp2_grad.json
+++ b/validation/inputs/cpu/mqc/gradient/cpu_water_sto-3g_rimp2_grad.json
@@ -1,0 +1,33 @@
+{
+    "schema": {
+        "name": "mqc-frag",
+        "version": "1.0"
+    },
+    "molecules": [
+        {
+            "xyz": "../../../sample_inputs/w1.xyz",
+            "molecular_charge": 0,
+            "molecular_multiplicity": 1
+        }
+    ],
+    "model": {
+        "method": "ri-mp2",
+        "basis": "sto-3g",
+        "aux_basis": "cc-pvdz-rifit"
+    },
+    "keywords": {
+        "scf": {
+            "maxiter": 100,
+            "tolerance": 1e-12
+        },
+        "correlation": {
+            "freeze_core": false
+        }
+    },
+    "system": {
+        "logger": {
+            "level": "Verbose"
+        }
+    },
+    "driver": "Gradient"
+}

--- a/validation/validation_tests_cpu.json
+++ b/validation/validation_tests_cpu.json
@@ -47,7 +47,7 @@
         {
             "name": "RHF HF sto-3g (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_hf_sto-3g.json",
-            "expected_energy": -98.570757663479,
+            "expected_energy": -98.570757663478,
             "type": "unfragmented"
         },
         {
@@ -179,7 +179,7 @@
         {
             "name": "RHF SiH4 3-21g (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_sih4_3-21g.json",
-            "expected_energy": -289.6869142386,
+            "expected_energy": -289.686914238601,
             "type": "unfragmented"
         },
         {
@@ -197,7 +197,7 @@
         {
             "name": "RHF HCl 3-21g (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_hcl_3-21g.json",
-            "expected_energy": -457.86923198705,
+            "expected_energy": -457.869231987049,
             "type": "unfragmented"
         },
         {
@@ -281,19 +281,19 @@
         {
             "name": "RHF SiH4 6-31g (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_sih4_6-31g.json",
-            "expected_energy": -291.173723638596,
+            "expected_energy": -291.173723638595,
             "type": "unfragmented"
         },
         {
             "name": "RHF PH3 6-31g (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_ph3_6-31g.json",
-            "expected_energy": -342.395943319633,
+            "expected_energy": -342.395943319632,
             "type": "unfragmented"
         },
         {
             "name": "RHF H2S 6-31g (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_h2s_6-31g.json",
-            "expected_energy": -398.626664265031,
+            "expected_energy": -398.626664265032,
             "type": "unfragmented"
         },
         {
@@ -377,7 +377,7 @@
         {
             "name": "RHF AlH3 cc-pvdz (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_alh3_cc-pvdz.json",
-            "expected_energy": -243.631755712986,
+            "expected_energy": -243.631755712985,
             "type": "unfragmented"
         },
         {
@@ -389,7 +389,7 @@
         {
             "name": "RHF PH3 cc-pvdz (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_ph3_cc-pvdz.json",
-            "expected_energy": -342.47042849794,
+            "expected_energy": -342.470428497942,
             "type": "unfragmented"
         },
         {
@@ -455,7 +455,7 @@
         {
             "name": "RHF Ne cc-pvtz (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_ne_cc-pvtz.json",
-            "expected_energy": -128.531861636322,
+            "expected_energy": -128.531861636321,
             "type": "unfragmented"
         },
         {
@@ -503,7 +503,7 @@
         {
             "name": "RHF H2S aug-cc-pvdz (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_h2s_aug-cc-pvdz.json",
-            "expected_energy": -398.698035963354,
+            "expected_energy": -398.698035963355,
             "type": "unfragmented"
         },
         {
@@ -521,7 +521,7 @@
         {
             "name": "RHF CH4 def2-svp (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_ch4_def2-svp.json",
-            "expected_energy": -40.169157144341,
+            "expected_energy": -40.169157144342,
             "type": "unfragmented"
         },
         {
@@ -551,7 +551,7 @@
         {
             "name": "RHF SiH4 def2-svp (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_sih4_def2-svp.json",
-            "expected_energy": -291.153923860552,
+            "expected_energy": -291.15392386055,
             "type": "unfragmented"
         },
         {
@@ -647,7 +647,7 @@
         {
             "name": "RHF AlH3 def2-tzvp (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_alh3_def2-tzvp.json",
-            "expected_energy": -243.641284905955,
+            "expected_energy": -243.641284905954,
             "type": "unfragmented"
         },
         {
@@ -677,7 +677,7 @@
         {
             "name": "RHF Ar def2-tzvp (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_ar_def2-tzvp.json",
-            "expected_energy": -526.802760332526,
+            "expected_energy": -526.802760332527,
             "type": "unfragmented"
         },
         {
@@ -707,7 +707,7 @@
         {
             "name": "RHF CH4 6-31g* (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_ch4_6-31g_st_.json",
-            "expected_energy": -40.195141002379,
+            "expected_energy": -40.195141002378,
             "type": "unfragmented"
         },
         {
@@ -749,25 +749,25 @@
         {
             "name": "RHF AlH3 6-31g* (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_alh3_6-31g_st_.json",
-            "expected_energy": -243.616255399695,
+            "expected_energy": -243.616255399696,
             "type": "unfragmented"
         },
         {
             "name": "RHF SiH4 6-31g* (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_sih4_6-31g_st_.json",
-            "expected_energy": -291.225102847642,
+            "expected_energy": -291.225102847643,
             "type": "unfragmented"
         },
         {
             "name": "RHF PH3 6-31g* (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_ph3_6-31g_st_.json",
-            "expected_energy": -342.447342229634,
+            "expected_energy": -342.447342229633,
             "type": "unfragmented"
         },
         {
             "name": "RHF H2S 6-31g* (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_h2s_6-31g_st_.json",
-            "expected_energy": -398.66707086397,
+            "expected_energy": -398.667070863969,
             "type": "unfragmented"
         },
         {
@@ -857,7 +857,7 @@
         {
             "name": "RHF SiH4 6-31g** (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_sih4_6-31g_st__st_.json",
-            "expected_energy": -291.230819820064,
+            "expected_energy": -291.230819820062,
             "type": "unfragmented"
         },
         {
@@ -869,13 +869,13 @@
         {
             "name": "RHF H2S 6-31g** (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_h2s_6-31g_st__st_.json",
-            "expected_energy": -398.674799073106,
+            "expected_energy": -398.674799073107,
             "type": "unfragmented"
         },
         {
             "name": "RHF HCl 6-31g** (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_hcl_6-31g_st__st_.json",
-            "expected_energy": -460.066160564697,
+            "expected_energy": -460.066160564696,
             "type": "unfragmented"
         },
         {
@@ -914,12 +914,12 @@
             "expected_energy": -74.962005712275,
             "expected_gradient": [
                 [
-                    0.0,
+                    -0.0,
                     3.17e-10,
                     -0.067617391053
                 ],
                 [
-                    -0.0,
+                    0.0,
                     -0.016791268482,
                     0.033808695648
                 ],
@@ -939,9 +939,9 @@
             "expected_energy": -40.20167213402,
             "expected_gradient": [
                 [
-                    0.0,
                     -0.0,
-                    0.0
+                    -0.0,
+                    -0.0
                 ],
                 [
                     0.001437398944,
@@ -980,7 +980,7 @@
                 ],
                 [
                     0.005193307714,
-                    0.0,
+                    -0.0,
                     0.000685472868
                 ],
                 [
@@ -1004,19 +1004,19 @@
             "expected_energy": -39.563806767208,
             "expected_gradient": [
                 [
-                    0.0,
+                    -0.0,
                     -0.0,
                     -0.0
                 ],
                 [
                     -0.00167984256,
                     -0.0,
-                    0.0
+                    -0.0
                 ],
                 [
                     0.00083992128,
                     -0.001454786332,
-                    -0.0
+                    0.0
                 ],
                 [
                     0.00083992128,
@@ -1034,7 +1034,7 @@
             "expected_energy": -76.027511701606,
             "expected_gradient": [
                 [
-                    -0.0,
+                    0.0,
                     2.31e-10,
                     0.01008181498
                 ],
@@ -1065,13 +1065,13 @@
                 ],
                 [
                     -0.0,
-                    -0.008465018573,
+                    -0.008465018574,
                     0.013341940487
                 ],
                 [
-                    0.0,
+                    -0.0,
                     0.008465018345,
-                    0.013341940315
+                    0.013341940316
                 ]
             ],
             "gradient_tolerance": 1e-07,
@@ -1081,10 +1081,10 @@
         {
             "name": "PBE gradient H2O cc-pvdz (CPU)",
             "input": "inputs/cpu/mqc/gradient/cpu_water_cc-pvdz_pbe_grad.json",
-            "expected_energy": -76.333065668911,
+            "expected_energy": -76.33306566891,
             "expected_gradient": [
                 [
-                    0.0,
+                    -0.0,
                     2.24e-10,
                     -0.028383098209
                 ],
@@ -1114,7 +1114,7 @@
                     -0.018529027149
                 ],
                 [
-                    -0.0,
+                    0.0,
                     -0.001754068653,
                     0.009264513658
                 ],
@@ -1136,22 +1136,22 @@
                 [
                     -1.25558e-07,
                     0.0,
-                    -0.0
+                    0.0
                 ],
                 [
                     -0.013273613866,
-                    -0.0,
+                    0.0,
                     -0.0
                 ],
                 [
                     0.006636869712,
                     -0.011494995164,
-                    0.0
+                    -0.0
                 ],
                 [
                     0.006636869712,
                     0.011494995164,
-                    -0.0
+                    0.0
                 ]
             ],
             "gradient_tolerance": 1e-07,
@@ -1186,22 +1186,22 @@
         {
             "name": "MP2 gradient H2O cc-pvdz (CPU)",
             "input": "inputs/cpu/mqc/gradient/cpu_water_cc-pvdz_mp2_grad.json",
-            "expected_energy": -76.230274593244,
+            "expected_energy": -76.230274593235,
             "expected_gradient": [
                 [
                     -0.0,
                     2.31e-10,
-                    -0.015697541357
+                    -0.015697541303
                 ],
                 [
                     0.0,
-                    0.002895680112,
-                    0.007848770765
+                    0.002895680161,
+                    0.007848770738
                 ],
                 [
                     0.0,
-                    -0.002895680344,
-                    0.007848770592
+                    -0.002895680392,
+                    0.007848770565
                 ]
             ],
             "gradient_tolerance": 1e-08,
@@ -1211,27 +1211,107 @@
         {
             "name": "MP2 gradient NH3 6-31g (CPU)",
             "input": "inputs/cpu/mqc/gradient/cpu_nh3_6-31g_mp2_grad.json",
-            "expected_energy": -56.277979006773,
+            "expected_energy": -56.277979006782,
+            "expected_gradient": [
+                [
+                    -0.0,
+                    0.0,
+                    -0.014957402913
+                ],
+                [
+                    -0.011578310911,
+                    0.0,
+                    0.004985800971
+                ],
+                [
+                    0.005789155455,
+                    -0.010027111382,
+                    0.004985800971
+                ],
+                [
+                    0.005789155455,
+                    0.010027111382,
+                    0.004985800971
+                ]
+            ],
+            "gradient_tolerance": 1e-08,
+            "check_translation": true,
+            "type": "unfragmented"
+        },
+        {
+            "name": "RI-MP2 gradient H2O sto-3g/cc-pvdz-rifit (CPU)",
+            "input": "inputs/cpu/mqc/gradient/cpu_water_sto-3g_rimp2_grad.json",
+            "expected_energy": -74.997266786568,
+            "expected_gradient": [
+                [
+                    -0.0,
+                    3.09e-10,
+                    -0.100074675812
+                ],
+                [
+                    0.0,
+                    -0.03164266039,
+                    0.050037338027
+                ],
+                [
+                    -0.0,
+                    0.031642660081,
+                    0.050037337785
+                ]
+            ],
+            "gradient_tolerance": 1e-08,
+            "check_translation": true,
+            "type": "unfragmented"
+        },
+        {
+            "name": "RI-MP2 gradient H2O cc-pvdz/cc-pvdz-rifit (CPU)",
+            "input": "inputs/cpu/mqc/gradient/cpu_water_cc-pvdz_rimp2_grad.json",
+            "expected_energy": -76.230257623889,
+            "expected_gradient": [
+                [
+                    -0.0,
+                    2.31e-10,
+                    -0.015717146972
+                ],
+                [
+                    0.0,
+                    0.002913907061,
+                    0.007858573573
+                ],
+                [
+                    -0.0,
+                    -0.002913907293,
+                    0.0078585734
+                ]
+            ],
+            "gradient_tolerance": 1e-08,
+            "check_translation": true,
+            "type": "unfragmented"
+        },
+        {
+            "name": "RI-MP2 gradient NH3 def2-svp/def2-svp-rifit (CPU)",
+            "input": "inputs/cpu/mqc/gradient/cpu_nh3_def2-svp_rimp2_grad.json",
+            "expected_energy": -56.338085238337,
             "expected_gradient": [
                 [
                     -0.0,
                     -0.0,
-                    -0.014957403197
+                    0.008308503754
                 ],
                 [
-                    -0.011578310831,
+                    -0.002395148441,
                     0.0,
-                    0.004985801066
+                    -0.002769501251
                 ],
                 [
-                    0.005789155416,
-                    -0.010027111313,
-                    0.004985801066
+                    0.001197574221,
+                    -0.002074259396,
+                    -0.002769501251
                 ],
                 [
-                    0.005789155416,
-                    0.010027111313,
-                    0.004985801066
+                    0.001197574221,
+                    0.002074259396,
+                    -0.002769501251
                 ]
             ],
             "gradient_tolerance": 1e-08,
@@ -1335,7 +1415,7 @@
         {
             "name": "MP2 H2O def2-svp frozen 1 (CPU)",
             "input": "inputs/cpu/mqc/mp2/cpu_water_def2-svp_mp2_f1.json",
-            "expected_energy": -76.161689337976,
+            "expected_energy": -76.161689337977,
             "type": "unfragmented"
         },
         {
@@ -1365,19 +1445,19 @@
         {
             "name": "CCSD H2O cc-pvdz frozen 1 (CPU)",
             "input": "inputs/cpu/mqc/ccsd/cpu_water_cc-pvdz_ccsd_f1.json",
-            "expected_energy": -76.237533859112,
+            "expected_energy": -76.237533859115,
             "type": "unfragmented"
         },
         {
             "name": "CCSD(T) H2O cc-pvdz frozen 1 (CPU)",
             "input": "inputs/cpu/mqc/ccsd-t/cpu_water_cc-pvdz_ccsdt_f1.json",
-            "expected_energy": -76.240549582971,
+            "expected_energy": -76.24054958297,
             "type": "unfragmented"
         },
         {
             "name": "CCSD(T) CH4 sto-3g frozen 1 (CPU)",
             "input": "inputs/cpu/mqc/ccsd-t/cpu_ch4_sto-3g_ccsdt_f1.json",
-            "expected_energy": -39.805169969887,
+            "expected_energy": -39.805169969877,
             "type": "unfragmented"
         },
         {
@@ -1494,7 +1574,7 @@
         {
             "name": "RI-CCSD H2O sto-3g/cc-pvdz-rifit frozen 0 (CPU)",
             "input": "inputs/cpu/mqc/ri-ccsd/cpu_water_sto-3g_riccsd_f0.json",
-            "expected_energy": -75.01117919517,
+            "expected_energy": -75.011179195171,
             "type": "unfragmented"
         },
         {


### PR DESCRIPTION
Speed up the RI-MP2 gradient, and measure where it actually goes

The follow-up to the correctness commit, and it starts by contradicting the
note that asked for it. That note said `build_gamma`'s five-deep loop was the
ceiling. Instrumented, it is 2% of the wall clock: on water/cc-pVTZ the split
is the Z-vector solve 36%, the differentiated quartets 22%, the fitted
three-centre contraction 16%, the exact integrals 13%, and every fitted step
together about a tenth.

Three changes, none of which moves a number in the answer:

* **The `O(N^5)` steps become gemms.** `B` is repacked into a matrix in the
  compound `(i,a)` index rather than a rank-3 array, which makes
  `(ia|jb)_RI = sum_P B B` one gemm instead of `n_o^2 n_v^2` dot products down
  its longest stride, and makes eq 8 two gemms instead of the loop it reads as.
  Eq 10 loses `n_o n_v` rank-one updates the same way. The repack the previous
  commit added to fix the layout bug is now the shape everything wants, so it
  costs nothing extra.
* **`three_centre_deriv` is threaded.** Each shell triple writes its own block
  and reads nothing another writes, so the outer loop parallelises with no
  reduction. It was serial and is called twice per gradient. The density-fitted
  SCF gradient uses it too and gets the same benefit.
* **A transpose is hoisted out of the component loop.** It depends on the atom
  block and not on the Cartesian direction, so it was the same transpose and
  the same allocation done three times per atom.

Measured warm on a wall clock, both paths timed under the same load because an
earlier benchmark on this branch reported a 1.75x regression that was another
user's load average:

    H2O   / cc-pVDZ   0.046 -> 0.033 s   1.39x
    H2O   / cc-pVTZ   0.617 -> 0.520 s   1.19x
    (H2O)2/ cc-pVDZ   0.496 -> 0.338 s   1.47x
    (H2O)2/ cc-pVTZ  12.289 ->10.988 s   1.12x

The largest case gains least, which is the opposite of what the gemms were
expected to buy and is worth stating rather than burying. These molecules grow
their basis at a fixed electron count, and that is exactly the regime where
`n_ao^4` outruns `n_occ^2 n_vir^2 n_aux` -- so the reference terms take a
*larger* share at cc-pVTZ, not a smaller one. The gemms are still the right
shape for a case with many electrons rather than many functions per electron;
no such case is cheap enough to sit in a benchmark that has to finish, so that
remains an argument rather than a measurement, and the benchmark says so.

Unchanged, verified rather than assumed: RI-MP2 against finite difference at
1.6e-6, 9.3e-7 and 5.4e-6, stored against recomputed integrals at 5e-16 to
9e-13, the conventional MP2 gradient on all five cases and both paths, the
fitted CPHF identity at 3e-16, the SCF gradient harness (which exercises the
newly threaded routine through the density-fitted path), and all 16 gradient
validation cases.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>