### PR TITLE
Give the continuum a gradient 

### DIFF
--- a/backends/cuest/CUEST.md
+++ b/backends/cuest/CUEST.md
@@ -439,8 +439,28 @@ Fock matrix beside Vxc. cuEST builds the cavity itself, so what is ours is the
 input data -- radii from `mqc_pcm_radii` and the Gaussian switching exponents,
 whose convention has *not* been checked against cuEST's and whose prefactor was
 calibrated against the reference rather than derived. Both spin channels share
-one solve, since the surface charges come from the total density. Gradients are
-bound (`cuestPCMDerivativeCompute`) but not called.
+one solve, since the surface charges come from the total density.
+
+`cuestPCMDerivativeCompute` is now called, from `system_gradient_pcm`, and its
+term added in `compute_scf_gradient`. **It has never been run.** This box has no
+libcuest to link against, so what has been checked is that it compiles against
+the real bindings -- argument counts, types and the parameter constants -- and
+nothing more. Before trusting it:
+
+- Finite-difference one component. Displace an atom, take `(E(+h) - E(-h))/2h`
+  against cuEST's own PCM energy, and compare with the reported gradient. That
+  validates the wiring -- layout, sign, and whether the one call covers every
+  term -- without depending on whether the cavity model is right.
+- Only then look at an optimisation. Before this the gradient omitted the
+  continuum entirely while the energy included it, so an optimisation was
+  minimising one function along the gradient of another and could not converge;
+  that is the symptom this is meant to fix.
+
+If the finite difference agrees but solvated optimisations still behave badly,
+suspect the switching exponents above rather than this: a prefactor fitted to an
+energy can absorb a constant error while leaving its geometry dependence wrong,
+and a gradient is exactly that geometry dependence. The 1.5% is upstream of
+everything here.
 
 Multi-rank GPU binding is implemented and logged, but has not yet been exercised
 beyond one rank.

--- a/backends/cuest/backend/mqc_cuest_gradient.f90
+++ b/backends/cuest/backend/mqc_cuest_gradient.f90
@@ -165,6 +165,15 @@ contains
       end if
       if (.not. error%has_error()) gradient = gradient + term
 
+      ! ---- continuum solvation (no-op without a cavity) ---------------------
+      !
+      ! Last, and from the total density: the cavity couples to the whole
+      ! electron density, not to one spin channel, which is why this is one call
+      ! for both the restricted and unrestricted paths where the two above are
+      ! two.
+      call system%gradient_pcm(scf%density, term, error)
+      if (.not. error%has_error()) gradient = gradient + term
+
       deallocate (term, weighted, half_density)
 
       if (error%has_error()) then

--- a/backends/cuest/backend/mqc_cuest_integrals.f90
+++ b/backends/cuest/backend/mqc_cuest_integrals.f90
@@ -46,6 +46,7 @@ module mqc_cuest_integrals
                     cuestPCMIntPlanCreate, cuestPCMIntPlanCreateWorkspaceQuery, &
                     cuestPCMIntPlanDestroy, &
                     cuestPCMPotentialCompute, cuestPCMPotentialComputeWorkspaceQuery, &
+                    cuestPCMDerivativeCompute, cuestPCMDerivativeComputeWorkspaceQuery, &
                     cuestResultsCreate, cuestResultsDestroy, &
                     CUEST_PCMINTPLAN, CUEST_PCMINTPLAN_NUM_POINT, &
                     CUEST_PCMINTPLAN_NUM_ACTIVE_POINT, &
@@ -53,6 +54,9 @@ module mqc_cuest_integrals
                     CUEST_PCMPOTENTIALCOMPUTE_PARAMETERS, &
                     CUEST_PCMPOTENTIALCOMPUTE_PARAMETERS_CONVERGENCE_THRESHOLD, &
                     CUEST_PCMPOTENTIALCOMPUTE_PARAMETERS_MAX_ITERATIONS, &
+                    CUEST_PCMDERIVATIVECOMPUTE_PARAMETERS, &
+                    CUEST_PCMDERIVATIVECOMPUTE_PARAMETERS_CONVERGENCE_THRESHOLD, &
+                    CUEST_PCMDERIVATIVECOMPUTE_PARAMETERS_MAX_ITERATIONS, &
                     CUEST_PCM_RESULTS, CUEST_PCMRESULT_PCM_DIELECTRIC_ENERGY, &
                     CUEST_PCMRESULT_CONVERGED_RESIDUAL, &
                     CUEST_PCMRESULT_NUM_ITERATIONS_TAKEN, CUEST_PCMRESULT_CONVERGED, &
