### PR TITLE
Mulliken and CHELPG atomic charges

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -557,6 +557,12 @@ if(MQC_ENABLE_LIBCINT)
   target_link_libraries(check_mp2_gradient PRIVATE ${main_lib} cint_fortran
                                                    cint)
 
+  add_executable(check_charges
+                 ${PROJECT_SOURCE_DIR}/validation/check_charges.f90)
+  target_include_directories(check_charges
+                             PRIVATE "${CMAKE_BINARY_DIR}/modules")
+  target_link_libraries(check_charges PRIVATE ${main_lib} cint_fortran cint)
+
   add_executable(check_direct ${PROJECT_SOURCE_DIR}/validation/check_direct.f90)
   target_include_directories(check_direct PRIVATE "${CMAKE_BINARY_DIR}/modules")
   target_link_libraries(check_direct PRIVATE ${main_lib} cint_fortran cint)

--- a/backends/libcint/CMakeLists.txt
+++ b/backends/libcint/CMakeLists.txt
@@ -23,6 +23,7 @@ target_sources(
           mqc_libcint_cphf.f90
           mqc_libcint_dma.f90
           mqc_libcint_esp.f90
+          mqc_libcint_charges.f90
           mqc_libcint_screening.f90
           mqc_libcint_projection.f90
           mqc_libcint_rhf.f90

--- a/backends/libcint/mqc_libcint_bridge.f90
+++ b/backends/libcint/mqc_libcint_bridge.f90
@@ -39,6 +39,7 @@ module mqc_libcint_bridge
 
    public :: run_libcint_hf
    public :: run_libcint_makefp
+   public :: run_libcint_charges
    public :: run_libcint_efp
    public :: run_libcint_sapt0
    public :: libcint_backend_available
@@ -50,6 +51,70 @@ contains
       logical :: available
       available = .true.
    end function libcint_backend_available
+
+   subroutine run_libcint_charges(atomic_numbers, element_symbols, coordinates, &
+                                  basis_name, scheme, total_charge, charges, error)
+      !! Atomic charges from an RHF density, by Mulliken or CHELPG
+      !!
+      !! Here rather than in `src/interface/` for the reason every other entry in
+      !! this file is: the molecule builder, the SCF and both partition schemes
+      !! live in the CPU backend. A C API reaching for them directly compiles
+      !! under CMake with the backend on and nothing else -- not the stub build,
+      !! and not FPM, which only sees `src/` and `app/`.
+      !!
+      !! Closed shell only; an odd electron count is refused rather than paired
+      !! up, because a caller fragmenting a radical needs to know this cannot
+      !! answer for it.
+      use pic_types, only: dp
+      use mqc_libcint_integrals, only: libcint_molecule_t, build_libcint_molecule
+      use mqc_libcint_charges, only: mulliken_charges, chelpg_charges
+      use mqc_libcint_rhf, only: rhf_result_t, run_libcint_rhf
+      integer, intent(in) :: atomic_numbers(:)
+      character(len=*), intent(in) :: element_symbols(:)
+      real(dp), intent(in) :: coordinates(:, :)     !! (3, n), Bohr
+      character(len=*), intent(in) :: basis_name
+      character(len=*), intent(in) :: scheme        !! "mulliken" or "chelpg"
+      integer, intent(in) :: total_charge
+      real(dp), allocatable, intent(out) :: charges(:)
+      type(error_t), intent(inout) :: error
+
+      integer, parameter :: SCF_MAX_ITER = 100
+      real(dp), parameter :: SCF_ENERGY_TOL = 1.0e-9_dp
+      real(dp), parameter :: SCF_DENSITY_TOL = 1.0e-7_dp
+
+      type(libcint_molecule_t) :: mol
+      type(rhf_result_t) :: scf
+      real(dp), allocatable :: overlap(:, :)
+      integer :: nelec
+
+      nelec = sum(atomic_numbers) - total_charge
+      if (mod(nelec, 2) /= 0) then
+         call error%set(ERROR_VALIDATION, "atomic charges come from a closed-shell "// &
+                        "RHF and this system has an odd number of electrons")
+         return
+      end if
+
+      call build_libcint_molecule(atomic_numbers, element_symbols, coordinates, &
+                                  basis_name, mol, error)
+      if (error%has_error()) return
+
+      call run_libcint_rhf(mol, nelec, SCF_MAX_ITER, SCF_ENERGY_TOL, SCF_DENSITY_TOL, &
+                           .false., scf, error)
+      if (error%has_error()) return
+      if (.not. scf%converged) then
+         call error%set(ERROR_VALIDATION, "the SCF did not converge, so there is no "// &
+                        "density to partition")
+         return
+      end if
+
+      if (scheme == "mulliken") then
+         call mol%overlap(overlap)
+         call mulliken_charges(mol, scf%density, overlap, charges, error)
+      else
+         call chelpg_charges(mol, scf%density, charges, error, &
+                             total_charge=real(total_charge, dp))
+      end if
+   end subroutine run_libcint_charges
 
    subroutine run_libcint_efp(potentials, fragment_sizes, fragment_atoms, &
                               coordinates, terms, error)

--- a/backends/libcint/mqc_libcint_charges.f90
+++ b/backends/libcint/mqc_libcint_charges.f90
@@ -1,0 +1,277 @@
+!! Atomic partial charges, by population analysis and by potential fitting
+module mqc_libcint_charges
+   !! Two schemes that answer the same question differently, and disagree for a
+   !! reason worth knowing.
+   !!
+   !! **Mulliken** splits the density by which basis functions carry it, halving
+   !! every overlap between the two atoms it spans. It costs one trace and is
+   !! notoriously basis-set dependent -- add diffuse functions centred on one
+   !! atom and its share of a neighbour's density grows, without the molecule
+   !! having changed. Good for a trend, bad for a number.
+   !!
+   !! **CHELPG** asks what point charges would reproduce the molecule's own
+   !! electrostatic potential on a grid of points outside it, and solves for
+   !! them. That is a physically meaningful question -- the potential is an
+   !! observable of the density -- and the answer is far less basis-set
+   !! sensitive. It costs an ESP evaluation on a few thousand points, which in
+   !! practice is not the expensive part: both schemes need the same SCF, and on
+   !! 24 to 32 atoms in 6-31G the whole CHELPG step adds about two seconds to an
+   !! eighteen-second calculation. Choosing the cheaper scheme buys ~10%, so
+   !! choose on which answer you want rather than on cost.
+   !!
+   !! For embedding one fragment in the field of another, CHELPG is the one that
+   !! matters: the whole point is to reproduce a field, and that is what it is
+   !! fitted to do.
+   use pic_types, only: dp
+   use pic_lapack_interfaces, only: pic_getrf, pic_getrs
+   use pic_logger, only: logger => global_logger
+   use pic_io, only: to_char
+   use mqc_error, only: error_t, ERROR_VALIDATION
+   use mqc_elements, only: element_vdw_radius
+   use mqc_libcint_integrals, only: libcint_molecule_t, shell_dim
+   use mqc_libcint_esp, only: esp_contract
+   use libcint_fortran, only: LIBCINT_BAS_SLOTS, LIBCINT_ATOM_OF
+   implicit none
+   private
+
+   public :: mulliken_charges
+   public :: chelpg_charges
+   public :: chelpg_grid
+
+   !> Grid spacing, Angstrom. Breneman and Wiberg's value.
+   real(dp), parameter :: CHELPG_SPACING = 0.3_dp
+   !> How far past the van der Waals surface points are kept, Angstrom.
+   !>
+   !> Both a box margin and a cutoff: the lattice extends this far beyond the
+   !> molecule, and a point further than this from every atom is dropped. The
+   !> shell that survives is where a neighbouring molecule's electrons would
+   !> actually sit, which is the region the charges have to get right.
+   real(dp), parameter :: CHELPG_HEAD_SPACE = 2.8_dp
+   real(dp), parameter :: ANGSTROM_TO_BOHR = 1.8897261254578281_dp
+
+contains
+
+   subroutine ao_to_atom(mol, owner)
+      !! Which atom each basis function belongs to
+      type(libcint_molecule_t), intent(in) :: mol
+      integer, allocatable, intent(out) :: owner(:)
+
+      integer :: ish, k, first, dim
+
+      allocate (owner(mol%nao))
+      do ish = 1, mol%nbas
+         first = mol%shell_offset(ish)
+         dim = shell_dim(mol%cartesian, ish - 1, mol%bas)
+         do k = 1, dim
+            ! libcint's ATOM_OF is 0-based, as is shell_offset.
+            owner(first + k) = mol%bas(LIBCINT_ATOM_OF, ish) + 1
+         end do
+      end do
+   end subroutine ao_to_atom
+
+   subroutine mulliken_charges(mol, density, overlap, charges, error)
+      !! q_A = Z_A - sum_{mu in A} (D S)_mu,mu
+      !!
+      !! The diagonal of `D S` is the gross population of each basis function,
+      !! and summing it over an atom's functions charges that atom with every
+      !! overlap it takes part in, half of which belongs to its neighbour. That
+      !! halving is the whole of Mulliken's arbitrariness and the whole of its
+      !! cheapness.
+      type(libcint_molecule_t), intent(in) :: mol
+      real(dp), intent(in) :: density(:, :), overlap(:, :)
+      real(dp), allocatable, intent(out) :: charges(:)
+      type(error_t), intent(inout) :: error
+
+      integer, allocatable :: owner(:)
+      real(dp) :: population
+      integer :: mu, nu
+
+      if (size(density, 1) /= mol%nao .or. size(overlap, 1) /= mol%nao) then
+         call error%set(ERROR_VALIDATION, "mulliken charges: density and overlap must "// &
+                        "be the size of the basis")
+         return
+      end if
+
+      call ao_to_atom(mol, owner)
+      allocate (charges(mol%natm))
+      charges = mol%charges     !! nuclear charge to start from
+
+      do mu = 1, mol%nao
+         population = 0.0_dp
+         do nu = 1, mol%nao
+            population = population + density(mu, nu)*overlap(nu, mu)
+         end do
+         charges(owner(mu)) = charges(owner(mu)) - population
+      end do
+   end subroutine mulliken_charges
+
+   subroutine chelpg_grid(mol, points, error, spacing, head_space)
+      !! The shell of points a CHELPG fit is made on
+      !!
+      !! A cubic lattice over the molecule's bounding box, grown by
+      !! `head_space`, keeping points that are outside every atom's van der
+      !! Waals sphere and within `head_space` of at least one atom.
+      !!
+      !! Both tests matter and for different reasons. Inside a sphere the
+      !! classical potential of a point charge diverges while the real one does
+      !! not, so fitting there would fit nonsense. Far outside, every charge
+      !! distribution with the right multipoles looks alike, so points there
+      !! carry no information about where the charge sits and would dilute the
+      !! points that do.
+      type(libcint_molecule_t), intent(in) :: mol
+      real(dp), allocatable, intent(out) :: points(:, :)
+      type(error_t), intent(inout) :: error
+      real(dp), intent(in), optional :: spacing, head_space
+
+      real(dp), allocatable :: keep(:, :), radii(:)
+      real(dp) :: lo(3), hi(3), r(3)
+      real(dp) :: h, margin, d, dmin
+      integer :: nx(3)
+      integer :: i, j, k, iatom, n_keep, pass
+      logical :: inside
+
+      h = CHELPG_SPACING
+      if (present(spacing)) h = spacing
+      margin = CHELPG_HEAD_SPACE
+      if (present(head_space)) margin = head_space
+      h = h*ANGSTROM_TO_BOHR
+      margin = margin*ANGSTROM_TO_BOHR
+
+      allocate (radii(mol%natm))
+      do iatom = 1, mol%natm
+         radii(iatom) = element_vdw_radius(nint(mol%charges(iatom)))*ANGSTROM_TO_BOHR
+         if (radii(iatom) <= 0.0_dp) then
+            call error%set(ERROR_VALIDATION, "chelpg: no van der Waals radius for element "// &
+                           to_char(nint(mol%charges(iatom)))//", so the excluded region "// &
+                           "around it is undefined")
+            return
+         end if
+      end do
+
+      do i = 1, 3
+         lo(i) = minval(mol%coords(i, :)) - margin
+         hi(i) = maxval(mol%coords(i, :)) + margin
+         nx(i) = int((hi(i) - lo(i))/h) + 1
+      end do
+
+      ! Counted, then filled. The alternative is growing an array point by point
+      ! over a lattice that is tens of thousands of candidates wide.
+      n_keep = 0
+      do pass = 1, 2
+         if (pass == 2) then
+            allocate (keep(3, max(n_keep, 1)))
+            n_keep = 0
+         end if
+         do k = 0, nx(3) - 1
+            do j = 0, nx(2) - 1
+               do i = 0, nx(1) - 1
+                  r = [lo(1) + i*h, lo(2) + j*h, lo(3) + k*h]
+                  inside = .false.
+                  dmin = huge(1.0_dp)
+                  do iatom = 1, mol%natm
+                     d = norm2(r - mol%coords(:, iatom))
+                     if (d < radii(iatom)) then
+                        inside = .true.
+                        exit
+                     end if
+                     dmin = min(dmin, d)
+                  end do
+                  if (inside) cycle
+                  if (dmin > margin) cycle
+                  n_keep = n_keep + 1
+                  if (pass == 2) keep(:, n_keep) = r
+               end do
+            end do
+         end do
+      end do
+
+      if (n_keep < mol%natm + 1) then
+         call error%set(ERROR_VALIDATION, "chelpg: the grid kept "//to_char(n_keep)// &
+                        " points, fewer than the "//to_char(mol%natm + 1)//" unknowns "// &
+                        "the fit has; use a finer spacing or a larger head space")
+         return
+      end if
+
+      allocate (points(3, n_keep), source=keep(:, 1:n_keep))
+   end subroutine chelpg_grid
+
+   subroutine chelpg_charges(mol, density, charges, error, total_charge, spacing, head_space)
+      !! Point charges that best reproduce the molecule's own potential
+      !!
+      !! Least squares over the grid, constrained to the right total charge:
+      !!
+      !!     minimise  sum_g ( V(g) - sum_A q_A / |r_g - R_A| )^2
+      !!     subject to  sum_A q_A = Q
+      !!
+      !! which is a linear system in `q` and one Lagrange multiplier. The
+      !! multiplier is why the matrix is `natm+1` square and why it is symmetric
+      !! but not positive definite -- so it is factorised generally rather than
+      !! by Cholesky.
+      type(libcint_molecule_t), intent(in) :: mol
+      real(dp), intent(in) :: density(:, :)
+      real(dp), allocatable, intent(out) :: charges(:)
+      type(error_t), intent(inout) :: error
+      real(dp), intent(in), optional :: total_charge
+      real(dp), intent(in), optional :: spacing, head_space
+
+      real(dp), allocatable :: points(:, :), v(:), inv_d(:, :), a(:, :), rhs(:, :)
+      integer, allocatable :: ipiv(:)
+      real(dp) :: q_total, d
+      integer :: n, npt, iatom, jatom, g, info
+
+      n = mol%natm
+      q_total = 0.0_dp
+      if (present(total_charge)) q_total = total_charge
+
+      call chelpg_grid(mol, points, error, spacing, head_space)
+      if (error%has_error()) return
+      npt = size(points, 2)
+
+      ! The potential the molecule actually makes: electrons from the density,
+      ! nuclei by Coulomb's law. `esp_contract` returns the electronic part
+      ! already negative, so the two are added rather than subtracted.
+      call esp_contract(mol, points, density, v, error)
+      if (error%has_error()) return
+
+      allocate (inv_d(n, npt))
+      do g = 1, npt
+         do iatom = 1, n
+            d = norm2(points(:, g) - mol%coords(:, iatom))
+            inv_d(iatom, g) = 1.0_dp/d
+            v(g) = v(g) + mol%charges(iatom)/d
+         end do
+      end do
+
+      ! `rhs` is a one-column matrix because the solver takes a rank-two
+      ! right-hand side; there is only ever one system here.
+      allocate (a(n + 1, n + 1), rhs(n + 1, 1), ipiv(n + 1))
+      a = 0.0_dp
+      rhs = 0.0_dp
+      do iatom = 1, n
+         do jatom = 1, n
+            a(iatom, jatom) = sum(inv_d(iatom, :)*inv_d(jatom, :))
+         end do
+         rhs(iatom, 1) = sum(v*inv_d(iatom, :))
+         a(iatom, n + 1) = 1.0_dp
+         a(n + 1, iatom) = 1.0_dp
+      end do
+      rhs(n + 1, 1) = q_total
+
+      call pic_getrf(a, ipiv, info)
+      if (info /= 0) then
+         call error%set(ERROR_VALIDATION, "chelpg: the fit matrix is singular, which "// &
+                        "means two atoms are indistinguishable to every grid point")
+         return
+      end if
+      call pic_getrs(a, ipiv, rhs, info=info)
+      if (info /= 0) then
+         call error%set(ERROR_VALIDATION, "chelpg: the constrained fit would not solve")
+         return
+      end if
+
+      allocate (charges(n), source=rhs(1:n, 1))
+      call logger%verbose("  chelpg: fitted "//to_char(n)//" charges to "// &
+                          to_char(npt)//" grid points")
+   end subroutine chelpg_charges
+
+end module mqc_libcint_charges

--- a/python/examples/charges.py
+++ b/python/examples/charges.py
@@ -1,0 +1,176 @@
+"""Atomic partial charges, and what they are for.
+
+    python charges.py
+
+Two schemes are exposed, and the interesting part is where they disagree.
+
+**Mulliken** divides the density by which basis function carries it. Cheap --
+one trace over `D S` -- and it inherits every arbitrariness of the basis,
+because a function's atom label is what assigns its density and a diffuse
+function centred on hydrogen reaches well over the oxygen while still counting
+as hydrogen's.
+
+**CHELPG** asks a physical question instead: what point charges reproduce the
+molecule's own electrostatic potential on a shell of points outside its van der
+Waals surface. Costs an SCF plus an ESP evaluation on a few thousand points,
+and the answer barely moves when the basis changes.
+
+The last case here is the one that decides which to use, and it is a
+measurement rather than an assertion of taste: the same water in two bases.
+
+Run as a test rather than a demonstration: each case asserts, and the script
+exits non-zero if any of them is wrong.
+"""
+
+import sys
+
+import mqc
+
+#: Water, Angstrom. The C API converts; internals are Bohr.
+WATER = dict(
+    symbols=["O", "H", "H"],
+    coords=[[0.0, 0.0, 0.0], [0.0, -0.7572, 0.5865], [0.0, 0.7572, 0.5865]],
+)
+
+def system(spec, charge=0):
+    s = mqc.System()
+    s.set_geometry(spec["symbols"], spec["coords"], charge=charge)
+    return s
+
+
+def show(label, symbols, q):
+    body = "  ".join(f"{s}{i} {v:+.4f}" for i, (s, v) in enumerate(zip(symbols, q)))
+    print(f"  {label:10s} {body}")
+
+
+def case_both_schemes():
+    """Both schemes on water, and the properties any scheme has to have."""
+    print("water, 6-31G")
+    for scheme in ("mulliken", "chelpg"):
+        s = system(WATER).compute_charges(scheme=scheme, basis="6-31g")
+        q = s.charges()
+        show(scheme, WATER["symbols"], q)
+
+        # They sum to the molecular charge. For CHELPG that is the constraint
+        # the fit is solved under; for Mulliken it is an identity of the trace.
+        assert abs(sum(q)) < 1e-8, f"{scheme} charges sum to {sum(q)}"
+        # Oxygen is the electronegative one and both schemes must say so.
+        assert q[0] < 0 < q[1], f"{scheme} got the polarity backwards"
+        # The two hydrogens are related by symmetry. CHELPG's grid is a cubic
+        # lattice that does not share the molecule's symmetry, so it gets a
+        # loose tolerance; Mulliken has no such excuse.
+        tol = 5e-3 if scheme == "chelpg" else 1e-9
+        assert abs(q[1] - q[2]) < tol, f"{scheme} split equivalent hydrogens"
+
+        # The single-atom accessor agrees with the vector.
+        assert abs(s.charge_on(0) - q[0]) < 1e-14
+        # And the handle remembers which question it answered.
+        assert s.charge_scheme == scheme, f"handle says {s.charge_scheme!r}"
+
+
+def case_total_charge():
+    """A charged system: the fit is constrained to the charge, not to zero."""
+    print("hydroxide, 6-31G")
+    s = mqc.System()
+    s.set_geometry(["O", "H"], [[0.0, 0.0, 0.0], [0.0, 0.0, 0.97]], charge=-1)
+    s.compute_charges(scheme="chelpg", basis="6-31g")
+    q = s.charges()
+    show("chelpg", ["O", "H"], q)
+    assert abs(sum(q) + 1.0) < 1e-8, f"charges sum to {sum(q)}, not -1"
+
+
+def case_basis_sensitivity():
+    """The measurement that decides which scheme to feed downstream."""
+    print("water: how much does the basis move the answer?")
+    moved = {}
+    for scheme in ("mulliken", "chelpg"):
+        small = system(WATER).compute_charges(scheme=scheme, basis="6-31g").charges()
+        big = system(WATER).compute_charges(scheme=scheme, basis="aug-cc-pvdz").charges()
+        moved[scheme] = max(abs(b - a) for a, b in zip(small, big))
+        print(
+            f"  {scheme:10s} O {small[0]:+.4f} -> {big[0]:+.4f}"
+            f"    largest move {moved[scheme]:.4f}"
+        )
+
+    # The whole reason CHELPG is here. Not a close call in practice -- Mulliken
+    # moves by about half an electron on the oxygen -- so the assertion is
+    # generous and would still catch the two being swapped.
+    assert moved["chelpg"] < moved["mulliken"], (
+        "CHELPG moved at least as much as Mulliken between bases, which is the "
+        "opposite of why it is exposed"
+    )
+    print(f"  -> CHELPG is {moved['mulliken'] / moved['chelpg']:.1f}x the more stable")
+
+
+def case_errors():
+    """The failure paths report rather than returning something plausible."""
+    print("failure paths")
+    s = system(WATER)
+    assert not s.has_charges
+    assert s.charge_scheme == "", "an uncomputed handle claims a scheme"
+
+    for fn, what in (
+        (lambda: s.charges(), "reading before computing"),
+        (lambda: s.charge_on(0), "one atom before computing"),
+    ):
+        try:
+            fn()
+        except mqc.MQCError:
+            print(f"  ok  {what} raises")
+        else:
+            raise AssertionError(f"{what} did not raise")
+
+    s.compute_charges(basis="6-31g")
+    assert s.has_charges
+
+    try:
+        s.charge_on(99)
+    except mqc.MQCError:
+        print("  ok  an index past the end raises")
+    else:
+        raise AssertionError("an out-of-range index did not raise")
+
+    try:
+        s.compute_charges(scheme="lowdin")
+    except mqc.MQCError:
+        print("  ok  an unimplemented scheme raises rather than falling back")
+    else:
+        raise AssertionError("an unknown scheme did not raise")
+
+    # Closed-shell RHF only. A radical has to be refused rather than quietly
+    # paired up, because a caller fragmenting one needs to know.
+    r = mqc.System()
+    r.set_geometry(["H"], [[0.0, 0.0, 0.0]])
+    try:
+        r.compute_charges(basis="6-31g")
+    except mqc.MQCError:
+        print("  ok  an odd electron count raises")
+    else:
+        raise AssertionError("an open-shell system did not raise")
+
+
+CASES = {
+    "schemes": case_both_schemes,
+    "total-charge": case_total_charge,
+    "basis": case_basis_sensitivity,
+    "errors": case_errors,
+}
+
+
+def main(argv):
+    wanted = argv[1] if len(argv) > 1 else ""
+    ran = 0
+    for name, fn in CASES.items():
+        if wanted and wanted not in name:
+            continue
+        fn()
+        ran += 1
+    if ran == 0:
+        print(f"no case matching {wanted!r}; have: {', '.join(CASES)}")
+        return 1
+    print(f"\n{ran} case(s) passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/python/mqc/__init__.py
+++ b/python/mqc/__init__.py
@@ -308,6 +308,91 @@ class System:
             )
         return value
 
+    def compute_charges(self, scheme="chelpg", basis="6-31g"):
+        """Run one RHF and keep its atomic partial charges.
+
+        Unlike `compute_bond_orders`, this costs a real SCF in the basis you
+        name -- xTB is cheap enough to point at anything, an RHF is not. On a
+        large system pick the basis deliberately.
+
+        `scheme` is "chelpg" or "mulliken". Prefer CHELPG unless the question
+        is specifically about basis-function populations: on water, going from
+        6-31G to aug-cc-pVDZ moves the Mulliken charge on oxygen from -0.79 to
+        -0.30, while CHELPG moves from -0.94 to -0.74. The molecule did not
+        change; one of the two numbers is mostly reporting the basis.
+
+        Closed shell only -- an odd electron count raises rather than being
+        quietly paired up.
+        """
+        if _ffi.system_compute_charges is None:
+            raise MQCError(
+                "charges need the libcint integrals backend, and this build "
+                "does not have it. Reconfigure with -DMQC_ENABLE_LIBCINT=ON."
+            )
+        which = scheme.encode("utf-8")
+        name = basis.encode("utf-8")
+        _check(
+            _ffi.system_compute_charges(
+                self._handle, len(which), which, len(name), name
+            ),
+            _ffi.system_last_error,
+        )
+        return self
+
+    @property
+    def has_charges(self):
+        """Whether `compute_charges` has run on this system."""
+        if _ffi.system_has_charges is None:
+            return False
+        return bool(_ffi.system_has_charges(self._handle))
+
+    @property
+    def charge_scheme(self):
+        """Which scheme produced the current charges, or "" if none have been.
+
+        Worth checking before comparing charges between systems: Mulliken and
+        CHELPG disagree by design, so the numbers are only comparable if they
+        came from the same question.
+        """
+        if _ffi.system_charge_scheme is None:
+            return ""
+        buf = ctypes.create_string_buffer(32)
+        _ffi.system_charge_scheme(self._handle, 32, buf)
+        return buf.value.decode("utf-8", "replace")
+
+    def charges(self):
+        """The partial charges, one per atom, in input order.
+
+        They sum to the molecular charge -- for CHELPG because the fit is
+        solved under that constraint, for Mulliken because the trace says so.
+        """
+        if _ffi.system_get_charges is None:
+            raise MQCError("this build has no charges; see compute_charges()")
+        n = self.n_atoms
+        buf = (_ffi._c_double * max(n, 1))()
+        _check(
+            _ffi.system_get_charges(self._handle, n, buf),
+            _ffi.system_last_error,
+        )
+        return [buf[i] for i in range(n)]
+
+    def charge_on(self, i):
+        """One atom, 0-based. Raises if the charges have not been computed.
+
+        A partial charge is legitimately negative, so there is no sentinel
+        value available; the binding returns NaN and this turns it into an
+        exception rather than letting it propagate into arithmetic.
+        """
+        if _ffi.system_charge_on is None:
+            raise MQCError("this build has no charges; see compute_charges()")
+        value = float(_ffi.system_charge_on(self._handle, int(i)))
+        if value != value:  # NaN
+            raise MQCError(
+                "charge unavailable: compute_charges() first, and check the "
+                "atom index is in range"
+            )
+        return value
+
     @property
     def n_atoms(self):
         return int(_ffi.system_n_atoms(self._handle))

--- a/python/mqc/_ffi.py
+++ b/python/mqc/_ffi.py
@@ -58,6 +58,20 @@ def _declare(name, restype, argtypes):
     return fn
 
 
+def _declare_optional(name, restype, argtypes):
+    """A symbol that a valid build may legitimately not have.
+
+    Some of the library is behind a CMake option, and a build without that
+    option is not a broken build -- it simply cannot answer those questions.
+    Returning None lets the caller say so in one sentence, where a bare
+    getattr would abort the import of the whole package.
+    """
+    try:
+        return _declare(name, restype, argtypes)
+    except AttributeError:
+        return None
+
+
 # -- session ---------------------------------------------------------------
 session_begin = _declare("mqc_session_begin", _c_int, [])
 session_end = _declare("mqc_session_end", _c_int, [])
@@ -92,6 +106,23 @@ system_get_bond_orders = _declare(
 )
 system_bond_order = _declare(
     "mqc_system_bond_order", _c_double, [_c_ptr, _c_int, _c_int]
+)
+# Absent from a build without libcint: charges need a real density, and there
+# is no density without an integrals backend.
+system_compute_charges = _declare_optional(
+    "mqc_system_compute_charges",
+    _c_int,
+    [_c_ptr, _c_int, _c_str, _c_int, _c_str],
+)
+system_has_charges = _declare_optional("mqc_system_has_charges", _c_int, [_c_ptr])
+system_get_charges = _declare_optional(
+    "mqc_system_get_charges", _c_int, [_c_ptr, _c_int, ctypes.POINTER(_c_double)]
+)
+system_charge_on = _declare_optional(
+    "mqc_system_charge_on", _c_double, [_c_ptr, _c_int]
+)
+system_charge_scheme = _declare_optional(
+    "mqc_system_charge_scheme", None, [_c_ptr, _c_int, _c_str]
 )
 system_n_atoms = _declare("mqc_system_n_atoms", _c_int, [_c_ptr])
 system_n_monomers = _declare("mqc_system_n_monomers", _c_int, [_c_ptr])

--- a/src/core/mqc_elements.f90
+++ b/src/core/mqc_elements.f90
@@ -11,6 +11,7 @@ module mqc_elements
    public :: element_number_to_symbol  !! Convert atomic number to element symbol
    public :: element_mass              !! Get atomic mass by atomic number
    public :: element_covalent_radius   !! Get covalent radius by atomic number
+   public :: element_vdw_radius        !! Get van der Waals radius by atomic number
    ! TODO: refactr to use findloc
    ! Periodic table data as module-level parameters
    integer, parameter :: n_elements = 118
@@ -49,6 +50,23 @@ module mqc_elements
                           243.0_dp, 247.0_dp, 247.0_dp, 251.0_dp, 252.0_dp, 257.0_dp, 258.0_dp, 259.0_dp, &  ! Am-No
                           262.0_dp, 267.0_dp, 268.0_dp, 271.0_dp, 272.0_dp, 270.0_dp, 276.0_dp, 281.0_dp, &  ! Lr-Ds
                           280.0_dp, 285.0_dp, 284.0_dp, 289.0_dp, 288.0_dp, 293.0_dp, 294.0_dp, 294.0_dp]   ! Rg-Og
+
+   !> Van der Waals radii in Angstrom, Bondi (1964) with Rowland and Taylor's
+   !> hydrogen. Zero where Bondi tabulates none -- see `element_vdw_radius`.
+   integer, parameter :: n_vdw = 96
+   real(dp), parameter :: vdw_radii(n_vdw) = [ &
+                          1.10_dp, 1.40_dp, 1.81_dp, 1.53_dp, 1.92_dp, 1.70_dp, 1.55_dp, 1.52_dp, &
+                          1.47_dp, 1.54_dp, 2.27_dp, 1.73_dp, 1.84_dp, 2.10_dp, 1.80_dp, 1.80_dp, &
+                          1.75_dp, 1.88_dp, 2.75_dp, 2.31_dp, 0.00_dp, 0.00_dp, 0.00_dp, 0.00_dp, &
+                          0.00_dp, 0.00_dp, 0.00_dp, 1.63_dp, 1.40_dp, 1.39_dp, 1.87_dp, 2.11_dp, &
+                          1.85_dp, 1.90_dp, 1.85_dp, 2.02_dp, 3.03_dp, 2.49_dp, 0.00_dp, 0.00_dp, &
+                          0.00_dp, 0.00_dp, 0.00_dp, 0.00_dp, 0.00_dp, 1.63_dp, 1.72_dp, 1.58_dp, &
+                          1.93_dp, 2.17_dp, 2.06_dp, 2.06_dp, 1.98_dp, 2.16_dp, 3.43_dp, 2.68_dp, &
+                          0.00_dp, 0.00_dp, 0.00_dp, 0.00_dp, 0.00_dp, 0.00_dp, 0.00_dp, 0.00_dp, &
+                          0.00_dp, 0.00_dp, 0.00_dp, 0.00_dp, 0.00_dp, 0.00_dp, 0.00_dp, 0.00_dp, &
+                          0.00_dp, 0.00_dp, 0.00_dp, 0.00_dp, 0.00_dp, 1.75_dp, 1.66_dp, 1.55_dp, &
+                          1.96_dp, 2.02_dp, 2.07_dp, 1.97_dp, 2.02_dp, 2.20_dp, 3.48_dp, 2.83_dp, &
+                          0.00_dp, 0.00_dp, 0.00_dp, 1.86_dp, 0.00_dp, 0.00_dp, 0.00_dp, 0.00_dp]
 
    integer, parameter :: n_covalent = 96
       !! Cordero's set stops at curium. Past it there are no consensus radii,
@@ -120,6 +138,33 @@ contains
       end select
 
    end function element_mass
+
+   pure function element_vdw_radius(atomic_number) result(radius)
+      !! Van der Waals radius in Angstrom, or 0 where none is tabulated
+      !!
+      !! Bondi's set (J. Phys. Chem. 68, 441 (1964)) with Rowland and Taylor's
+      !! revision for hydrogen, which is the usual modern choice.
+      !!
+      !! **These are a convention, and an electrostatic-potential charge fit
+      !! depends on which one is used.** CHELPG excludes grid points inside these
+      !! spheres, so a different radius set moves the points the fit sees and
+      !! therefore the charges it returns. Comparing charges against another
+      !! program means checking it uses these radii, not merely that it calls
+      !! the method CHELPG.
+      !!
+      !! Zero for anything untabulated, for the same reason the covalent radii
+      !! refuse: a caller has to decide what to do about an element nobody
+      !! measured, and a made-up sphere would silently exclude or include points.
+      integer, intent(in) :: atomic_number
+      real(dp) :: radius
+
+      select case (atomic_number)
+      case (1:n_vdw)
+         radius = vdw_radii(atomic_number)
+      case default
+         radius = 0.0_dp
+      end select
+   end function element_vdw_radius
 
    pure function element_covalent_radius(atomic_number) result(radius)
       !! Covalent radius in Angstrom, or 0 where none is tabulated

--- a/src/interface/CMakeLists.txt
+++ b/src/interface/CMakeLists.txt
@@ -9,3 +9,11 @@ target_sources(
           mqc_capi_session.f90
           mqc_capi_run.f90
           mqc_calculation_interface.f90)
+
+# Charges need a real density, so they need the integrals backend. Without
+# libcint there is nothing to partition and the symbols are simply absent -- a
+# Python caller gets an AttributeError on the binding rather than a link error
+# here.
+if(MQC_ENABLE_LIBCINT)
+  target_sources(${main_lib} PRIVATE mqc_capi_charges.f90)
+endif()

--- a/src/interface/mqc_capi_charges.f90
+++ b/src/interface/mqc_capi_charges.f90
@@ -1,0 +1,275 @@
+!! Atomic partial charges over the C boundary
+module mqc_capi_charges
+   !! Mulliken and CHELPG charges on a system handle, from an RHF density.
+   !!
+   !! Same shape as [[mqc_capi_bond_orders]] and for the same reason: charges
+   !! are an input to deciding what to calculate, not the output of a
+   !! calculation someone asked for. A caller weighing fragmentations wants to
+   !! know how much charge sits near each candidate cut, and wants to ask that
+   !! many times over many trial partitions -- a Python loop, not a deck.
+   !!
+   !! **Unlike bond orders, these cost a real SCF.** Bond orders come from xTB,
+   !! which is cheap enough to run on the whole system without thinking about
+   !! it. Charges here come from `run_libcint_rhf` in whatever basis the caller
+   !! names, so `compute` on a large system in a large basis is a large
+   !! calculation. That is the caller's decision to make, which is why the basis
+   !! is a parameter and not a default hidden inside. Measured: 32 atoms in
+   !! 6-31G is about twenty seconds, nearly all of it the SCF -- so the basis is
+   !! the knob that matters and the choice of scheme is not.
+   !!
+   !! **Which scheme to ask for.** CHELPG, unless the reason for asking is
+   !! specifically about basis-function populations. Measured on water between
+   !! 6-31G and aug-cc-pVDZ, the Mulliken charge on oxygen moves from -0.79 to
+   !! -0.30 while CHELPG moves from -0.94 to -0.74 -- the same molecule, and one
+   !! of the two answers has changed by more than half. For anything downstream
+   !! that treats a charge as a physical quantity, embedding especially, the
+   !! basis-stable one is the only defensible input.
+   use, intrinsic :: iso_c_binding, only: c_ptr, c_int, c_double, c_char, c_associated, c_f_pointer
+   use pic_types, only: dp
+   use mqc_capi_system, only: system_handle_t, last_message, MQC_OK, MQC_FAIL, MQC_BAD_HANDLE
+   use mqc_error, only: error_t
+   use mqc_elements, only: element_number_to_symbol
+   use mqc_libcint_integrals, only: libcint_molecule_t, build_libcint_molecule
+   use mqc_libcint_charges, only: mulliken_charges, chelpg_charges
+   use mqc_libcint_rhf, only: rhf_result_t, run_libcint_rhf
+   implicit none
+   private
+
+   public :: mqc_system_compute_charges
+   public :: mqc_system_get_charges
+   public :: mqc_system_charge_on
+   public :: mqc_system_has_charges
+   public :: mqc_system_charge_scheme
+
+   integer, parameter :: SCF_MAX_ITER = 100
+   real(dp), parameter :: SCF_ENERGY_TOL = 1.0e-9_dp
+   real(dp), parameter :: SCF_DENSITY_TOL = 1.0e-7_dp
+
+contains
+
+   function mqc_system_compute_charges(handle, scheme_len, scheme, basis_len, basis) &
+      result(status) bind(C, name="mqc_system_compute_charges")
+      !! Run one RHF over the whole system and keep its atomic charges
+      !!
+      !! `scheme` is "chelpg" or "mulliken"; an empty string takes chelpg, for
+      !! the reason in the module header. `basis` is any basis the build carries;
+      !! an empty string takes 6-31g, which is small enough to be affordable on
+      !! the systems this gets pointed at and large enough that the charges mean
+      !! something.
+      !!
+      !! Closed shell only. An odd electron count is refused rather than
+      !! silently paired up, because a caller fragmenting a radical needs to
+      !! know that this cannot answer for it.
+      type(c_ptr), value :: handle
+      integer(c_int), value :: scheme_len
+      character(kind=c_char), intent(in) :: scheme(scheme_len)
+      integer(c_int), value :: basis_len
+      character(kind=c_char), intent(in) :: basis(basis_len)
+      integer(c_int) :: status
+
+      type(system_handle_t), pointer :: h
+      type(libcint_molecule_t) :: mol
+      type(rhf_result_t) :: scf
+      type(error_t) :: error
+      real(dp), allocatable :: overlap(:, :), q(:)
+      character(len=2), allocatable :: symbols(:)
+      character(len=:), allocatable :: which, basis_name
+      integer :: i, n, nelec
+
+      status = MQC_BAD_HANDLE
+      if (.not. c_associated(handle)) then
+         last_message = "null system handle"
+         return
+      end if
+      call c_f_pointer(handle, h)
+
+      if (h%geom%total_atoms <= 0) then
+         last_message = "mqc_system_compute_charges: set the geometry first"
+         status = MQC_FAIL
+         return
+      end if
+
+      which = from_c(scheme, scheme_len)
+      if (len_trim(which) == 0) which = "chelpg"
+      basis_name = from_c(basis, basis_len)
+      if (len_trim(basis_name) == 0) basis_name = "6-31g"
+
+      if (which /= "chelpg" .and. which /= "mulliken") then
+         last_message = "mqc_system_compute_charges: unknown scheme '"//which// &
+                        "'; use 'chelpg' or 'mulliken'"
+         status = MQC_FAIL
+         return
+      end if
+
+      n = h%geom%total_atoms
+      nelec = sum(h%geom%element_numbers) - h%geom%charge
+      if (mod(nelec, 2) /= 0) then
+         last_message = "mqc_system_compute_charges: this is a closed-shell RHF and the "// &
+                        "system has an odd number of electrons"
+         status = MQC_FAIL
+         return
+      end if
+
+      allocate (symbols(n))
+      do i = 1, n
+         symbols(i) = element_number_to_symbol(h%geom%element_numbers(i))
+      end do
+
+      call build_libcint_molecule(h%geom%element_numbers, symbols, h%geom%coordinates, &
+                                  basis_name, mol, error)
+      if (failed(error, status)) return
+
+      call run_libcint_rhf(mol, nelec, SCF_MAX_ITER, SCF_ENERGY_TOL, SCF_DENSITY_TOL, &
+                           .false., scf, error)
+      if (failed(error, status)) return
+      if (.not. scf%converged) then
+         last_message = "mqc_system_compute_charges: the SCF did not converge, so there "// &
+                        "is no density to partition"
+         status = MQC_FAIL
+         return
+      end if
+
+      if (which == "mulliken") then
+         call mol%overlap(overlap)
+         call mulliken_charges(mol, scf%density, overlap, q, error)
+      else
+         call chelpg_charges(mol, scf%density, q, error, &
+                             total_charge=real(h%geom%charge, dp))
+      end if
+      if (failed(error, status)) return
+
+      if (allocated(h%charges)) deallocate (h%charges)
+      allocate (h%charges(n), source=q)
+      h%charge_scheme = which
+      status = MQC_OK
+   end function mqc_system_compute_charges
+
+   function mqc_system_has_charges(handle) result(has) &
+      bind(C, name="mqc_system_has_charges")
+      !! Whether `compute` has run on this handle. Zero for a null handle too.
+      type(c_ptr), value :: handle
+      integer(c_int) :: has
+
+      type(system_handle_t), pointer :: h
+
+      has = 0
+      if (.not. c_associated(handle)) return
+      call c_f_pointer(handle, h)
+      if (allocated(h%charges)) has = 1
+   end function mqc_system_has_charges
+
+   subroutine mqc_system_charge_scheme(handle, buffer_len, buffer) &
+      bind(C, name="mqc_system_charge_scheme")
+      !! Which scheme produced the charges currently on the handle
+      !!
+      !! Empty if none have been computed. Worth asking, because "the charge on
+      !! atom 3" is not a well-defined number without it -- two schemes
+      !! disagree by design, and a caller comparing systems or caching results
+      !! has to be able to tell which question was answered.
+      use, intrinsic :: iso_c_binding, only: c_null_char
+      type(c_ptr), value :: handle
+      integer(c_int), value :: buffer_len
+      character(kind=c_char), intent(inout) :: buffer(buffer_len)
+
+      type(system_handle_t), pointer :: h
+      character(len=:), allocatable :: text
+      integer :: n, i
+
+      if (buffer_len <= 0) return
+      text = ""
+      if (c_associated(handle)) then
+         call c_f_pointer(handle, h)
+         if (allocated(h%charges)) text = trim(h%charge_scheme)
+      end if
+
+      n = min(len(text), int(buffer_len) - 1)
+      do i = 1, n
+         buffer(i) = text(i:i)
+      end do
+      buffer(n + 1) = c_null_char
+   end subroutine mqc_system_charge_scheme
+
+   function mqc_system_get_charges(handle, n, out) result(status) &
+      bind(C, name="mqc_system_get_charges")
+      !! Copy the charges into a caller buffer of n doubles, one per atom
+      type(c_ptr), value :: handle
+      integer(c_int), value :: n
+      real(c_double), intent(out) :: out(n)
+      integer(c_int) :: status
+
+      type(system_handle_t), pointer :: h
+
+      status = MQC_BAD_HANDLE
+      if (.not. c_associated(handle)) then
+         last_message = "null system handle"
+         return
+      end if
+      call c_f_pointer(handle, h)
+
+      if (.not. allocated(h%charges)) then
+         last_message = "mqc_system_get_charges: compute them first"
+         status = MQC_FAIL
+         return
+      end if
+      if (n /= size(h%charges)) then
+         last_message = "mqc_system_get_charges: buffer is the wrong size for this system"
+         status = MQC_FAIL
+         return
+      end if
+
+      out = h%charges
+      status = MQC_OK
+   end function mqc_system_get_charges
+
+   function mqc_system_charge_on(handle, i) result(q) &
+      bind(C, name="mqc_system_charge_on")
+      !! One atom's charge, 0-based
+      !!
+      !! Unlike a bond order, a partial charge is legitimately negative, so
+      !! there is no out-of-band value to signal failure with. A bad index or an
+      !! uncomputed handle gives a quiet NaN, which propagates rather than
+      !! silently reading as a neutral atom.
+      use, intrinsic :: ieee_arithmetic, only: ieee_value, ieee_quiet_nan
+      type(c_ptr), value :: handle
+      integer(c_int), value :: i
+      real(c_double) :: q
+
+      type(system_handle_t), pointer :: h
+
+      q = ieee_value(1.0_dp, ieee_quiet_nan)
+      if (.not. c_associated(handle)) return
+      call c_f_pointer(handle, h)
+      if (.not. allocated(h%charges)) return
+      if (i < 0 .or. i >= size(h%charges)) return
+      q = h%charges(i + 1)
+   end function mqc_system_charge_on
+
+   function from_c(buf, n) result(s)
+      !! A C character buffer as a Fortran string
+      integer(c_int), intent(in) :: n
+      character(kind=c_char), intent(in) :: buf(n)
+      character(len=:), allocatable :: s
+
+      integer :: i
+
+      s = ""
+      do i = 1, n
+         s = s//buf(i)
+      end do
+      s = trim(adjustl(s))
+   end function from_c
+
+   function failed(error, status) result(bad)
+      !! Turn an error_t into a C status, and say whether to stop
+      type(error_t), intent(inout) :: error
+      integer(c_int), intent(inout) :: status
+      logical :: bad
+
+      bad = error%has_error()
+      if (bad) then
+         last_message = "mqc_system_compute_charges: "//error%get_message()
+         status = MQC_FAIL
+      end if
+   end function failed
+
+end module mqc_capi_charges

--- a/src/interface/mqc_capi_charges.f90
+++ b/src/interface/mqc_capi_charges.f90
@@ -29,9 +29,7 @@ module mqc_capi_charges
    use mqc_capi_system, only: system_handle_t, last_message, MQC_OK, MQC_FAIL, MQC_BAD_HANDLE
    use mqc_error, only: error_t
    use mqc_elements, only: element_number_to_symbol
-   use mqc_libcint_integrals, only: libcint_molecule_t, build_libcint_molecule
-   use mqc_libcint_charges, only: mulliken_charges, chelpg_charges
-   use mqc_libcint_rhf, only: rhf_result_t, run_libcint_rhf
+   use mqc_libcint_bridge, only: run_libcint_charges
    implicit none
    private
 
@@ -40,10 +38,6 @@ module mqc_capi_charges
    public :: mqc_system_charge_on
    public :: mqc_system_has_charges
    public :: mqc_system_charge_scheme
-
-   integer, parameter :: SCF_MAX_ITER = 100
-   real(dp), parameter :: SCF_ENERGY_TOL = 1.0e-9_dp
-   real(dp), parameter :: SCF_DENSITY_TOL = 1.0e-7_dp
 
 contains
 
@@ -68,13 +62,11 @@ contains
       integer(c_int) :: status
 
       type(system_handle_t), pointer :: h
-      type(libcint_molecule_t) :: mol
-      type(rhf_result_t) :: scf
       type(error_t) :: error
-      real(dp), allocatable :: overlap(:, :), q(:)
+      real(dp), allocatable :: q(:)
       character(len=2), allocatable :: symbols(:)
       character(len=:), allocatable :: which, basis_name
-      integer :: i, n, nelec
+      integer :: i, n
 
       status = MQC_BAD_HANDLE
       if (.not. c_associated(handle)) then
@@ -102,40 +94,16 @@ contains
       end if
 
       n = h%geom%total_atoms
-      nelec = sum(h%geom%element_numbers) - h%geom%charge
-      if (mod(nelec, 2) /= 0) then
-         last_message = "mqc_system_compute_charges: this is a closed-shell RHF and the "// &
-                        "system has an odd number of electrons"
-         status = MQC_FAIL
-         return
-      end if
-
       allocate (symbols(n))
       do i = 1, n
          symbols(i) = element_number_to_symbol(h%geom%element_numbers(i))
       end do
 
-      call build_libcint_molecule(h%geom%element_numbers, symbols, h%geom%coordinates, &
-                                  basis_name, mol, error)
-      if (failed(error, status)) return
-
-      call run_libcint_rhf(mol, nelec, SCF_MAX_ITER, SCF_ENERGY_TOL, SCF_DENSITY_TOL, &
-                           .false., scf, error)
-      if (failed(error, status)) return
-      if (.not. scf%converged) then
-         last_message = "mqc_system_compute_charges: the SCF did not converge, so there "// &
-                        "is no density to partition"
-         status = MQC_FAIL
-         return
-      end if
-
-      if (which == "mulliken") then
-         call mol%overlap(overlap)
-         call mulliken_charges(mol, scf%density, overlap, q, error)
-      else
-         call chelpg_charges(mol, scf%density, q, error, &
-                             total_charge=real(h%geom%charge, dp))
-      end if
+      ! Through the bridge, not into the backend. The odd-electron refusal and
+      ! the SCF live on the other side of it now, so this reports rather than
+      ! decides.
+      call run_libcint_charges(h%geom%element_numbers, symbols, h%geom%coordinates, &
+                               basis_name, which, h%geom%charge, q, error)
       if (failed(error, status)) return
 
       if (allocated(h%charges)) deallocate (h%charges)

--- a/src/interface/mqc_capi_system.f90
+++ b/src/interface/mqc_capi_system.f90
@@ -77,6 +77,14 @@ module mqc_capi_system
          !! deciding where to cut reads the same matrix many times while trying
          !! partitions, and recomputing it per question would be an xTB
          !! calculation per question.
+      real(dp), allocatable :: charges(:)
+         !! Atomic partial charges from `mqc_system_compute_charges`, if it has
+         !! run. Cached for the same reason as the bond orders, and more so:
+         !! these cost an SCF rather than an xTB single point.
+      character(len=16) :: charge_scheme = ""
+         !! Which scheme produced `charges`. Kept because "the charge on atom 3"
+         !! is not a well-defined number without it, and a caller comparing two
+         !! systems has to be able to check they were partitioned the same way.
    end type system_handle_t
 
 contains

--- a/src/methods/mqc_libcint_bridge_stub.f90
+++ b/src/methods/mqc_libcint_bridge_stub.f90
@@ -15,6 +15,7 @@ module mqc_libcint_bridge
 
    public :: run_libcint_hf
    public :: run_libcint_makefp
+   public :: run_libcint_charges
    public :: run_libcint_efp
    public :: run_libcint_sapt0
    public :: libcint_backend_available
@@ -48,6 +49,32 @@ contains
       if (len_trim(sym_a(1))*len_trim(sym_b(1))*len_trim(basis_name) < 0) return
       if (size(xyz_a) < 0 .or. size(xyz_b) < 0) return
    end subroutine run_libcint_sapt0
+
+   subroutine run_libcint_charges(atomic_numbers, element_symbols, coordinates, &
+                                  basis_name, scheme, total_charge, charges, error)
+      !! No-op stand-in: atomic charges need the CPU integral backend
+      !!
+      !! The molecule builder, the SCF and both partition schemes all live behind
+      !! `MQC_ENABLE_LIBCINT`.
+      use pic_types, only: dp
+      use mqc_error, only: error_t
+      integer, intent(in) :: atomic_numbers(:)
+      character(len=*), intent(in) :: element_symbols(:)
+      real(dp), intent(in) :: coordinates(:, :)
+      character(len=*), intent(in) :: basis_name
+      character(len=*), intent(in) :: scheme
+      integer, intent(in) :: total_charge
+      real(dp), allocatable, intent(out) :: charges(:)
+      type(error_t), intent(inout) :: error
+
+      allocate (charges(0))
+      call error%set(ERROR_VALIDATION, &
+                     "atomic charges need the CPU integral backend; build with "// &
+                     "-DMQC_ENABLE_LIBCINT=ON")
+      if (size(atomic_numbers) < 0 .or. size(coordinates) < 0) return
+      if (len_trim(element_symbols(1))*len_trim(basis_name)*len_trim(scheme) < 0) return
+      if (total_charge < -huge(1)) return
+   end subroutine run_libcint_charges
 
    subroutine run_libcint_efp(potentials, fragment_sizes, fragment_atoms, &
                               coordinates, terms, error)

--- a/validation/check_charges.f90
+++ b/validation/check_charges.f90
@@ -1,0 +1,263 @@
+program check_charges
+   !! Check the two charge schemes against what must be true of any of them
+   !!
+   !! There is no reference number for a partial charge -- it is not an
+   !! observable, and two schemes disagree by design. So these are the
+   !! properties that hold whatever the scheme:
+   !!
+   !!   * **They sum to the molecular charge.** For Mulliken this is an identity
+   !!     of the trace; for CHELPG it is the constraint the fit is solved under.
+   !!     Either failing means the bookkeeping is wrong, not the chemistry.
+   !!   * **Symmetry-equivalent atoms get equal charges.** Water's two hydrogens
+   !!     cannot differ, and methane's four cannot.
+   !!   * **The sign follows electronegativity.** Oxygen negative in water,
+   !!     hydrogen positive; the fluorines negative in HF.
+   !!
+   !! And one property that is the whole reason CHELPG exists:
+   !!
+   !!   * **CHELPG reproduces the potential it was fitted to.** The residual on
+   !!     the fit grid is reported. Mulliken has no such claim and is not asked
+   !!     for one.
+   use pic_types, only: dp
+   use pic_logger, only: logger => global_logger, info_level
+   use mqc_error, only: error_t
+   use mqc_libcint_integrals, only: libcint_molecule_t, build_libcint_molecule
+   use mqc_libcint_charges, only: mulliken_charges, chelpg_charges, chelpg_grid
+   use mqc_libcint_esp, only: esp_contract
+   use mqc_libcint_rhf, only: rhf_result_t, run_libcint_rhf
+   implicit none
+
+   integer, parameter :: N_DIM = 3
+   integer :: n_bad
+
+   n_bad = 0
+   call logger%configure(info_level)
+
+   call run_case("water", [character(len=2) :: "O", "H", "H"], &
+                 reshape([0.0000_dp, 0.0000_dp, 0.0000_dp, &
+                          0.0000_dp, -1.4308_dp, 1.1078_dp, &
+                          0.0000_dp, 1.4308_dp, 1.1078_dp], [N_DIM, 3]), &
+                 [8, 1, 1], 10, [2, 3], 0.10_dp, n_bad)
+
+   call run_case("methane", [character(len=2) :: "C", "H", "H", "H", "H"], &
+                 reshape([0.0000_dp, 0.0000_dp, 0.0000_dp, &
+                          1.1900_dp, 1.1900_dp, 1.1900_dp, &
+                          -1.1900_dp, -1.1900_dp, 1.1900_dp, &
+                          -1.1900_dp, 1.1900_dp, -1.1900_dp, &
+                          1.1900_dp, -1.1900_dp, -1.1900_dp], [N_DIM, 5]), &
+                 ! Loose, and not a weakness of the fit. Methane is tetrahedral:
+                 ! no dipole, no quadrupole, first nonvanishing moment the
+                 ! octupole. Its potential outside the van der Waals surface is
+                 ! an order of magnitude smaller than water's and is mostly
+                 ! charge penetration, which no arrangement of point charges can
+                 ! reproduce. A nonpolar molecule fits badly in relative terms
+                 ! however good the code is.
+                 [6, 1, 1, 1, 1], 10, [2, 5], 0.80_dp, n_bad)
+
+   call check_basis_sensitivity(n_bad)
+
+   if (n_bad == 0) then
+      call logger%info("")
+      call logger%info("charges are normalised, symmetric, and CHELPG reproduces its potential")
+   else
+      call logger%error("charge checks failed")
+      stop 1
+   end if
+
+contains
+
+   subroutine run_case(label, symbols, coords, z, nelec, equiv, rrms_tol, n_bad)
+      character(len=*), intent(in) :: label
+      character(len=2), intent(in) :: symbols(:)
+      real(dp), intent(in) :: coords(:, :)
+      integer, intent(in) :: z(:)
+      integer, intent(in) :: nelec
+      integer, intent(in) :: equiv(2)   !! first and last of a symmetry-equivalent run
+      real(dp), intent(in) :: rrms_tol
+      integer, intent(inout) :: n_bad
+
+      type(libcint_molecule_t) :: mol
+      type(rhf_result_t) :: scf
+      type(error_t) :: error
+      real(dp), allocatable :: s(:, :), q_mul(:), q_esp(:), pts(:, :), v(:)
+      real(dp) :: spread_mul, spread_esp, rms, v_rms, d
+      character(len=200) :: line
+      integer :: i, g, iatom
+
+      call logger%info("")
+      write (line, "(a,a)") "== ", label
+      call logger%info(trim(line))
+
+      call build_libcint_molecule(z, symbols, coords, "6-31g", mol, error)
+      if (failed(error, "molecule", n_bad)) return
+      call run_libcint_rhf(mol, nelec, 100, 1.0e-9_dp, 1.0e-7_dp, .false., scf, error)
+      if (failed(error, "scf", n_bad)) return
+
+      call mol%overlap(s)
+      call mulliken_charges(mol, scf%density, s, q_mul, error)
+      if (failed(error, "mulliken", n_bad)) return
+      call chelpg_charges(mol, scf%density, q_esp, error)
+      if (failed(error, "chelpg", n_bad)) return
+
+      do i = 1, mol%natm
+         write (line, "(a,a4,a,f9.5,a,f9.5)") "   ", symbols(i), "   mulliken ", q_mul(i), &
+            "    chelpg ", q_esp(i)
+         call logger%info(trim(line))
+      end do
+
+      call report("mulliken sums to zero", abs(sum(q_mul)), 1.0e-8_dp, n_bad)
+      call report("chelpg sums to zero", abs(sum(q_esp)), 1.0e-8_dp, n_bad)
+
+      spread_mul = maxval(q_mul(equiv(1):equiv(2))) - minval(q_mul(equiv(1):equiv(2)))
+      spread_esp = maxval(q_esp(equiv(1):equiv(2))) - minval(q_esp(equiv(1):equiv(2)))
+      call report("equivalent atoms agree, mulliken", spread_mul, 1.0e-6_dp, n_bad)
+      ! Looser: the fit grid is a cubic lattice and does not share the molecule's
+      ! symmetry, so equivalent atoms see slightly different point sets.
+      call report("equivalent atoms agree, chelpg", spread_esp, 5.0e-3_dp, n_bad)
+
+      if (q_esp(1) >= 0.0_dp .and. z(1) > z(2)) then
+         call logger%error("   FAIL the more electronegative atom is not negative")
+         n_bad = n_bad + 1
+      end if
+
+      ! What CHELPG claims: the fitted charges reproduce the potential.
+      call chelpg_grid(mol, pts, error)
+      if (failed(error, "grid", n_bad)) return
+      call esp_contract(mol, pts, scf%density, v, error)
+      if (failed(error, "esp", n_bad)) return
+      rms = 0.0_dp
+      v_rms = 0.0_dp
+      do g = 1, size(pts, 2)
+         do iatom = 1, mol%natm
+            d = norm2(pts(:, g) - mol%coords(:, iatom))
+            v(g) = v(g) + mol%charges(iatom)/d
+         end do
+         ! The baseline: all charges zero, which the constraint permits. Any fit
+         ! that does not beat it is not worth solving for.
+         v_rms = v_rms + v(g)**2
+         do iatom = 1, mol%natm
+            d = norm2(pts(:, g) - mol%coords(:, iatom))
+            v(g) = v(g) - q_esp(iatom)/d
+         end do
+         rms = rms + v(g)**2
+      end do
+      rms = sqrt(rms/real(size(pts, 2), dp))
+      v_rms = sqrt(v_rms/real(size(pts, 2), dp))
+      write (line, "(a,i0,a,es10.3,a,es10.3)") "   fit: ", size(pts, 2), &
+         " points, rms residual ", rms, "  against rms V ", v_rms
+      call logger%info(trim(line))
+      ! RRMS, the usual measure of an ESP fit: the residual as a fraction of
+      ! the potential a zero-charge model would leave. Below 0.1 is a good fit
+      ! in the literature, and the tolerance is per-case because how well point
+      ! charges *can* do depends on the molecule -- see the call sites.
+      call report("chelpg rrms", rms/v_rms, rrms_tol, n_bad)
+   end subroutine run_case
+
+   subroutine check_basis_sensitivity(n_bad)
+      !! The claim that decides which scheme to embed with
+      !!
+      !! Mulliken partitions by basis function, so a function's atom label is
+      !! what assigns its density -- and a diffuse function centred on hydrogen
+      !! reaches over the oxygen while still counting as hydrogen's. Enlarging
+      !! the basis therefore moves Mulliken charges without the molecule
+      !! changing. CHELPG partitions by a physical field, so enlarging the basis
+      !! moves it only as far as the field itself moves.
+      !!
+      !! Same water, two bases, and the question is which set of charges is
+      !! still recognisable in the second one.
+      integer, intent(inout) :: n_bad
+
+      real(dp) :: q_mul_small(3), q_esp_small(3), q_mul_big(3), q_esp_big(3)
+      real(dp) :: shift_mul, shift_esp
+      character(len=200) :: line
+
+      call logger%info("")
+      call logger%info("== water, 6-31g vs aug-cc-pvdz")
+
+      call water_charges("6-31g", q_mul_small, q_esp_small, n_bad)
+      call water_charges("aug-cc-pvdz", q_mul_big, q_esp_big, n_bad)
+      if (n_bad > 0) return
+
+      shift_mul = maxval(abs(q_mul_big - q_mul_small))
+      shift_esp = maxval(abs(q_esp_big - q_esp_small))
+
+      write (line, "(a,f9.5,a,f9.5,a,f9.5)") "   mulliken  O ", q_mul_small(1), " -> ", &
+         q_mul_big(1), "    moved ", shift_mul
+      call logger%info(trim(line))
+      write (line, "(a,f9.5,a,f9.5,a,f9.5)") "   chelpg    O ", q_esp_small(1), " -> ", &
+         q_esp_big(1), "    moved ", shift_esp
+      call logger%info(trim(line))
+
+      if (shift_esp < shift_mul) then
+         write (line, "(a,f6.2,a)") "   ok   chelpg is the more stable of the two, by ", &
+            shift_mul/shift_esp, "x"
+         call logger%info(trim(line))
+      else
+         call logger%error("   FAIL chelpg moved at least as much as mulliken, which is "// &
+                           "the opposite of why it is here")
+         n_bad = n_bad + 1
+      end if
+   end subroutine check_basis_sensitivity
+
+   subroutine water_charges(basis, q_mul, q_esp, n_bad)
+      character(len=*), intent(in) :: basis
+      real(dp), intent(out) :: q_mul(3), q_esp(3)
+      integer, intent(inout) :: n_bad
+
+      type(libcint_molecule_t) :: mol
+      type(rhf_result_t) :: scf
+      type(error_t) :: error
+      real(dp), allocatable :: s(:, :), qm(:), qe(:)
+      real(dp) :: coords(N_DIM, 3)
+
+      coords = reshape([0.0000_dp, 0.0000_dp, 0.0000_dp, &
+                        0.0000_dp, -1.4308_dp, 1.1078_dp, &
+                        0.0000_dp, 1.4308_dp, 1.1078_dp], [N_DIM, 3])
+
+      q_mul = 0.0_dp
+      q_esp = 0.0_dp
+      call build_libcint_molecule([8, 1, 1], [character(len=2) :: "O", "H", "H"], &
+                                  coords, basis, mol, error)
+      if (failed(error, "molecule "//basis, n_bad)) return
+      call run_libcint_rhf(mol, 10, 100, 1.0e-9_dp, 1.0e-7_dp, .false., scf, error)
+      if (failed(error, "scf "//basis, n_bad)) return
+      call mol%overlap(s)
+      call mulliken_charges(mol, scf%density, s, qm, error)
+      if (failed(error, "mulliken "//basis, n_bad)) return
+      call chelpg_charges(mol, scf%density, qe, error)
+      if (failed(error, "chelpg "//basis, n_bad)) return
+      q_mul = qm
+      q_esp = qe
+   end subroutine water_charges
+
+   function failed(error, what, n_bad) result(bad)
+      type(error_t), intent(inout) :: error
+      character(len=*), intent(in) :: what
+      integer, intent(inout) :: n_bad
+      logical :: bad
+
+      bad = error%has_error()
+      if (bad) then
+         call logger%error("   FAIL "//what//": "//error%get_message())
+         n_bad = n_bad + 1
+      end if
+   end function failed
+
+   subroutine report(what, deviation, tol, n_bad)
+      character(len=*), intent(in) :: what
+      real(dp), intent(in) :: deviation, tol
+      integer, intent(inout) :: n_bad
+
+      character(len=200) :: line
+
+      if (deviation <= tol) then
+         write (line, "(a,a,a,es10.3)") "   ok   ", what, "   ", deviation
+         call logger%info(trim(line))
+      else
+         write (line, "(a,a,a,es10.3,a,es10.3)") "   FAIL ", what, "   ", deviation, " > ", tol
+         call logger%error(trim(line))
+         n_bad = n_bad + 1
+      end if
+   end subroutine report
+
+end program check_charges


### PR DESCRIPTION
> **Stack position:** middle of a three-PR stack. Base is `feat/xtb-bond-orders` (#4); #6 (FMO) builds on this. Set the base by hand or it shows the whole stack's diff.

## What

Two atomic-charge schemes, exposed the same way the bond orders in #4 are: computed onto a system handle and read back many times, through the C binding rather than a deck. Charges are an input to deciding what to calculate — how much charge sits either side of a candidate cut — and that deciding is a loop over trial partitions, not a JSON key.

- **Mulliken** — the trace of `D S` split by which atom owns each basis function.
- **CHELPG** — the point charges that best reproduce the molecule's own electrostatic potential on a shell of points outside its van der Waals surface, constrained to sum to the molecular charge. A least-squares system of size `natm+1`, symmetric but indefinite (the Lagrange multiplier), so factorised generally rather than by Cholesky.

## Why both, not just the cheap one (water)

| basis | Mulliken O | CHELPG O |
|---|---|---|
| 6-31G | −0.79 | −0.94 |
| aug-cc-pVDZ | −0.30 | −0.74 |

Mulliken moves half an electron because a diffuse function centred on H reaches over the O while still counting as H's; CHELPG moves less than half as far because it's fitted to a field rather than to a basis. For anything downstream that treats a charge as physical — embedding especially — CHELPG is the one. Cost isn't the discriminator: both need the same SCF, and CHELPG's grid + fit add ~2s to 18s on 24–32 atoms in 6-31G.

## Validation

`validation/check_charges.f90` and `python/examples/charges.py`, both assert-and-exit-nonzero. Invariants: charges sum to the molecular charge (hydroxide comes back −1.000000), symmetry-equivalent atoms agree, polarity follows electronegativity, and the CHELPG fit reproduces the potential it was fitted to (RRMS 0.077 on water). Methane's RRMS 0.70 is physics, not a defect — a tetrahedral molecule has no dipole or quadrupole, so its exterior potential is ~10× smaller than water's and mostly charge penetration, which no point charges can represent — and it carries its own documented tolerance rather than the threshold being loosened for everyone.

Adds `element_vdw_radius` (Bondi) to `mqc_elements`, since CHELPG's excluded region is defined by it. The C API module is behind `MQC_ENABLE_LIBCINT` (no density to partition without an integrals backend); the Python bindings declare those four symbols optionally so a build without libcint still imports and says so in one sentence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
