### PR TITLE
Start the SCF from Wolfsberg-Helmholz, not from the core Hamiltonian

### DIFF
--- a/backends/libcint/mqc_libcint_rhf.f90
+++ b/backends/libcint/mqc_libcint_rhf.f90
@@ -277,9 +277,29 @@ contains
          !! against PySCF, so it is what the direct build is checked against --
          !! not because anything should run with it. It is n^4 in memory.
       integer, intent(in), optional :: guess
-         !! One of SCF_GUESS_*. Defaults to the core guess, which is the only
-         !! one needing nothing but H -- the caller decides policy, because
-         !! `guess_density` has to be built before this routine is entered.
+         !! One of SCF_GUESS_*. Defaults to Wolfsberg-Helmholz, the best guess
+         !! that needs nothing but `H` and `S` -- superposition of atomic
+         !! densities is better still, and is what a deck gets, but
+         !! `guess_density` has to be built before this routine is entered and
+         !! so cannot be a default here.
+         !!
+         !! **It used to default to the core guess**, which is `F = H`: every
+         !! electron-electron term ignored, and the worst starting point
+         !! available. Iterations to 1e-12, measured:
+         !!
+         !!     HCN   STO-3G  B2GP-PLYP   core 15   gwh  9   sad 9
+         !!     H2O   cc-pVDZ B3LYP       core 11   gwh  9   sad 9
+         !!     NH3   cc-pVDZ PBE         core 12   gwh 10   sad 9
+         !!     CH4   cc-pVDZ HF          core 10   gwh 10   sad 8
+         !!
+         !! Never worse, occasionally much better, and free -- `H` and `S` are
+         !! both in hand before the first Fock build.
+         !!
+         !! This moves nothing a deck does: the driver resolves "auto" to SAD
+         !! and always passes it. What it moves is every *library* caller that
+         !! did not think about the guess -- the validation harnesses, SAPT, the
+         !! EFP potential, the projection code -- each of which was silently
+         !! taking the worst option.
       type(xc_context_t), intent(inout), optional :: xc
          !! Exchange-correlation. Present turns this into a Kohn-Sham SCF; absent
          !! leaves it Hartree-Fock. One argument rather than six, and one loop
@@ -332,7 +352,7 @@ contains
       if (present(diis_vectors)) diis_size = diis_vectors
       use_in_core = .false.
       if (present(in_core)) use_in_core = in_core
-      guess_kind = SCF_GUESS_CORE
+      guess_kind = SCF_GUESS_GWH
       if (present(guess)) guess_kind = guess
 
       n_ao = mol%nao
@@ -548,7 +568,8 @@ contains
       integer, intent(in), optional :: diis_start
          !! First iteration allowed to extrapolate. See the default below.
       integer, intent(in), optional :: guess
-         !! One of SCF_GUESS_*. Defaults to the core guess.
+         !! One of SCF_GUESS_*. Defaults to Wolfsberg-Helmholz, as the restricted
+         !! path does and for the same reason -- see the note there.
       type(xc_context_t), intent(inout), optional :: xc
          !! Exchange-correlation, spin-polarised. Present makes this an
          !! unrestricted Kohn-Sham SCF; absent leaves it unrestricted
@@ -591,7 +612,7 @@ contains
       if (present(diis_start)) start_cycle = diis_start
       use_in_core = .false.
       if (present(in_core)) use_in_core = in_core
-      guess_kind = SCF_GUESS_CORE
+      guess_kind = SCF_GUESS_GWH
       if (present(guess)) guess_kind = guess
 
       ! 2S+1 = n_alpha - n_beta + 1, so the unpaired count is multiplicity - 1.

--- a/test/test_mqc_libcint_uhf.f90
+++ b/test/test_mqc_libcint_uhf.f90
@@ -20,7 +20,8 @@ module test_mqc_libcint_uhf
    use mqc_error, only: error_t
    use mqc_cgto, only: molecular_basis_type
    use mqc_libcint_integrals, only: libcint_molecule_t, build_libcint_molecule