@@ -282,6 +286,7 @@ module mqc_cuest_integrals
       procedure :: gradient_xc => system_gradient_xc
       procedure :: gradient_two_electron_uks => system_gradient_two_electron_uks
       procedure :: gradient_xc_uks => system_gradient_xc_uks
+      procedure :: gradient_pcm => system_gradient_pcm
    end type cuest_system_t
 
 contains
@@ -1244,6 +1249,109 @@ contains
 
       if (error%has_error()) pcm_energy = 0.0_dp
    end subroutine system_pcm_device
+
+   subroutine system_gradient_pcm(this, density, gradient, error)
+      !! The continuum's contribution to the nuclear gradient
+      !!
+      !! Everything in the dielectric energy depends on where the nuclei are:
+      !! the surface points sit on atom-centred spheres, the switching weights
+      !! are functions of interatomic distances, and the surface charges
+      !! interact with the nuclei directly. cuEST differentiates all of that
+      !! behind one call, in the same way it builds the cavity itself.
+      !!
+      !! The surface charges do *not* need a response term. They are determined
+      !! variationally, so the energy is stationary with respect to them and
+      !! their derivative contributes nothing at first order -- the same reason
+      !! `pcm_device` hands the Fock matrix the full potential rather than half
+      !! of it. What would otherwise be the expensive part of a continuum
+      !! gradient is therefore simply absent.
+      !!
+      !! `d_q_in` holds the converged charges on entry: the last SCF iteration
+      !! copies `q_out` into it, so a gradient taken after a converged SCF
+      !! starts from the right surface rather than from zero.
+      class(cuest_system_t), intent(inout) :: this
+      real(dp), intent(in) :: density(:, :)    !! Total density, (n_ao, n_ao)
+      real(dp), intent(out) :: gradient(:, :)  !! (3, n_atoms), Hartree/Bohr
+      type(error_t), intent(inout) :: error
+
+      type(cuestWorkspaceDescriptor_t) :: temporary_desc
+      type(cuestWorkspace_t) :: temporary_ws
+      type(c_ptr) :: params, results
+      integer(c_int) :: status
+      integer(c_int64_t) :: max_iter
+      real(dp) :: residual
+
+      gradient = 0.0_dp
+      if (error%has_error() .or. .not. this%has_pcm) return
+
+      call stage_matrix(this, this%d_matrix, density, "density (PCM gradient)", error)
+      if (error%has_error()) return
+
+      params = c_null_ptr
+      results = c_null_ptr
+      call cuest_status_check(cuestParametersCreate(CUEST_PCMDERIVATIVECOMPUTE_PARAMETERS, params), &
+                              "cuestParametersCreate(PCM derivative)", error)
+      if (.not. error%has_error()) then
+         call cuest_status_check(cuest_param_set_f64(CUEST_PCMDERIVATIVECOMPUTE_PARAMETERS, params, &
+                                                     CUEST_PCMDERIVATIVECOMPUTE_PARAMETERS_CONVERGENCE_THRESHOLD, &
+                                                     this%pcm_tolerance), &
+                                 "PCM derivative convergence threshold", error)
+      end if
+      if (.not. error%has_error()) then
+         max_iter = int(this%pcm_max_iter, c_int64_t)
+         call cuest_status_check(cuest_param_set_i64(CUEST_PCMDERIVATIVECOMPUTE_PARAMETERS, params, &
+                                                     CUEST_PCMDERIVATIVECOMPUTE_PARAMETERS_MAX_ITERATIONS, &
+                                                     max_iter), &
+                                 "PCM derivative iteration limit", error)
+      end if
+      if (.not. error%has_error()) then
+         call cuest_status_check(cuestResultsCreate(CUEST_PCM_RESULTS, results), &
+                                 "cuestResultsCreate(PCM derivative)", error)
+      end if
+
+      if (.not. error%has_error()) then
+         call cuest_status_check(cuestPCMDerivativeComputeWorkspaceQuery(this%handle, this%pcm_plan, &
+                                                                         params, temporary_desc, &
+                                                                         this%d_matrix, this%d_q_in, &
+                                                                         this%d_q_out, results, &
+                                                                         this%d_gradient), &
+                                 "cuestPCMDerivativeComputeWorkspaceQuery", error)
+      end if
+      if (.not. error%has_error()) call workspace_alloc(temporary_ws, temporary_desc, error)
+      if (.not. error%has_error()) then
+         call cuest_status_check(cuestPCMDerivativeCompute(this%handle, this%pcm_plan, params, &
+                                                           temporary_ws, this%d_matrix, this%d_q_in, &
+                                                           this%d_q_out, results, this%d_gradient), &
+                                 "cuestPCMDerivativeCompute", error)
+      end if
+
+      ! The derivative runs its own iterative solve, so it converges or it does
+      ! not, exactly as the energy's does. Read the residual rather than
+      ! `CUEST_PCMRESULT_CONVERGED` for the reason given in `pcm_device`: that
+      ! attribute's width is not recoverable from the bindings.
+      if (.not. error%has_error()) then
+         call cuest_status_check(cuest_results_query_f64(CUEST_PCM_RESULTS, results, &
+                                                         CUEST_PCMRESULT_CONVERGED_RESIDUAL, &
+                                                         residual), &
+                                 "query PCM derivative residual", error)
+         if (.not. error%has_error()) then
+            this%pcm_residual = residual
+            this%pcm_solved = (residual <= this%pcm_tolerance)
+         end if
+      end if
+
+      call workspace_free(temporary_ws)
+      if (c_associated(results)) then
+         status = cuestResultsDestroy(CUEST_PCM_RESULTS, results)
+         call cuest_status_check(status, "cuestResultsDestroy(PCM derivative)", error)
+      end if
+      if (c_associated(params)) then
+         status = cuestParametersDestroy(CUEST_PCMDERIVATIVECOMPUTE_PARAMETERS, params)
+         call cuest_status_check(status, "cuestParametersDestroy(PCM derivative)", error)
+      end if
+
+      call fetch_gradient(this, gradient, "dE_diel/dR", error)
+   end subroutine system_gradient_pcm
 
    subroutine system_xc_device(this, d_c_occ, d_out, xc_energy, error)
       !! RKS exchange-correlation potential, device in and device out

