### PR TITLE
keep hand-maintained cases in the manifest across a regeneration

### DIFF
--- a/tools/cpu_validation/gen_cpu_validation.py
+++ b/tools/cpu_validation/gen_cpu_validation.py
@@ -1558,6 +1558,32 @@ def main():
         print(f"{mol.label:6s} {basis:12s} sapt0    "
               f"elst={terms['Elst10,r']:+.9f} exch={terms['Exch10']:+.9f} "
               f"E={energy:.12f}", flush=True)
+    # Carry the hand-maintained entries through the regeneration.
+    #
+    # HAND_MAINTAINED spares those *decks* from the sweep below, but the manifest
+    # is rebuilt from `tests` alone and this script cannot produce their entries:
+    # EFP2's reference is GAMESS, not PySCF, and MAKEFP returns a potential
+    # rather than an energy. So every regeneration silently dropped them while
+    # leaving the decks on disk -- coverage that still looks present and no
+    # longer runs, which is worse than coverage that is visibly gone. That is
+    # exactly what happened to the two EFP2 cases: the decks are in the tree and
+    # the manifest has not mentioned them since whenever this was last rerun.
+    #
+    # Read back what is there, keep the entries whose deck is hand-maintained,
+    # and re-emit them. An entry this run *did* generate wins, so a case that
+    # graduates to being generated is not duplicated by its own history.
+    if MANIFEST.exists():
+        generated_inputs = {t["input"] for t in tests}
+        try:
+            previous = json.loads(MANIFEST.read_text())
+        except json.JSONDecodeError:
+            previous = {"tests": []}
+        for entry in previous.get("tests", []):
+            deck = entry.get("input", "")
+            rel = deck[len("inputs/"):] if deck.startswith("inputs/") else deck
+            if rel in HAND_MAINTAINED and deck not in generated_inputs:
+                tests.append(entry)
+                print(f"kept hand-maintained {deck}", flush=True)
 
     manifest = {"description": DESCRIPTION, "tolerance": TOLERANCE, "tests": tests}
     if args.dry_run:


### PR DESCRIPTION
## Finding: main isn't running its EFP2 validation cases at all

The two EFP2 validation cases aren't being run. Their decks are in the tree at `validation/inputs/cpu/mqc/efp/`, but **main's manifest has 212 entries and mentions neither** — nor makefp, nor anything else the generator can't produce. Nothing failed when that happened: the files are still there, so the coverage still *looks* present. (Merging SAPT restored the two entries as a side effect; this stops it recurring.)

## Why it happened

`HAND_MAINTAINED` was only half a guard. It spares those decks from the stale sweep — which is why they survive on disk — but the manifest is rebuilt from `tests` alone, and `tests` is what the generator produced. It can't produce these: EFP2's reference is GAMESS rather than PySCF, and MAKEFP writes a potential rather than returning an energy. So each regeneration wrote a manifest without them.

## Fix

Read the existing manifest back, keep the entries whose deck is on the hand-maintained list, and re-emit them. An entry this run generated wins, so a case that graduates to being produced here is replaced rather than duplicated by its own history.

Checked both ways rather than by reading: a regeneration emitting only an RHF case keeps both EFP2 entries where it used to drop them, and one emitting the EFP2 deck itself yields a single entry carrying the new number.

## Beyond EFP2

This also rescues the four FMO decks that **#6** adds — they're added to `HAND_MAINTAINED` for the sweep, so without this they'd keep their files but lose their manifest entries the same way. The makefp decks have no entries to lose today, and would hit the same problem if they gained any.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