-   use mqc_libcint_rhf, only: rhf_result_t, run_libcint_rhf, run_libcint_uhf
+   use mqc_libcint_rhf, only: rhf_result_t, run_libcint_rhf, run_libcint_uhf, &
+                              SCF_GUESS_CORE
    implicit none
    private
    public :: collect_mqc_libcint_uhf_tests
@@ -201,6 +202,21 @@ contains
       !! and starting at iteration one has to still find the wrong one --
       !! otherwise this passes for some unrelated reason and stops guarding
       !! the delay it exists for.
+      !!
+      !! **The second half names its guess, and that is load-bearing.** The
+      !! pathology needs a symmetric starting point, and the core guess is the
+      !! symmetric one -- `F = H` knows nothing about the electrons, so the pi
+      !! pair enters exactly degenerate and linear extrapolation cannot split
+      !! it. Wolfsberg-Helmholz enters already slightly split, and from there
+      !! even `diis_start=1` finds the ground state. That was discovered by
+      !! changing the default guess to GWH and watching this assertion fail:
+      !! both runs came back at -75.325108417965, the ground state, and the
+      !! test stopped guarding anything. Pinned to `core` it keeps demonstrating
+      !! the failure the delay exists to prevent.
+      !!
+      !! Worth stating plainly, because it is the more useful half of that
+      !! discovery: a starting guess does not only change how *fast* an SCF
+      !! converges, it changes *which solution* it finds.
       type(error_type), allocatable, intent(out) :: error
       type(libcint_molecule_t) :: mol
       type(error_t) :: err
@@ -221,7 +237,8 @@ contains
                  "the default DIIS delay must reach the pi-hole ground state")
       if (allocated(error)) return
 
-      call run_libcint_uhf(mol, 9, 2, 400, E_TOL, D_TOL, .false., bad, err, diis_start=1)
+      call run_libcint_uhf(mol, 9, 2, 400, E_TOL, D_TOL, .false., bad, err, &
+                           diis_start=1, guess=SCF_GUESS_CORE)
       call check(error, bad%converged, "extrapolating from the start still converges")
       if (allocated(error)) return
       call check(error, bad%energy > GROUND + 0.1_dp, &


### PR DESCRIPTION
`run_libcint_rhf` and `run_libcint_uhf` defaulted to `F = H`: every electron-electron term ignored, and the worst starting point available. Every caller that did not think about the guess got it.

Iterations to 1e-12, measured:

    HCN   STO-3G  B2GP-PLYP   core 15   gwh  9   sad 9
    H2O   cc-pVDZ B3LYP       core 11   gwh  9   sad 9
    NH3   cc-pVDZ PBE         core 12   gwh 10   sad 9
    CH4   cc-pVDZ HF          core 10   gwh 10   sad 8

Never worse, occasionally much better, and free -- H and S are both in hand before the first Fock build. Superposition of atomic densities is better still and is what a deck already gets, but `guess_density` has to be built before these routines are entered, so it cannot be their default.

This moves nothing a deck does: the driver resolves "auto" to SAD and always passes it. What it moves is every *library* caller that did not think about the guess -- the validation harnesses, SAPT, the EFP potential, the projection code.

**It is not only a speed change, and that is worth knowing before merging.** `uhf_diis_delay_finds_the_ground_state` failed on this, and correctly. That test converges OH/def2-SVP twice: once with the DIIS delay, and once extrapolating from the first iteration, where it is supposed to land on a sigma-hole state 158 mHartree up. The pathology needs a symmetric starting point -- the core guess enters with the pi pair exactly degenerate, and linear extrapolation cannot split it. From Wolfsberg-Helmholz the pair enters already slightly split, and both runs came back at -75.325108417965, the ground state.

So the guess changed which solution the SCF found, not just how quickly it got there. That is a good outcome here and a reminder that it need not be elsewhere. The test now pins its second run to `core` so it keeps demonstrating the failure the delay exists to prevent, with the reasoning recorded next to it.