--- a/mqc_docs/source/capabilities.rst
+++ b/mqc_docs/source/capabilities.rst
@@ -684,3 +684,21 @@ For a 20-water cluster with cutoffs ``2=5.0, 3=4.0``:
 2. Start with lower fragmentation levels (MBE(2) or MBE(3))
 3. For overlapping systems, use GMBE(2) with controlled intersection depth
 4. Profile with small test systems before production runs
+
+Acknowledgements
+================
+
+Metalquicha builds on several external projects, without which much of the above
+would not exist:
+
+- **cuEST** -- the GPU quantum chemistry engine behind the ``cuest`` backend,
+  `NVIDIA cuEST <https://developer.nvidia.com/cuda/cuda-x-libraries/cuest>`_.
+  All GPU Hartree-Fock and Kohn-Sham energies, gradients and the PCM continuum
+  are assembled from its APIs.
+- **tblite** -- the semi-empirical engine behind the XTB methods,
+  `tblite <https://github.com/tblite/tblite>`_, providing GFN1-xTB and GFN2-xTB.
+- **DL-FIND** -- the geometry optimizer behind the ``Optimize`` driver,
+  `DL-FIND <https://www.chemshell.org/dl-find>`_, reached through
+  `libdlfind <https://github.com/digital-chemistry-laboratory/libdlfind>`_.
+
+We are grateful to their authors and maintainers.

--- a/src/methods/mqc_method_factory.F90
+++ b/src/methods/mqc_method_factory.F90
@@ -205,6 +205,11 @@ contains
       m%options%density_tol = config%scf%density_convergence
       m%options%use_diis = config%scf%use_diis
       m%options%diis_size = config%scf%diis_size
+      ! Not from `config%dft`, and so easy to leave out: the continuum sits on
+      ! the shared config beside the SCF settings precisely because it applies
+      ! to any reference. `configure_dft` copied it and this did not, which made
+      ! `keywords.pcm` a no-op for Hartree-Fock, MP2 and coupled cluster.
+      m%options%pcm = config%pcm
    end subroutine configure_hf
 
    subroutine configure_dft(m, config)

