### PR TITLE
scale diis error

### DIFF
--- a/src/methods/mqc_diis.f90
+++ b/src/methods/mqc_diis.f90
@@ -175,6 +175,7 @@ contains
       logical, intent(out) :: ok              !! False when the subspace is too small or singular
 
       real(dp), allocatable :: b_matrix(:, :)
+      real(dp) :: scale
       integer :: n, i, j
 
       ok = .false.
@@ -190,6 +191,22 @@ contains
                                      diis_slot_of_age(newest, n_stored, max_vectors, j))
          end do
       end do
+
+      ! Scale the error block to O(1) against the -1 constraint border. Its
+      ! entries are inner products of error vectors, so near convergence they
+      ! are ~|e|^2 -- around 1e-16 by the time the SCF is where it should stop,
+      ! against a border that stays -1. Eliminating that unscaled makes the
+      ! weights of a saturated subspace noise, and the failure is not a visible
+      ! blow-up: the density bottoms out and then drifts *away* from the fixed
+      ! point by a few percent an iteration, with the energy flat to 1e-14 the
+      ! whole time. An SCF then exhausts its iterations and returns a density
+      ! wrong by 1e-6, which every variational quantity absorbs and every
+      ! response property inherits.
+      !
+      ! The weights are invariant under this: scaling the block rescales the
+      ! Lagrange multiplier alone, which nothing reads.
+      scale = maxval(abs(b_matrix(1:n, 1:n)))
+      if (scale > 0.0_dp) b_matrix(1:n, 1:n) = b_matrix(1:n, 1:n)/scale
 
       call solve_diis(b_matrix, coefficients, ok)
       deallocate (b_matrix)

--- a/validation/check_xc_kernel.f90
+++ b/validation/check_xc_kernel.f90
@@ -138,6 +138,20 @@ contains
       call run_libcint_rhf(mol, nelec, 200, 1.0e-12_dp, 1.0e-10_dp, .false., scf, error, xc=xc)
       if (fail(error, n_bad)) return
 
+      ! An SCF that ran out of iterations returns its last iterate and no error,
+      ! so this has to be asked for. It is not a formality here: a reference
+      ! density wrong by 1e-6 moves the analytic polarizability by 1e-5 while
+      ! leaving a finite-field control -- which is variational, and so
+      ! second-order insensitive to exactly this -- looking correct. Every
+      ! disagreement in this file traced back to that and to nothing else.
+      if (.not. scf%converged) then
+         write (*, "(a,i0,a)") "  FAIL: the reference SCF did not converge in ", &
+            scf%iterations, " iterations"
+         n_bad = n_bad + 1
+         call mol%destroy()
+         return
+      end if
+
       ! The same reference, with and without the kernel in the response. The
       ! difference between these two is the whole of what this file tests: if
       ! they agree, `xc_kernel_apply` contributed nothing and the plumbing is


### PR DESCRIPTION
Scale the DIIS error block, and stop trusting an exhausted SCF

The exchange-correlation kernel check has been failing on H2O/SVWN by 8e-6
against a 1e-6 tolerance, and on H2O/BLYP by 8e-7. The kernel was not the
reason, and neither was anything it was reasonable to suspect: the grid is
converged to 1e-9 and integrates the density to the same 1e-8 PySCF's does,
plain Hartree-Fock reproduces PySCF's orbital energies to every printed digit,
V_xc is the exact derivative of E_xc and f_xc the exact derivative of V_xc --
both to the finite-difference floor -- and at a common density the two codes'
potentials differ by 6e-8.

What was wrong is that the reference SCF never converged.

`diis_coefficients` assembled the bordered system with the error block
unscaled. Those entries are inner products of error vectors, so by the time an
SCF is near where it should stop they are around 1e-16, against a constraint
border that stays -1. Eliminating that makes the weights of a saturated
subspace noise. The failure is not a visible blow-up: for H2O/SVWN the density
bottoms out at 1.4e-8 after seven iterations and then drifts *away* from the
fixed point at about 3% an iteration, with the energy flat to 1e-14, until 200
iterations return a density wrong by 2.3e-6.

Scaling the block to O(1) fixes it -- the weights are invariant, only the
Lagrange multiplier rescales. H2O/SVWN now converges in 15 iterations having
never converged at all; HCN/SVWN takes 16 where it took 80, HCN/BLYP 16 where
it took 62.

That the polarizability was the thing to notice is not luck. A variational
quantity absorbs a first-order error in the density and a finite field, being
variational at every point, absorbs it too -- which is why the finite-field
control agreed with PySCF while the analytic response, whose error is first
order in the residual, did not. The disagreement tracked the final density
error at a factor of 3.5 across both failing cases, and the five cases that
passed are the five whose SCF converged.

So the check now fails on `.not. scf%converged` rather than reading the last
iterate of an SCF that ran out of road. The driver already asks; a library
caller has to.

    H2O / sto-3g, SVWN   -8.309E-06  ->  1.154E-08
    H2O / sto-3g, BLYP   -7.910E-07  ->  2.072E-09

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>