--- a/src/methods/mqc_method_hf.F90
+++ b/src/methods/mqc_method_hf.F90
@@ -13,6 +13,7 @@ module mqc_method_hf
    use pic_types, only: dp
    use mqc_config_types, only: guess_step_t
    use mqc_method_base, only: qc_method_t
+   use mqc_method_config, only: pcm_config_t
    use mqc_result_types, only: calculation_result_t
    use mqc_physical_fragment, only: physical_fragment_t
    use mqc_error, only: error_t, ERROR_VALIDATION
@@ -28,6 +29,12 @@ module mqc_method_hf
 
    type :: hf_options_t
       !! Hartree-Fock calculation options
+      type(pcm_config_t) :: pcm
+         !! Continuum solvation. Carried here as well as on the Kohn-Sham
+         !! options because a continuum is a property of the reference, not of
+         !! the functional: Hartree-Fock, MP2 and coupled cluster all reach the
+         !! backend through this type, and leaving it off meant `keywords.pcm`
+         !! was read, validated, and then silently dropped for every one of them.
       character(len=32) :: basis_set = "sto-3g"
          !! Orbital basis set name
       character(len=32) :: aux_basis_set = "def2-universal-jkfit"
@@ -119,6 +126,7 @@ contains
       type(cuest_scf_settings_t) :: settings
       type(error_t) :: backend_error
 
+      settings%pcm = this%options%pcm
       settings%basis_set = this%options%basis_set
       settings%aux_basis_set = this%options%aux_basis_set
       settings%aux_basis_named = this%options%aux_basis_named

--- a/test/test_mqc_config_roundtrip.f90
+++ b/test/test_mqc_config_roundtrip.f90
@@ -41,7 +41,8 @@ contains
                   new_unittest("counterpoise_is_refused_where_it_is_ignored", &
                                test_counterpoise_refusals), &
                   new_unittest("hf_settings_reach_the_method", test_hf_roundtrip), &
-                  new_unittest("dft_settings_reach_the_method", test_dft_roundtrip) &
+                  new_unittest("dft_settings_reach_the_method", test_dft_roundtrip), &
+                  new_unittest("pcm_reaches_every_reference", test_pcm_reaches_every_reference) &
                   ]
    end subroutine collect_mqc_config_roundtrip_tests
 
@@ -214,6 +215,94 @@ contains
                  "counterpoise with "//label//" must be refused, not ignored")
       call err%clear()
    end subroutine must_refuse
+
+   subroutine write_pcm_input(method, extra_model)
+      !! A deck asking for a continuum, for whichever reference
+      character(len=*), intent(in) :: method
+      character(len=*), intent(in) :: extra_model
+      integer :: unit
+
+      open (newunit=unit, file=SCRATCH_FILE, status="replace", action="write")
+      write (unit, "(A)") "{"
+      write (unit, "(A)") '  "schema": {"name": "roundtrip", "version": "1.0"},'
+      write (unit, "(A)") '  "model": {'
+      write (unit, "(A)") '    "method": "'//method//'",'
+      if (len_trim(extra_model) > 0) then
+         write (unit, "(A)") '    "basis": "cc-pvdz",'
+         write (unit, "(A)") "    "//extra_model
+      else
+         write (unit, "(A)") '    "basis": "cc-pvdz"'
+      end if
+      write (unit, "(A)") "  },"
+      write (unit, "(A)") '  "driver": "Energy",'
+      write (unit, "(A)") '  "keywords": {"pcm": {"dielectric": 78.4, "angular_points": 110}},'
+      write (unit, "(A)") '  "molecules": [{'
+      write (unit, "(A)") '    "symbols": ["He"], "geometry": [0.0, 0.0, 0.0],'
+      write (unit, "(A)") '    "molecular_charge": 0, "molecular_multiplicity": 1'
+      write (unit, "(A)") "  }]"
+      write (unit, "(A)") "}"
+      close (unit)
+   end subroutine write_pcm_input
+
+   subroutine test_pcm_reaches_every_reference(error)
+      !! A continuum is a property of the reference, not of the functional
+      !!
+      !! `keywords.pcm` parses, validates and reaches `method_config` whatever
+      !! the method is -- so a reference that forgets to copy it off the shared
+      !! config produces a gas-phase number for a deck that asked for solvent,
+      !! converged and of the right magnitude, with nothing in the output to say
+      !! so. Hartree-Fock did exactly that, and MP2 and coupled cluster inherited
+      !! it, because they are all configured through `configure_hf`.
+      type(error_type), allocatable, intent(out) :: error
+      type(mqc_config_t) :: config
+      type(driver_config_t) :: driver
+      class(qc_method_t), allocatable :: method
+      type(error_t) :: parse_error
+
+      call write_pcm_input("hf", "")
+      call read_json_config_file(SCRATCH_FILE, config, parse_error)
+      call remove_input()
+      call check(error,.not. parse_error%has_error(), "a deck with keywords.pcm should parse")
+      if (allocated(error)) return
+
+      call check(error, config%pcm_enabled, "keywords.pcm must survive parsing")
+      if (allocated(error)) return
+
+      call config_to_driver(config, driver)
+      call check(error, driver%method_config%pcm%enabled, &
+                 "pcm must survive the config adapter")
+      if (allocated(error)) return
+
+      allocate (method, source=create_method(driver%method_config))
+      select type (m => method)
+      type is (hf_method_t)
+         call check(error, m%options%pcm%enabled, &
+                    "pcm must reach the Hartree-Fock method, not just the Kohn-Sham one")
+         if (allocated(error)) return
+         call check(error, m%options%pcm%dielectric, 78.4_dp, &
+                    "the dielectric must reach the Hartree-Fock method")
+      class default
+         call check(error, .false., "method = hf should build an hf_method_t")
+      end select
+      deallocate (method)
+      if (allocated(error)) return
+
+      ! The path that already worked, so a fix to one cannot quietly break it.
+      call write_pcm_input("dft", '"functional": "pbe0"')
+      call read_json_config_file(SCRATCH_FILE, config, parse_error)
+      call remove_input()
+      call check(error,.not. parse_error%has_error(), "the Kohn-Sham deck should parse")
+      if (allocated(error)) return
+
+      call config_to_driver(config, driver)
+      allocate (method, source=create_method(driver%method_config))
+      select type (m => method)
+      type is (dft_method_t)
+         call check(error, m%options%pcm%enabled, "pcm must reach the Kohn-Sham method")
+      class default
+         call check(error, .false., "method = dft should build a dft_method_t")
+      end select
+   end subroutine test_pcm_reaches_every_reference
 
    subroutine test_hf_roundtrip(error)
       !> Error handling


### PR DESCRIPTION
A geometry optimisation in solvent could not converge, and the reason was not numerical. `compute_scf_gradient` assembled nuclear repulsion, kinetic, nuclear attraction, Pulay, two-electron and exchange-correlation, and nothing from the cavity, while the SCF energy it was minimising added `pcm_energy`. The optimiser was being handed the derivative of one function and the value of another. No quasi-Newton method converges on that: the search direction is not a descent direction for the energy, the gradient norm plateaus at whatever the missing force happens to be, and the two convergence tests are never satisfied together.

The missing force is not small. The nuclei interact with the surface charges directly, the surface points ride on atom-centred spheres, and the switching weights are functions of interatomic distances -- all of it geometry dependent, all of it absent. cuEST differentiates the lot behind `cuestPCMDerivativeCompute`, which was bound and never called.

What is *not* needed is a response term for the surface charges. They are determined variationally, so the energy is stationary with respect to them and they contribute nothing at first order -- the same fact that lets `pcm_device` hand the Fock matrix the full potential rather than half of it. The expensive part of a continuum gradient is simply not there.

The derivative call takes the same arguments as the potential call it sits beside, down to `inQ`/`outQ`, so this follows `pcm_device` line for line. That also means the charges come in warm: the last SCF iteration copies `q_out` into `q_in`, so the gradient starts from the converged surface.

**This has never been executed.** There is no libcuest on the machine it was written on. What is verified is that it compiles against the real bindings -- the argument counts and types on `cuestPCMDerivativeCompute` and its workspace query, and the parameter constants -- and that the CPU suite is untouched at 73/73. `CUEST.md` records how to check it: finite-difference one component against cuEST's own PCM energy first, because that tests this wiring independently of the switching-exponent convention, which is separately documented as unverified and calibrated rather than derived.

Should close #215 