### PR TITLE
Spread one cuEST system over several GPUs, and stop running out of me…

### DIFF
--- a/backends/cuest/CUEST.md
+++ b/backends/cuest/CUEST.md
@@ -462,5 +462,107 @@ energy can absorb a constant error while leaving its geometry dependence wrong,
 and a gradient is exactly that geometry dependence. The 1.5% is upstream of
 everything here.
 
-Multi-rank GPU binding is implemented and logged, but has not yet been exercised
-beyond one rank.
+## Multi-GPU
+
+```json
+"system": { "gpu": true, "multi_gpu": true }
+```
+
+then `mpirun -np 4 ./build/mqc deck.json`, one rank per GPU. The rank-to-device
+binding is the one that was already here -- `cudaSetDevice(mod(local_rank,
+device_count))` in `mqc_cuest_context.f90`, which is what cuEST's own
+`basic_multigpu_usage` sample does with pthreads instead of ranks.
+
+**What divides, and what does not.** The exchange-correlation quadrature
+divides. Nothing else does. Every rank still builds a full density-fitting
+plan, so this mode does **not** reduce the memory that a large DF calculation
+runs out of -- for that see the next section, which is the actual fix.
+
+That is a property of cuEST 0.2's API, not a shortcut taken here:
+
+- `cuestAOPairListCreate` takes a screening *threshold*, not a list. There is no
+  way to hand one GPU a subset of shell pairs.
+- Splitting the auxiliary basis gives each GPU a different fitting metric
+  `(P|Q)^-1/2`. That is a different, worse fit, not a partition of one.
+- `cuestDFSymmetricExchangeCompute` is opaque from C to K. The `B^P C`
+  intermediate that a distributed K would have to reduce is never exposed.
+
+The grid is different because we build it ourselves. `mqc_cuest_grid.f90`
+computes the Treutler-Ahlrichs radial mesh and hands it to `cuestAtomGridCreate`,
+so rank *g* of *N* simply keeps radial shells `g, g+N, g+2N, ...` -- of every
+atom, with all nuclear coordinates still passed to `cuestMolecularGridCreate`.
+The Becke partition weight at a point is a function of that point and all the
+nuclei and knows nothing about which other points exist, so the slices partition
+the quadrature **exactly**. Summing them reproduces the single-GPU integral term
+for term, not to a tolerance. `Vxc` (an `n_ao^2` allreduce), `Exc` and `dExc/dR`
+are reduced inside `mqc_cuest_integrals.f90`, so the SCF and the gradient never
+learn the mode exists.
+
+Striding rather than blocking, because the mesh is dense near the nucleus and
+sparse in the tail: a contiguous split would give one rank the core and another
+the vacuum. `keywords.dft.radial_points` must be at least the rank count, or the
+run is refused -- a rank with no radial shells would have no XC plan, and the XC
+plan is what the DF plan asks for its exact-exchange fraction, so that rank would
+build a differently defined Fock operator rather than merely contribute nothing.
+
+**Refused with fragmentation.** A fragmented run already means one rank per
+subsystem; the two want the same ranks for different things and there is no
+sensible precedence between them. Also refused on the CPU backend, and for any
+method cuEST cannot run. All three abort rather than falling back, because the
+reason to reach for this mode is that the single-GPU version did not fit -- a
+silent fallback is not a degraded success, it is the same failure arriving later.
+
+On a single rank the mode is inert: `gpu_team_active` is false, the grid is not
+sliced, and every reduction is a no-op. That is what makes `-np 1` a valid
+reference for `-np N`:
+
+```bash
+./validation/run_multigpu_test.sh 4        # 1 rank vs 4, energy and |grad|
+```
+
+Non-root ranks are dropped to `warning` level for the duration, so four GPUs
+report one calculation rather than four interleaved copies of it.
+
+**Not yet run on hardware.** Everything above compiles against the real bindings
+and the partition arithmetic is unit-tested (`test_mqc_gpu_team`), but this
+repository's box has V100s, which cuEST refuses. Nothing here has executed on a
+GPU.
+
+## Running out of device memory
+
+The largest allocation a cuEST run makes is the DF plan's persistent workspace,
+which holds the cached three-index integrals. NVIDIA's own reference SCF marks
+that line as the likely point of failure, and a B3LYP/cc-pVTZ gradient on
+anything sizeable is where people meet it. Two keywords and one automatic
+behaviour:
+
+```json
+"keywords": { "scf": {
+    "df_integral_direct": true,
+    "df_derivative_memory": "recompute"
+} }
+```
+
+- **`df_integral_direct`** sets `CUEST_DFINTPLAN_PARAMETERS_THREE_INDEX_INTEGRAL_DIRECT`.
+  The three-index integrals are recomputed on every J and K build instead of
+  stored. This is the single largest reduction available. It is slower, and it
+  is the difference between an answer and none.
+- **`df_derivative_memory`** sets
+  `CUEST_DFSYMMETRICDERIVATIVECOMPUTE_PARAMETERS_MEMORY_POLICY`: `auto`
+  (cuEST's default), `devicecache`, `hostcache`, `overwrite` or `recompute`. A
+  separate allocation with a separate lifetime -- the plan's cache lives across
+  the whole SCF, this one only across the gradient -- which is why a gradient
+  can run out of memory where the energy that produced it did not.
+
+Neither is needed to get a diagnosis. The plan's size is queried before it is
+allocated and logged at verbose level against the device's free memory, and if
+the cache will not fit the plan is rebuilt integral-direct automatically, with a
+warning naming both numbers. Setting `df_integral_direct` explicitly skips the
+query and makes the choice the deck's rather than the backend's. A failure that
+survives all of that reports what it needed, what was free, and which of the two
+knobs is still unused.
+
+The names in `df_derivative_memory` are repeated by hand in `mqc_cuest_iface`,
+which is compiled on the fpm path where the cuEST bindings do not exist.
+`test_mqc_cuest_memory_policy` pins them against the real enumerators wherever
+the bindings are present, so the copy cannot drift silently.

--- a/backends/cuest/backend/mqc_cuest_driver.f90
+++ b/backends/cuest/backend/mqc_cuest_driver.f90
@@ -22,7 +22,8 @@ module mqc_cuest_driver
                             SCF_GUESS_CORE, SCF_GUESS_GWH, SCF_GUESS_SAC
    use mqc_cuest_atomic_guess, only: build_sac_guess
    use mqc_cuest_gradient, only: compute_scf_gradient
-   use mqc_cuest_iface, only: cuest_scf_settings_t
+   use mqc_cuest_iface, only: cuest_scf_settings_t, parse_df_derivative_memory
+   use mqc_gpu_team, only: gpu_team_active, gpu_team_size
    implicit none
    private
 
@@ -57,9 +58,23 @@ contains
       character(len=8), allocatable :: element_symbols(:)
       integer :: iatom, functional_id, n_alpha, n_beta
       logical :: need_gradient, unrestricted, occupations_ok
+      logical :: shard_grid
+      integer :: derivative_memory
 
       need_gradient = .false.
       if (present(want_gradient)) need_gradient = want_gradient
+
+      ! Resolved before any integrals, so a misspelled policy costs nothing.
+      call parse_df_derivative_memory(settings%df_derivative_memory, derivative_memory, error)
+      if (error%has_error()) then
+         call record_failure(result, error)
+         return
+      end if
+
+      ! Only the molecular system is sharded. `gpu_team_active` is false for a
+      ! single-rank run whatever the deck asked for, so this is also what turns
+      ! the mode off when there is nothing to spread over.
+      shard_grid = settings%multi_gpu .and. gpu_team_active()
 
       ! ---- which functional, if any ----------------------------------------
       if (len_trim(settings%functional) == 0) then
@@ -154,13 +169,19 @@ contains
                             orbital_basis, auxiliary_basis, settings%spherical, &
                             n_alpha, functional_id, settings%radial_points, &
                             settings%angular_points, error, n_occ_beta=n_beta, &
-                            n_guess_columns=n_guess_columns, pcm=settings%pcm)
+                            n_guess_columns=n_guess_columns, pcm=settings%pcm, &
+                            shard_xc_grid=shard_grid, &
+                            df_integral_direct=settings%df_integral_direct, &
+                            df_derivative_memory_policy=derivative_memory)
       else
          call system%create(context, fragment%element_numbers, fragment%coordinates, &
                             orbital_basis, auxiliary_basis, settings%spherical, &
                             fragment%nelec/2, functional_id, settings%radial_points, &
                             settings%angular_points, error, &
-                            n_guess_columns=n_guess_columns, pcm=settings%pcm)
+                            n_guess_columns=n_guess_columns, pcm=settings%pcm, &
+                            shard_xc_grid=shard_grid, &
+                            df_integral_direct=settings%df_integral_direct, &
+                            df_derivative_memory_policy=derivative_memory)
       end if
 
       if (.not. error%has_error()) then

--- a/backends/cuest/backend/mqc_cuest_grid.f90
+++ b/backends/cuest/backend/mqc_cuest_grid.f90
@@ -20,7 +20,8 @@ module mqc_cuest_grid
    use, intrinsic :: iso_c_binding, only: c_ptr, c_null_ptr, c_int, c_int64_t, &
                                                                              c_double, c_loc, c_associated
    use pic_types, only: dp
-   use mqc_error, only: error_t
+   use mqc_error, only: error_t, ERROR_VALIDATION
+   use pic_io, only: to_char
    use mqc_cuest_runtime, only: cuest_status_check
    use cuest, only: cuestAtomGridCreate, cuestAtomGridDestroy, &
                     cuestParametersCreate, cuestParametersDestroy, &
@@ -107,24 +108,64 @@ contains
       end do
    end subroutine ahlrichs_radial_quadrature
 
-   subroutine build_atom_grids(handle, atomic_numbers, n_radial, n_angular, grid_set, error)
+   subroutine build_atom_grids(handle, atomic_numbers, n_radial, n_angular, grid_set, error, &
+                               shard_index, shard_count)
       !! Build one unpruned direct-product grid per atom
+      !!
+      !! With `shard_count` > 1 each atom keeps only every `shard_count`-th
+      !! radial shell, starting at `shard_index`. Every atom is still present
+      !! and every atom still gets a grid, so the molecular grid built from the
+      !! result covers the whole molecule at a lower radial density; the Becke
+      !! partition weight at a surviving point is unchanged, because it is a
+      !! function of that point and of all the nuclear positions and knows
+      !! nothing about which other points exist. Summing the slices therefore
+      !! reproduces the unsharded quadrature exactly, term for term -- this is
+      !! a partition of the sum, not an approximation to it.
+      !!
+      !! Striding rather than blocking on purpose: consecutive radial shells
+      !! carry wildly different weight (the mesh is dense near the nucleus and
+      !! sparse in the tail), so a contiguous block would hand one rank the
+      !! core and another the vacuum. Striding gives every rank the same mix.
       type(c_ptr), intent(in) :: handle          !! cuEST handle
       integer, intent(in) :: atomic_numbers(:)   !! Z per atom
-      integer, intent(in) :: n_radial            !! Radial points per atom
+      integer, intent(in) :: n_radial            !! Radial points per atom, before sharding
       integer, intent(in) :: n_angular           !! Lebedev order per radial shell
       type(atom_grid_set_t), intent(out) :: grid_set
       type(error_t), intent(inout) :: error
+      integer, intent(in), optional :: shard_index  !! 0-based slice to keep
+      integer, intent(in), optional :: shard_count  !! Number of slices; 1 keeps everything
 
       real(dp), allocatable :: nodes(:), weights(:)
+      real(dp), allocatable :: my_nodes(:), my_weights(:)
       integer(c_int64_t), allocatable :: angular_points(:)
       type(c_ptr) :: grid_params
       integer(c_int) :: status
-      integer :: iatom, n_atoms
+      integer :: iatom, n_atoms, n_shards, my_shard, n_kept, i, k
+
+      n_shards = 1
+      my_shard = 0
+      if (present(shard_count)) n_shards = max(shard_count, 1)
+      if (present(shard_index)) my_shard = shard_index
+
+      ! A shard with no radial shells would leave this rank without an XC plan,
+      ! and the XC plan is what the DF plan asks for its exact-exchange
+      ! fraction -- so the rank would go on to build a *differently defined*
+      ! Fock operator rather than merely contribute nothing. Refused here,
+      ! where the cause is still visible.
+      if (n_shards > n_radial) then
+         call error%set(ERROR_VALIDATION, &
+                        "multi-GPU XC grid: "//to_char(n_shards)//" ranks share "// &
+                        to_char(n_radial)//" radial shells, so some rank would get none. "// &
+                        "Raise keywords.dft.radial_points to at least the rank count, "// &
+                        "or run on fewer ranks.")
+         return
+      end if
+
+      n_kept = (n_radial - my_shard - 1)/n_shards + 1
 
       n_atoms = size(atomic_numbers)
       grid_set%n_atoms = n_atoms
-      grid_set%n_radial = n_radial
+      grid_set%n_radial = n_kept
       grid_set%n_angular = n_angular
 
       allocate (grid_set%grids(n_atoms))
@@ -137,13 +178,20 @@ contains
 
       ! One angular order for every radial shell -- this is what makes the
       ! grid "unpruned".
-      allocate (nodes(n_radial), weights(n_radial), angular_points(n_radial))
+      allocate (nodes(n_radial), weights(n_radial))
+      allocate (my_nodes(n_kept), my_weights(n_kept), angular_points(n_kept))
       angular_points = int(n_angular, c_int64_t)
 
       do iatom = 1, n_atoms
          call ahlrichs_radial_quadrature(n_radial, ahlrichs_radius(atomic_numbers(iatom)), &
                                          nodes, weights)
-         call create_atom_grid(handle, int(n_radial, c_int64_t), nodes, weights, &
+         k = 0
+         do i = my_shard + 1, n_radial, n_shards
+            k = k + 1
+            my_nodes(k) = nodes(i)
+            my_weights(k) = weights(i)
+         end do
+         call create_atom_grid(handle, int(n_kept, c_int64_t), my_nodes, my_weights, &
                                angular_points, grid_params, grid_set%grids(iatom), error)
          if (error%has_error()) exit
       end do
@@ -151,7 +199,7 @@ contains
       status = cuestParametersDestroy(CUEST_ATOMGRID_PARAMETERS, grid_params)
       call cuest_status_check(status, "cuestParametersDestroy(atom grid)", error)
 
-      deallocate (nodes, weights, angular_points)
+      deallocate (nodes, weights, my_nodes, my_weights, angular_points)
       if (error%has_error()) then
          call error%add_context("mqc_cuest_grid:build_atom_grids")
          call grid_set%destroy()

--- a/backends/cuest/backend/mqc_cuest_integrals.f90
+++ b/backends/cuest/backend/mqc_cuest_integrals.f90
@@ -34,12 +34,16 @@ module mqc_cuest_integrals
    use mqc_cgto, only: molecular_basis_type
    use mqc_cuest_basis, only: cuest_shell_set_t, build_cuest_shells
    use mqc_cuest_grid, only: atom_grid_set_t, build_atom_grids
+   use mqc_gpu_team, only: gpu_team_active, gpu_team_rank, gpu_team_size, &
+                           gpu_team_reduce, gpu_team_reduce_scalar
    use mqc_cuest_context, only: cuest_context_t
    use mqc_cuest_runtime, only: cuest_status_check, cublas_status_check, &
                                 workspace_alloc, workspace_free, &
                                 copy_to_device, copy_to_host, device_sync, &
                                 device_offset, &
-                                device_alloc, device_free
+                                device_alloc, device_free, &
+                                device_memory_info, format_bytes, workspace_bytes
+   use pic_logger, only: logger => global_logger
    use cublas, only: cublasDaxpy, cublasDcopy, cublasDdot
    use cuest, only: cuestWorkspace_t, cuestWorkspaceDescriptor_t, &
                     cuestParametersCreate, cuestParametersDestroy, &
@@ -84,6 +88,8 @@ module mqc_cuest_integrals
                     CUEST_DFINTPLAN_PARAMETERS_EXCHANGE_FRACTION, &
                     CUEST_DFINTPLAN_PARAMETERS_LRC_EXCHANGE_FRACTION, &
                     CUEST_DFINTPLAN_PARAMETERS_LRC_EXCHANGE_OMEGA, &
+                    CUEST_DFINTPLAN_PARAMETERS_THREE_INDEX_INTEGRAL_DIRECT, &
+                    CUEST_DFSYMMETRICDERIVATIVECOMPUTE_PARAMETERS_MEMORY_POLICY, &
                     cuestMolecularGridCreate, cuestMolecularGridCreateWorkspaceQuery, &
                     cuestMolecularGridDestroy, &
                     cuestXCIntPlanCreate, cuestXCIntPlanCreateWorkspaceQuery, &
@@ -109,7 +115,8 @@ module mqc_cuest_integrals
                     CUEST_XCINTPLAN, CUEST_XCINTPLAN_EXCHANGE_SCALE, &
                     CUEST_XCINTPLAN_LRC_EXCHANGE_SCALE, CUEST_XCINTPLAN_LRC_OMEGA
    use cuest_helpers, only: cuest_query_i64, cuest_query_f64, cuest_param_set_f64, &
-                            cuest_param_set_i64, cuest_results_query_f64, &
+                            cuest_param_set_i64, cuest_param_set_i32, &
+                            cuest_results_query_f64, &
                             cuest_results_query_i64
    implicit none
    private
@@ -198,6 +205,27 @@ module mqc_cuest_integrals
 
       logical :: has_xc = .false.
          !! Whether an XC plan exists, i.e. this is DFT rather than HF
+      logical :: xc_grid_sharded = .false.
+         !! Whether this system's XC quadrature is one slice of a grid shared
+         !! with the other ranks of a GPU team. When it is, every Exc, Vxc and
+         !! dExc/dR produced here is a partial sum and is reduced across the
+         !! team before it leaves this module -- so nothing downstream, in the
+         !! SCF or the gradient, has to know the mode exists.
+         !!
+         !! Never set for the free-atom systems the SAC guess builds: those are
+         !! solved redundantly on every rank over the full grid, because they
+         !! are cheap and because a guess that differed between ranks would
+         !! desynchronize the SCF that follows.
+      logical :: df_integral_direct = .false.
+         !! Whether the DF plan recomputes the three-index integrals instead of
+         !! caching them. Halves nothing and costs time; it is here because the
+         !! cache is the single largest device allocation a calculation makes,
+         !! and a run that does not fit is worth more slowly than not at all.
+      integer :: df_derivative_memory_policy = -1
+         !! cuEST's memory policy for the DF gradient, or -1 to leave cuEST's
+         !! own default in place. Separate from the flag above because it is a
+         !! separate allocation with a separate lifetime: the plan's cache
+         !! lives across the whole SCF, this one only across the gradient.
       logical :: needs_exchange = .true.
          !! False for a pure functional, where K would be computed and then
          !! scaled by zero. cuEST's own header advises skipping the call.
@@ -293,7 +321,8 @@ contains
 
    subroutine system_create(this, context, atomic_numbers, coordinates, mol_basis, &
                             aux_mol_basis, use_spherical, n_occ, functional_id, &
-                            n_radial, n_angular, error, n_occ_beta, n_guess_columns, pcm)
+                            n_radial, n_angular, error, n_occ_beta, n_guess_columns, pcm, &
+                            shard_xc_grid, df_integral_direct, df_derivative_memory_policy)
       !! Build every cuEST object needed for one molecule
       !!
       !! Coordinates are in Bohr, matching metalquicha's internal units and
@@ -324,6 +353,17 @@ contains
          !! guess carries the summed atomic occupations, which usually exceeds
          !! the molecule's own count. Sizing here matters: growing a pool later
          !! would reallocate it and invalidate the pointers already borrowed.
+      logical, intent(in), optional :: shard_xc_grid
+         !! Take only this rank's slice of the XC quadrature, and reduce every
+         !! XC quantity across the GPU team before returning it. Absent means
+         !! the whole grid, which is what a single-GPU run and every free-atom
+         !! guess system want. Opt-in rather than inferred from the team being
+         !! live, because the guess systems are built while it is.
+      logical, intent(in), optional :: df_integral_direct
+         !! Recompute the three-index DF integrals rather than caching them
+      integer, intent(in), optional :: df_derivative_memory_policy
+         !! One of CUEST_DFSYMMETRICDERIVATIVECOMPUTE_MEMORY_POLICY_*, or
+         !! absent/negative to leave cuEST's default alone
 
       integer :: iatom, n_atoms
       integer(c_int64_t) :: widest, n_spin
@@ -337,6 +377,11 @@ contains
       this%unrestricted = present(n_occ_beta)
       if (this%unrestricted) this%n_occ_beta = int(n_occ_beta, c_int64_t)
       this%has_xc = (functional_id >= 0)
+      if (present(shard_xc_grid)) this%xc_grid_sharded = shard_xc_grid
+      if (present(df_integral_direct)) this%df_integral_direct = df_integral_direct
+      if (present(df_derivative_memory_policy)) then
+         this%df_derivative_memory_policy = df_derivative_memory_policy
+      end if
 
       if (size(coordinates, 2) /= n_atoms) then
          call error%set(ERROR_VALIDATION, "cuEST system: coordinate/atom count mismatch")
@@ -683,13 +728,87 @@ contains
 
    subroutine build_df_plan(this, error)
       !! Create the density-fitted integral plan over both bases
+      !!
+      !! This is where a calculation runs out of device memory. The plan's
+      !! persistent workspace holds the cached three-index integrals, and it is
+      !! by a wide margin the largest allocation the run makes -- NVIDIA's own
+      !! reference SCF marks the same line as the likely point of failure. Two
+      !! things follow. The size is queried and logged before it is asked for,
+      !! so a failure names a number instead of just failing; and if the number
+      !! does not fit, the plan is rebuilt integral-direct, which recomputes
+      !! those integrals on every J and K build rather than storing them.
+      !!
+      !! Integral-direct is slower and is not chosen for its own sake. It is
+      !! chosen because a run that does not fit produces no answer at all,
+      !! which is worse than a slow one. A deck can pin it on with
+      !! `keywords.scf.df_integral_direct`, in which case no query decides
+      !! anything and the fallback below never runs.
       class(cuest_system_t), intent(inout) :: this
       type(error_t), intent(inout) :: error
 
       type(cuestWorkspaceDescriptor_t) :: persistent_desc, temporary_desc
       type(cuestWorkspace_t) :: temporary_ws
-      type(c_ptr) :: plan_params
-      integer(c_int) :: status
+      integer(c_int64_t) :: needed, free_bytes, total_bytes
+      logical :: direct, have_memory_reading, retried
+
+      direct = this%df_integral_direct
+      retried = .false.
+
+      do
+         call df_plan_attempt(this, direct, persistent_desc, temporary_desc, needed, error)
+         if (error%has_error()) return
+
+         call device_memory_info(free_bytes, total_bytes, have_memory_reading)
+
+         call logger%verbose("cuEST DF plan: "//trim(format_bytes(needed))// &
+                             " of device memory for the three-index integrals"// &
+                             merge(" (integral-direct)", "                  ", direct))
+         if (have_memory_reading) then
+            call logger%verbose("  device has "//trim(format_bytes(free_bytes))// &
+                                " free of "//trim(format_bytes(total_bytes)))
+         end if
+
+         ! Only the automatic case escalates. A deck that asked for the cache
+         ! and cannot have it should hear so from the allocator, not be quietly
+         ! given a different calculation -- but a deck that asked for nothing
+         ! in particular is better served by an answer.
+         if (direct .or. retried .or. .not. have_memory_reading) exit
+         if (needed <= free_bytes) exit
+
+         call logger%warning("cuEST DF plan needs "//trim(format_bytes(needed))// &
+                             " but only "//trim(format_bytes(free_bytes))// &
+                             " is free; rebuilding integral-direct. This recomputes the "// &
+                             "three-index integrals every Fock build, so it is slower. Set "// &
+                             "keywords.scf.df_integral_direct to make the choice explicit.")
+         call df_plan_discard(this)
+         direct = .true.
+         retried = .true.
+      end do
+
+      this%df_integral_direct = direct
+
+      call workspace_alloc(this%ws_df_plan, persistent_desc, error)
+      if (error%has_error()) then
+         call describe_df_plan_oom(needed, direct, error)
+         return
+      end if
+      call workspace_alloc(temporary_ws, temporary_desc, error)
+
+      if (.not. error%has_error()) then
+         call df_plan_create(this, direct, temporary_ws, error)
+      end if
+
+      call workspace_free(temporary_ws)
+   end subroutine build_df_plan
+
+   subroutine df_plan_parameters(this, direct, plan_params, error)
+      !! The DF plan parameter block, exchange operator and memory policy alike
+      class(cuest_system_t), intent(inout) :: this
+      logical, intent(in) :: direct
+      type(c_ptr), intent(out) :: plan_params
+      type(error_t), intent(inout) :: error
+
+      integer(c_int32_t), target :: direct_flag
 
       plan_params = c_null_ptr
       call cuest_status_check(cuestParametersCreate(CUEST_DFINTPLAN_PARAMETERS, plan_params), &
@@ -711,6 +830,31 @@ contains
                                                   CUEST_DFINTPLAN_PARAMETERS_LRC_EXCHANGE_OMEGA, &
                                                   this%lrc_omega), &
                               "configure DF plan range-separation parameter", error)
+
+      ! Set unconditionally, including the 0 case: leaving the attribute alone
+      ! and setting it to 0 both mean "cache", but only the first depends on
+      ! what cuEST's default happens to be, and the point of the retry above is
+      ! that the two builds differ in exactly this one respect.
+      direct_flag = merge(1_c_int32_t, 0_c_int32_t, direct)
+      call cuest_status_check(cuest_param_set_i32(CUEST_DFINTPLAN_PARAMETERS, plan_params, &
+                                                  CUEST_DFINTPLAN_PARAMETERS_THREE_INDEX_INTEGRAL_DIRECT, &
+                                                  direct_flag), &
+                              "configure DF plan three-index integral-direct", error)
+   end subroutine df_plan_parameters
+
+   subroutine df_plan_attempt(this, direct, persistent_desc, temporary_desc, needed, error)
+      !! Ask cuEST how much memory this plan would take, without taking it
+      class(cuest_system_t), intent(inout) :: this
+      logical, intent(in) :: direct
+      type(cuestWorkspaceDescriptor_t), intent(out) :: persistent_desc, temporary_desc
+      integer(c_int64_t), intent(out) :: needed
+      type(error_t), intent(inout) :: error
+
+      type(c_ptr) :: plan_params
+      integer(c_int) :: status
+
+      needed = 0_c_int64_t
+      call df_plan_parameters(this, direct, plan_params, error)
       if (error%has_error()) return
 
       call cuest_status_check(cuestDFIntPlanCreateWorkspaceQuery(this%handle, this%basis, &
@@ -719,21 +863,77 @@ contains
                                                                  temporary_desc, this%df_plan), &
                               "cuestDFIntPlanCreateWorkspaceQuery", error)
       if (.not. error%has_error()) then
-         call workspace_alloc(this%ws_df_plan, persistent_desc, error)
-         call workspace_alloc(temporary_ws, temporary_desc, error)
+         needed = workspace_bytes(persistent_desc) + workspace_bytes(temporary_desc)
       end if
 
-      if (.not. error%has_error()) then
-         call cuest_status_check(cuestDFIntPlanCreate(this%handle, this%basis, this%aux_basis, &
-                                                      this%pair_list, plan_params, this%ws_df_plan, &
-                                                      temporary_ws, this%df_plan), &
-                                 "cuestDFIntPlanCreate", error)
-      end if
+      status = cuestParametersDestroy(CUEST_DFINTPLAN_PARAMETERS, plan_params)
+      call cuest_status_check(status, "cuestParametersDestroy(DF plan query)", error)
+   end subroutine df_plan_attempt
 
-      call workspace_free(temporary_ws)
+   subroutine df_plan_create(this, direct, temporary_ws, error)
+      !! Build the plan the query above sized
+      class(cuest_system_t), intent(inout) :: this
+      logical, intent(in) :: direct
+      type(cuestWorkspace_t), intent(inout) :: temporary_ws
+      type(error_t), intent(inout) :: error
+
+      type(c_ptr) :: plan_params
+      integer(c_int) :: status
+
+      call df_plan_parameters(this, direct, plan_params, error)
+      if (error%has_error()) return
+
+      call cuest_status_check(cuestDFIntPlanCreate(this%handle, this%basis, this%aux_basis, &
+                                                   this%pair_list, plan_params, this%ws_df_plan, &
+                                                   temporary_ws, this%df_plan), &
+                              "cuestDFIntPlanCreate", error)
+
       status = cuestParametersDestroy(CUEST_DFINTPLAN_PARAMETERS, plan_params)
       call cuest_status_check(status, "cuestParametersDestroy(DF plan)", error)
-   end subroutine build_df_plan
+   end subroutine df_plan_create
+
+   subroutine df_plan_discard(this)
+      !! Drop a plan handle the workspace query left behind
+      !!
+      !! The query writes `outPlan` before anything is allocated, so a second
+      !! query would overwrite a live-looking pointer. Nulling it keeps
+      !! `destroy` from later handing cuEST a handle that was never created.
+      class(cuest_system_t), intent(inout) :: this
+
+      this%df_plan = c_null_ptr
+   end subroutine df_plan_discard
+
+   subroutine describe_df_plan_oom(needed, direct, error)
+      !! Turn a bare allocation failure into a diagnosis
+      integer(c_int64_t), intent(in) :: needed
+      logical, intent(in) :: direct
+      type(error_t), intent(inout) :: error
+
+      integer(c_int64_t) :: free_bytes, total_bytes
+      logical :: ok
+      character(len=:), allocatable :: advice
+
+      call device_memory_info(free_bytes, total_bytes, ok)
+
+      if (direct) then
+         advice = "The plan is already integral-direct, so the three-index cache is not "// &
+                  "what is missing. A smaller auxiliary basis, or splitting the system "// &
+                  "with a fragmentation method, is what is left."
+      else
+         advice = "Setting keywords.scf.df_integral_direct to true recomputes the "// &
+                  "three-index integrals instead of caching them, which is the single "// &
+                  "largest reduction available here."
+      end if
+
+      if (ok) then
+         call error%add_context("cuEST DF plan needs "//trim(format_bytes(needed))// &
+                                " of device memory; "//trim(format_bytes(free_bytes))// &
+                                " free of "//trim(format_bytes(total_bytes))//". "//advice)
+      else
+         call error%add_context("cuEST DF plan needs "//trim(format_bytes(needed))// &
+                                " of device memory. "//advice)
+      end if
+   end subroutine describe_df_plan_oom
 
    subroutine system_xc_uks_device(this, d_c_alpha, d_c_beta, n_occ_beta, &
                                    d_out_alpha, d_out_beta, xc_energy, error)
@@ -798,7 +998,13 @@ contains
       status = cuestParametersDestroy(CUEST_XCPOTENTIALUKSCOMPUTE_PARAMETERS, params)
       call cuest_status_check(status, "cuestParametersDestroy(UKS XC potential)", error)
 
-      if (.not. error%has_error()) xc_energy = energy
+      ! Both spin channels are slices of the same quadrature, so both reduce.
+      call reduce_xc_device(this, d_out_alpha, this%n_ao*this%n_ao, "Vxc alpha (team)", error)
+      call reduce_xc_device(this, d_out_beta, this%n_ao*this%n_ao, "Vxc beta (team)", error)
+      if (.not. error%has_error()) then
+         xc_energy = energy
+         call reduce_xc_scalar(this, xc_energy)
+      end if
    end subroutine system_xc_uks_device
 
    subroutine system_compute_xc_uks(this, c_occ_alpha, c_occ_beta, xc_energy, &
@@ -890,7 +1096,9 @@ contains
 
       ! ---- per-atom grids ---------------------------------------------------
       call build_atom_grids(this%handle, atomic_numbers, n_radial, n_angular, &
-                            grid_set, error)
+                            grid_set, error, &
+                            shard_index=grid_shard_index(this), &
+                            shard_count=grid_shard_count(this))
       if (error%has_error()) return
 
       ! ---- molecular grid (HOST coordinates and HOST atom-grid array) -------
@@ -1405,7 +1613,15 @@ contains
       status = cuestParametersDestroy(CUEST_XCPOTENTIALRKSCOMPUTE_PARAMETERS, params)
       call cuest_status_check(status, "cuestParametersDestroy(RKS XC potential)", error)
 
-      if (.not. error%has_error()) xc_energy = energy
+      ! On a sharded grid what cuEST just wrote is this rank's slice of the
+      ! quadrature, not the integral. Reduced here rather than in the SCF so
+      ! that `d_out` and `xc_energy` mean the same thing to every caller
+      ! whether or not the run is multi-GPU.
+      call reduce_xc_device(this, d_out, this%n_ao*this%n_ao, "Vxc (team)", error)
+      if (.not. error%has_error()) then
+         xc_energy = energy
+         call reduce_xc_scalar(this, xc_energy)
+      end if
    end subroutine system_xc_device
 
    subroutine system_compute_xc(this, c_occ, xc_energy, xc_potential, error)
@@ -2173,6 +2389,9 @@ contains
                               "cuestParametersCreate(DF derivative)", error)
       if (error%has_error()) return
 
+      call apply_df_derivative_memory_policy(this, params, error)
+      if (error%has_error()) return
+
       variable_buffer%hostBufferSizeInBytes = 0_c_size_t
       variable_buffer%deviceBufferSizeInBytes = DF_EXCHANGE_BUFFER_BYTES
 
@@ -2254,6 +2473,7 @@ contains
       call cuest_status_check(status, "cuestParametersDestroy(RKS XC derivative)", error)
 
       call fetch_gradient(this, gradient, "dExc/dR", error)
+      if (.not. error%has_error()) call reduce_xc_host(this, gradient)
    end subroutine system_gradient_xc
 
    subroutine system_gradient_two_electron_uks(this, total_density, c_occ_alpha, c_occ_beta, &
@@ -2321,6 +2541,9 @@ contains
       params = c_null_ptr
       call cuest_status_check(cuestParametersCreate(CUEST_DFSYMMETRICDERIVATIVECOMPUTE_PARAMETERS, params), &
                               "cuestParametersCreate(DF derivative, UKS)", error)
+      if (error%has_error()) return
+
+      call apply_df_derivative_memory_policy(this, params, error)
       if (error%has_error()) return
 
       variable_buffer%hostBufferSizeInBytes = 0_c_size_t
@@ -2411,6 +2634,7 @@ contains
       call cuest_status_check(status, "cuestParametersDestroy(UKS XC derivative)", error)
 
       call fetch_gradient(this, gradient, "dExc/dR (UKS)", error)
+      if (.not. error%has_error()) call reduce_xc_host(this, gradient)
    end subroutine system_gradient_xc_uks
 
    subroutine stage_matrix(this, device_ptr, matrix, label, error)
@@ -2543,5 +2767,100 @@ contains
       this%n_ao = 0
       this%n_occ = 0
    end subroutine system_destroy
+
+   pure function grid_shard_index(this) result(shard)
+      !! Which slice of the radial mesh this system keeps
+      class(cuest_system_t), intent(in) :: this
+      integer :: shard
+
+      shard = 0
+      if (this%xc_grid_sharded) shard = gpu_team_rank()
+   end function grid_shard_index
+
+   pure function grid_shard_count(this) result(n_shards)
+      !! How many slices the radial mesh is cut into; 1 means no cut
+      class(cuest_system_t), intent(in) :: this
+      integer :: n_shards
+
+      n_shards = 1
+      if (this%xc_grid_sharded) n_shards = gpu_team_size()
+   end function grid_shard_count
+
+   subroutine reduce_xc_scalar(this, value)
+      !! Sum one rank's share of an XC scalar over the team
+      class(cuest_system_t), intent(in) :: this
+      real(dp), intent(inout) :: value
+
+      if (.not. this%xc_grid_sharded) return
+      call gpu_team_reduce_scalar(value)
+   end subroutine reduce_xc_scalar
+
+   subroutine reduce_xc_host(this, array)
+      !! Sum one rank's share of an XC array over the team, in place
+      class(cuest_system_t), intent(in) :: this
+      real(dp), intent(inout) :: array(:, :)
+
+      real(dp), allocatable :: flat(:)
+
+      if (.not. this%xc_grid_sharded) return
+      if (size(array) == 0) return
+      flat = reshape(array, [size(array)])
+      call gpu_team_reduce(flat)
+      array = reshape(flat, shape(array))
+   end subroutine reduce_xc_host
+
+   subroutine reduce_xc_device(this, d_buffer, n_elements, label, error)
+      !! Sum one rank's share of a device-resident XC matrix over the team
+      !!
+      !! Staged through the host rather than reduced from device memory: the
+      !! MPI in use is not assumed to be CUDA-aware, and a non-aware MPI handed
+      !! a device pointer does not fail, it reads host garbage. n_ao^2 doubles
+      !! once per SCF iteration is a few megabytes against a Fock build, so the
+      !! round trip is not where the time goes.
+      class(cuest_system_t), intent(in) :: this
+      type(c_ptr), intent(in) :: d_buffer
+      integer(c_int64_t), intent(in) :: n_elements
+      character(len=*), intent(in) :: label
+      type(error_t), intent(inout) :: error
+
+      real(dp), allocatable :: staging(:)
+
+      if (.not. this%xc_grid_sharded) return
+      if (error%has_error() .or. n_elements <= 0) return
+
+      allocate (staging(n_elements))
+      call copy_to_host(staging, d_buffer, label, error)
+      if (.not. error%has_error()) then
+         call gpu_team_reduce(staging)
+         call copy_to_device(d_buffer, staging, label, error)
+      end if
+      deallocate (staging)
+   end subroutine reduce_xc_device
+
+   subroutine apply_df_derivative_memory_policy(this, params, error)
+      !! Tell cuEST where the DF gradient may keep its intermediates
+      !!
+      !! Left alone unless a deck asked, because cuEST's own default is the
+      !! fast one and most calculations should keep it. It is worth asking for
+      !! on exactly the calculation that motivated this: the gradient's
+      !! intermediate is allocated on top of an SCF's worth of device memory
+      !! that is still live, so a gradient can run out where the energy did
+      !! not, and trading it for recomputation is the difference between an
+      !! answer and none.
+      class(cuest_system_t), intent(in) :: this
+      type(c_ptr), intent(in) :: params
+      type(error_t), intent(inout) :: error
+
+      integer(c_int32_t), target :: policy
+
+      if (this%df_derivative_memory_policy < 0) return
+
+      policy = int(this%df_derivative_memory_policy, c_int32_t)
+      call cuest_status_check(cuest_param_set_i32(CUEST_DFSYMMETRICDERIVATIVECOMPUTE_PARAMETERS, &
+                                                  params, &
+                                                  CUEST_DFSYMMETRICDERIVATIVECOMPUTE_PARAMETERS_MEMORY_POLICY, &
+                                                  policy), &
+                              "configure DF derivative memory policy", error)
+   end subroutine apply_df_derivative_memory_policy
 
 end module mqc_cuest_integrals

--- a/backends/cuest/backend/mqc_cuest_runtime.f90
+++ b/backends/cuest/backend/mqc_cuest_runtime.f90
@@ -21,7 +21,7 @@ module mqc_cuest_runtime
    use cusolver, only: CUSOLVER_STATUS_SUCCESS, cusolver_status_name
    use cuda_runtime, only: cudaMalloc, cudaFree, cudaMemcpy, cudaSuccess, &
                            cudaMemcpyHostToDevice, cudaMemcpyDeviceToHost, &
-                           cudaDeviceSynchronize
+                           cudaDeviceSynchronize, cudaMemGetInfo
    use cuda_helpers, only: cuda_error_name, cuda_error_string
    implicit none
    private
@@ -36,6 +36,9 @@ module mqc_cuest_runtime
    public :: device_alloc, device_free        !! Device buffers counted in doubles
    public :: device_offset        !! Address of an element part-way into a buffer
    public :: copy_to_device, copy_to_host     !! Host <-> device transfers
+   public :: device_memory_info   !! Free and total bytes on the current device
+   public :: format_bytes         !! Byte count as a human-readable string
+   public :: workspace_bytes      !! Device bytes a workspace descriptor asks for
 
    integer(c_size_t), parameter :: BYTES_PER_DOUBLE = 8_c_size_t
 
@@ -266,5 +269,71 @@ contains
                                         cudaMemcpyDeviceToHost), &
                              "cudaMemcpy D2H ("//trim(context)//")", error)
    end subroutine copy_to_host
+
+   subroutine device_memory_info(free_bytes, total_bytes, ok)
+      !! Free and total device memory, in bytes
+      !!
+      !! `ok` is false when CUDA declines to answer, in which case the two
+      !! counts are zero. Callers use this to *report*, never to decide -- a
+      !! free-memory reading is a snapshot, another process can take the
+      !! memory a microsecond later, and the allocation itself remains the
+      !! authority on whether it fits.
+      integer(c_int64_t), intent(out) :: free_bytes, total_bytes
+      logical, intent(out) :: ok
+
+      integer(c_size_t) :: free_c, total_c
+      integer(c_int) :: status
+
+      free_c = 0_c_size_t
+      total_c = 0_c_size_t
+      status = cudaMemGetInfo(free_c, total_c)
+      ok = (status == cudaSuccess)
+      if (ok) then
+         free_bytes = int(free_c, c_int64_t)
+         total_bytes = int(total_c, c_int64_t)
+      else
+         free_bytes = 0_c_int64_t
+         total_bytes = 0_c_int64_t
+      end if
+   end subroutine device_memory_info
+
+   pure function workspace_bytes(descriptor) result(bytes)
+      !! Device bytes a workspace descriptor asks for
+      type(cuestWorkspaceDescriptor_t), intent(in) :: descriptor
+      integer(c_int64_t) :: bytes
+
+      bytes = int(descriptor%deviceBufferSizeInBytes, c_int64_t)
+   end function workspace_bytes
+
+   pure function format_bytes(bytes) result(text)
+      !! A byte count as GiB/MiB/KiB, two decimals
+      !!
+      !! Written out rather than left in bytes because the numbers these
+      !! messages carry are in the tens of billions, and "84.3 GiB" is a
+      !! sentence a person can act on where 90529103872 is not.
+      integer(c_int64_t), intent(in) :: bytes
+      character(len=32) :: text
+
+      real(dp) :: value
+      character(len=3) :: unit
+
+      value = real(bytes, dp)
+      if (value >= 1024.0_dp**3) then
+         value = value/1024.0_dp**3
+         unit = "GiB"
+      else if (value >= 1024.0_dp**2) then
+         value = value/1024.0_dp**2
+         unit = "MiB"
+      else if (value >= 1024.0_dp) then
+         value = value/1024.0_dp
+         unit = "KiB"
+      else
+         write (text, "(I0,1X,A)") bytes, "B"
+         text = adjustl(text)
+         return
+      end if
+      write (text, "(F0.2,1X,A)") value, unit
+      text = adjustl(text)
+   end function format_bytes
 
 end module mqc_cuest_runtime

--- a/backends/cuest/backend/mqc_cuest_scf.f90
+++ b/backends/cuest/backend/mqc_cuest_scf.f90
@@ -69,6 +69,7 @@ module mqc_cuest_scf
    use mqc_error, only: error_t, ERROR_VALIDATION
    use mqc_diis_device, only: diis_device_t
    use mqc_cuest_integrals, only: cuest_system_t
+   use mqc_gpu_team, only: gpu_team_agree
    use mqc_cuest_context, only: cuest_context_t
    use mqc_cuest_runtime, only: device_sync, cublas_status_check, &
                                 cusolver_status_check, copy_int_to_host, copy_to_host, &
@@ -373,6 +374,7 @@ contains
       real(dp) :: electronic_energy, previous_energy, energy_change, error_norm
       real(dp) :: xc_energy, pcm_energy, trace_h, trace_j, trace_k
       logical :: diis_ok
+      logical :: iteration_converged
 
       character(len=MAX_LINE_LENGTH) :: line
 
@@ -577,8 +579,17 @@ contains
             call logger%info(trim(line))
          end if
 
-         if (iteration > 1 .and. abs(energy_change) < energy_tolerance &
-             .and. error_norm < density_tolerance) then
+         ! Every rank of a GPU team runs this same loop, and every rank has to
+         ! leave it on the same iteration: one rank exiting early would leave
+         ! the others waiting forever in the next XC reduction. The ranks
+         ! should already agree -- the only term that differs before reduction
+         ! is Exc, and that is reduced before it reaches the energy -- so this
+         ! is a guard against a hang, not a correction. Outside a team it is a
+         ! no-op.
+         iteration_converged = (iteration > 1 .and. abs(energy_change) < energy_tolerance &
+                                .and. error_norm < density_tolerance)
+         call gpu_team_agree(iteration_converged)
+         if (iteration_converged) then
             result%converged = .true.
             result%iterations = iteration
             exit
@@ -770,6 +781,7 @@ contains
       integer :: n_ao, n_mo, n_alpha, n_beta, iteration
       integer :: n_fock_spin, n_err_spin
       real(dp) :: electronic_energy, previous_energy, energy_change, error_norm, xc_energy
+      logical :: iteration_converged
       real(dp) :: pcm_energy
       real(dp) :: trace_h, trace_j, trace_ka, trace_kb
       logical :: diis_ok, occupations_ok, beta_exchange
@@ -989,8 +1001,17 @@ contains
             call logger%info(trim(line))
          end if
 
-         if (iteration > 1 .and. abs(energy_change) < energy_tolerance &
-             .and. error_norm < density_tolerance) then
+         ! Every rank of a GPU team runs this same loop, and every rank has to
+         ! leave it on the same iteration: one rank exiting early would leave
+         ! the others waiting forever in the next XC reduction. The ranks
+         ! should already agree -- the only term that differs before reduction
+         ! is Exc, and that is reduced before it reaches the energy -- so this
+         ! is a guard against a hang, not a correction. Outside a team it is a
+         ! no-op.
+         iteration_converged = (iteration > 1 .and. abs(energy_change) < energy_tolerance &
+                                .and. error_norm < density_tolerance)
+         call gpu_team_agree(iteration_converged)
+         if (iteration_converged) then
             result%converged = .true.
             result%iterations = iteration
             exit

--- a/src/io/mqc_config_adapter.f90
+++ b/src/io/mqc_config_adapter.f90
@@ -220,6 +220,11 @@ contains
       driver_config%method_config%scf%allow_crap_scf = mqc_config%allow_crap_scf
       driver_config%method_config%scf%unrestricted = mqc_config%scf_unrestricted
       driver_config%method_config%scf%density_fitting = mqc_config%scf_density_fitting
+      driver_config%method_config%scf%df_integral_direct = mqc_config%scf_df_integral_direct
+      if (allocated(mqc_config%scf_df_derivative_memory)) then
+         driver_config%method_config%scf%df_derivative_memory = mqc_config%scf_df_derivative_memory
+      end if
+      driver_config%method_config%multi_gpu = mqc_config%multi_gpu
       driver_config%method_config%corr%freeze_core = mqc_config%corr_freeze_core
       driver_config%method_config%corr%n_frozen_core = mqc_config%corr_n_frozen_core
       driver_config%method_config%corr%use_df = mqc_config%corr_density_fitting

--- a/src/io/mqc_config_types.f90
+++ b/src/io/mqc_config_types.f90
@@ -159,6 +159,24 @@ module mqc_config_types
       logical :: scf_unrestricted = .false.
       logical :: allow_crap_scf = .false.
       logical :: scf_density_fitting = .false.
+      logical :: scf_df_integral_direct = .false.
+         !! Recompute the three-index DF integrals every Fock build instead of
+         !! caching them on the device. cuEST only. The cache is the largest
+         !! device allocation a GPU run makes, so this is the first thing to
+         !! reach for when one runs out of memory -- at the cost of rebuilding
+         !! those integrals every iteration.
+         !!
+         !! Off by default, but not the whole story: left off, the backend still
+         !! queries the size and switches to direct on its own if the cache will
+         !! not fit, saying so. Setting this to false does not veto that -- it
+         !! is "no preference", and a run that must not be silently changed
+         !! should be watching the log either way.
+      character(len=:), allocatable :: scf_df_derivative_memory
+         !! Where the density-fitted gradient keeps its intermediates:
+         !! 'auto' (cuEST's own default), 'devicecache', 'hostcache',
+         !! 'overwrite' or 'recompute'. cuEST only, and a separate allocation
+         !! from the plan cache above: a gradient can run out of memory where
+         !! the energy that produced it did not.
       ! keywords.correlation -- post-Hartree-Fock, kept apart from the SCF ones
       logical :: corr_freeze_core = .true.
       integer :: corr_n_frozen_core = -1   !! -1 counts the core from the elements
@@ -244,6 +262,14 @@ module mqc_config_types
       ! one answer downstream however the deck spelled the question; naming both
       ! and disagreeing is refused rather than given a precedence rule.
       logical :: gpu = .false.
+      logical :: multi_gpu = .false.
+         !! system.multi_gpu -- give one system every rank's GPU instead of
+         !! giving every rank its own system.
+         !!
+         !! Refused alongside fragmentation, which already means "one rank per
+         !! subsystem"; the two want the same ranks for different things and
+         !! there is no sensible precedence between them. Refused on the CPU
+         !! backend, where there is no device to spread over.
       logical :: gpu_set = .false.
          !! Whether the deck named `system.gpu`. "Absent" and "false" have to be
          !! told apart: absent leaves `backend` alone, false pins it to the CPU.

--- a/src/io/mqc_json_config_reader.f90
+++ b/src/io/mqc_json_config_reader.f90
@@ -211,6 +211,7 @@ contains
       call optional_logical(json, "system.unchecked_input", config%unchecked_input)
       call optional_string(json, "system.checkpoint", config%checkpoint_file)
       call optional_string(json, "system.fragment_breakdown", config%fragment_breakdown)
+      call optional_logical(json, "system.multi_gpu", config%multi_gpu)
 
       ! ---- keywords --------------------------------------------------------
       call optional_int(json, "keywords.scf.maxiter", config%scf_maxiter)
@@ -223,6 +224,10 @@ contains
       call optional_logical(json, "keywords.scf.allow_crap_scf", config%allow_crap_scf)
       call optional_logical(json, "keywords.scf.density_fitting", &
                             config%scf_density_fitting)
+      call optional_logical(json, "keywords.scf.df_integral_direct", &
+                            config%scf_df_integral_direct)
+      call optional_string(json, "keywords.scf.df_derivative_memory", &
+                           config%scf_df_derivative_memory)
       call optional_logical(json, "keywords.correlation.freeze_core", &
                             config%corr_freeze_core)
       call optional_int(json, "keywords.correlation.n_frozen_core", &

--- a/src/io/mqc_json_schema.f90
+++ b/src/io/mqc_json_schema.f90
@@ -190,6 +190,7 @@ contains
       type(key_set_t) :: keys
       call allow(keys, "logger")
       call allow(keys, "gpu")
+      call allow(keys, "multi_gpu")
       call allow(keys, "skip_json_output")
       call allow(keys, "unchecked_input")
       call allow(keys, "checkpoint")
@@ -288,6 +289,8 @@ contains
       call allow(keys, "guess")
       call allow(keys, "allow_crap_scf")
       call allow(keys, "density_fitting")
+      call allow(keys, "df_integral_direct")
+      call allow(keys, "df_derivative_memory")
    end function scf_keys
 
    function correlation_keys() result(keys)

--- a/src/methods/CMakeLists.txt
+++ b/src/methods/CMakeLists.txt
@@ -8,6 +8,7 @@ target_sources(
           mqc_method_dft.F90
           mqc_method_mcscf.f90
           mqc_cuest_iface.f90
+          mqc_gpu_team.f90
           mqc_diis.f90
           mqc_lebedev_data.f90
           mqc_lebedev.f90

--- a/src/methods/mqc_cuest_iface.f90
+++ b/src/methods/mqc_cuest_iface.f90
@@ -20,6 +20,7 @@ module mqc_cuest_iface
    public :: BACKEND_AUTO, BACKEND_CUEST, BACKEND_LIBCINT
    public :: parse_backend_name
    public :: method_runs_on_cuest
+   public :: parse_df_derivative_memory
 
    !> Which integral backend a deck asked for.
    !>
@@ -136,6 +137,27 @@ module mqc_cuest_iface
 
       integer :: radial_points = 75    !! XC grid radial points per atom
       integer :: angular_points = 302  !! XC grid Lebedev order
+
+      ! ---- multi-GPU and device memory --------------------------------------
+      logical :: multi_gpu = .false.
+         !! Spread one system's GPU work over every rank in the run, each rank
+         !! on its own device, rather than giving each rank a whole system.
+         !!
+         !! Refused together with fragmentation: fragmentation already owns the
+         !! rank dimension -- a rank is a fragment there -- and the two would be
+         !! competing for the same ranks. Refused on the CPU backend too, where
+         !! it means nothing.
+         !!
+         !! Only the exchange-correlation quadrature is actually divided; see
+         !! `mqc_gpu_team` for why J and K cannot be, and what does reduce them.
+      logical :: df_integral_direct = .false.
+         !! Recompute the three-index density-fitting integrals on every Fock
+         !! build rather than caching them on the device. Slower, and the
+         !! largest single saving of device memory available.
+      character(len=16) :: df_derivative_memory = "auto"
+         !! Where the density-fitted gradient keeps its intermediates:
+         !! 'auto' (leave cuEST's default), 'devicecache', 'hostcache',
+         !! 'overwrite' or 'recompute'.
    end type cuest_scf_settings_t
 
 contains
@@ -195,5 +217,48 @@ contains
       offloadable = (method_type == METHOD_TYPE_HF .or. &
                      method_type == METHOD_TYPE_DFT)
    end function method_runs_on_cuest
+
+   subroutine parse_df_derivative_memory(name, policy, error)
+      !! A deck's DF-gradient memory policy name to cuEST's enumerator
+      !!
+      !! Returns -1 for 'auto', which means "set nothing and let cuEST keep its
+      !! own default". The numbers are cuEST's
+      !! CUEST_DFSYMMETRICDERIVATIVECOMPUTE_MEMORY_POLICY_* values, repeated
+      !! here rather than imported because this module is compiled on the fpm
+      !! path too, where the cuEST bindings do not exist. They are checked
+      !! against the bindings by test_mqc_cuest_memory_policy.
+      use mqc_error, only: error_t, ERROR_VALIDATION
+      character(len=*), intent(in) :: name
+      integer, intent(out) :: policy
+      type(error_t), intent(inout) :: error
+
+      character(len=:), allocatable :: lower
+      integer :: i
+
+      lower = trim(adjustl(name))
+      do i = 1, len(lower)
+         if (lower(i:i) >= "A" .and. lower(i:i) <= "Z") then
+            lower(i:i) = achar(iachar(lower(i:i)) + 32)
+         end if
+      end do
+
+      policy = -1
+      select case (lower)
+      case ("", "auto")
+         policy = -1
+      case ("devicecache")
+         policy = 0
+      case ("hostcache")
+         policy = 1
+      case ("overwrite")
+         policy = 2
+      case ("recompute")
+         policy = 3
+      case default
+         call error%set(ERROR_VALIDATION, "unknown df_derivative_memory '"//lower// &
+                        "'; expected 'auto', 'devicecache', 'hostcache', 'overwrite' "// &
+                        "or 'recompute'")
+      end select
+   end subroutine parse_df_derivative_memory
 
 end module mqc_cuest_iface

--- a/src/methods/mqc_gpu_team.f90
+++ b/src/methods/mqc_gpu_team.f90
@@ -1,0 +1,131 @@
+!! The set of ranks that share one system's GPU work
+module mqc_gpu_team
+   !! Process-wide state for the multi-GPU mode: several MPI ranks, each bound
+   !! to its own GPU, cooperating on a *single* system rather than on separate
+   !! fragments.
+   !!
+   !! This is deliberately not the fragmented parallelism. There, one rank owns
+   !! a whole subsystem and nothing has to be reduced mid-SCF; here every rank
+   !! runs the same SCF and owns a slice of one quantity, so the ranks are in
+   !! lockstep and a reduction happens inside every iteration.
+   !!
+   !! What is sliced is the exchange-correlation quadrature, and only that.
+   !! cuEST 0.2 exposes no way to split a density-fitted J or K build -- the
+   !! pair list is built from a threshold rather than handed a subset, and
+   !! splitting the auxiliary basis would change the fitting metric rather than
+   !! partition it -- so every rank still builds a full DF plan. The mode
+   !! divides XC time and XC memory by the team size and nothing else. See
+   !! `backends/cuest/CUEST.md` for why, and for the knobs that do reduce the
+   !! DF plan.
+   !!
+   !! The team lives here, in `src/`, and knows nothing about cuEST or CUDA,
+   !! for the same reason `mqc_cuest_iface` does: the backend cannot be part of
+   !! the fpm build, and the driver that enables the team cannot reach it.
+   !! Reductions are over host arrays; staging a device buffer through the host
+   !! is the backend's business, because only the backend knows what a device
+   !! pointer is.
+   use pic_types, only: dp
+   use pic_mpi_lib, only: comm_t, allreduce
+   implicit none
+   private
+
+   public :: gpu_team_enable      !! Put this rank into a team
+   public :: gpu_team_disable     !! Leave the team; reductions become no-ops
+   public :: gpu_team_active      !! Whether a team of more than one rank is live
+   public :: gpu_team_rank        !! This rank's index in the team, 0-based
+   public :: gpu_team_size        !! How many ranks share the system
+   public :: gpu_team_reduce      !! Sum a host array across the team, in place
+   public :: gpu_team_reduce_scalar  !! Sum a scalar across the team, in place
+   public :: gpu_team_agree       !! Make a logical unanimous across the team
+
+   logical, save :: team_live = .false.
+   integer, save :: team_rank = 0
+   integer, save :: team_size = 1
+   type(comm_t), save :: team_comm
+
+contains
+
+   subroutine gpu_team_enable(comm)
+      !! Enrol this rank in the team spanning `comm`
+      !!
+      !! A single-rank communicator enables nothing: the mode would then cost a
+      !! reduction per iteration and buy no division of work, and `active`
+      !! staying false keeps every reduction below a no-op rather than a
+      !! zero-length collective.
+      type(comm_t), intent(in) :: comm
+
+      team_comm = comm
+      team_rank = comm%rank()
+      team_size = comm%size()
+      team_live = (team_size > 1)
+   end subroutine gpu_team_enable
+
+   subroutine gpu_team_disable()
+      !! Leave the team
+      team_live = .false.
+      team_rank = 0
+      team_size = 1
+   end subroutine gpu_team_disable
+
+   pure function gpu_team_active() result(active)
+      !! Whether work should be sliced and results reduced
+      logical :: active
+
+      active = team_live
+   end function gpu_team_active
+
+   pure function gpu_team_rank() result(rank)
+      !! This rank's slice index, 0-based; 0 when no team is live
+      integer :: rank
+
+      rank = team_rank
+   end function gpu_team_rank
+
+   pure function gpu_team_size() result(n_slices)
+      !! Number of slices; 1 when no team is live
+      integer :: n_slices
+
+      n_slices = team_size
+   end function gpu_team_size
+
+   subroutine gpu_team_reduce(buffer)
+      !! Sum a host array over the team, in place
+      !!
+      !! A no-op outside a team, so callers need no conditional of their own.
+      real(dp), intent(inout) :: buffer(:)
+
+      if (.not. team_live) return
+      if (size(buffer) == 0) return
+      call allreduce(team_comm, buffer)
+   end subroutine gpu_team_reduce
+
+   subroutine gpu_team_reduce_scalar(value)
+      !! Sum a scalar over the team, in place
+      real(dp), intent(inout) :: value
+
+      if (.not. team_live) return
+      call allreduce(team_comm, value)
+   end subroutine gpu_team_reduce_scalar
+
+   subroutine gpu_team_agree(flag)
+      !! Force every rank to the same answer, true only if all ranks say true
+      !!
+      !! Used on the SCF's convergence test. The ranks should already agree --
+      !! every term but the reduced XC one is computed redundantly from
+      !! identical inputs, and cuEST is pinned to FP64 -- but "should" is doing
+      !! a lot of work there, and the failure mode if it is wrong is not a
+      !! wrong number, it is one rank leaving the loop while the others wait
+      !! forever in the next reduction. One collective per iteration is cheap
+      !! insurance against a hang.
+      logical, intent(inout) :: flag
+
+      real(dp) :: vote
+
+      if (.not. team_live) return
+      vote = 0.0_dp
+      if (flag) vote = 1.0_dp
+      call allreduce(team_comm, vote)
+      flag = (vote >= real(team_size, dp) - 0.5_dp)
+   end subroutine gpu_team_agree
+
+end module mqc_gpu_team

--- a/src/methods/mqc_method_config.f90
+++ b/src/methods/mqc_method_config.f90
@@ -73,6 +73,11 @@ module mqc_method_config
          !! both, so which one runs has to be asked for rather than inferred
          !! from an auxiliary basis being present -- that name carries a
          !! default, so inferring would mean every calculation silently fitted.
+      logical :: df_integral_direct = .false.
+         !! cuEST only: recompute the three-index DF integrals rather than
+         !! caching them on the device. See mqc_config_types.
+      character(len=16) :: df_derivative_memory = "auto"
+         !! cuEST only: where the DF gradient keeps its intermediates.
    end type scf_config_t
 
    !============================================================================
@@ -345,6 +350,10 @@ module mqc_method_config
       character(len=16) :: backend = "auto"
          !! Integral backend request; see `parse_backend_name`.
       integer :: device_rank = 0
+      logical :: multi_gpu = .false.
+         !! Spread one system's GPU work over every rank rather than giving
+         !! each rank its own system. cuEST only, and refused with
+         !! fragmentation.
          !! Node-local MPI rank, used to spread ranks across the GPUs on a
          !! node. Zero is correct for a serial run; a fragmented run must set
          !! the real value or every rank binds to device 0.

--- a/src/methods/mqc_method_dft.F90
+++ b/src/methods/mqc_method_dft.F90
@@ -49,6 +49,12 @@ module mqc_method_dft
          !! Print SCF iterations
       integer :: device_rank = 0
          !! Node-local MPI rank, for spreading ranks across a node's GPUs
+      logical :: multi_gpu = .false.
+         !! Spread one system's GPU work over every rank's device
+      logical :: df_integral_direct = .false.
+         !! Recompute the three-index DF integrals instead of caching them
+      character(len=16) :: df_derivative_memory = "auto"
+         !! Where the DF gradient keeps its intermediates
       logical :: unrestricted = .false.
          !! Force UHF/UKS even for a closed shell
       character(len=32) :: guess = "auto"
@@ -161,6 +167,9 @@ contains
       settings%spherical = this%options%spherical
       settings%verbose = this%options%verbose
       settings%device_rank = this%options%device_rank
+      settings%multi_gpu = this%options%multi_gpu
+      settings%df_integral_direct = this%options%df_integral_direct
+      settings%df_derivative_memory = this%options%df_derivative_memory
       ! Resolved here rather than carried as a string, so an unknown name fails
       ! once, before any integrals, instead of at each dispatch.
       call parse_backend_name(this%options%backend, settings%backend, backend_error)

--- a/src/methods/mqc_method_factory.F90
+++ b/src/methods/mqc_method_factory.F90
@@ -170,6 +170,9 @@ contains
       m%options%spherical = config%use_spherical
       m%options%verbose = config%verbose
       m%options%device_rank = config%device_rank
+      m%options%multi_gpu = config%multi_gpu
+      m%options%df_integral_direct = config%scf%df_integral_direct
+      m%options%df_derivative_memory = config%scf%df_derivative_memory
 
       m%options%backend = config%backend
       ! SCF settings from shared config%scf
@@ -224,6 +227,9 @@ contains
       m%options%spherical = config%use_spherical
       m%options%verbose = config%verbose
       m%options%device_rank = config%device_rank
+      m%options%multi_gpu = config%multi_gpu
+      m%options%df_integral_direct = config%scf%df_integral_direct
+      m%options%df_derivative_memory = config%scf%df_derivative_memory
 
       ! SCF settings from shared config%scf
       m%options%unrestricted = config%scf%unrestricted

--- a/src/methods/mqc_method_hf.F90
+++ b/src/methods/mqc_method_hf.F90
@@ -69,6 +69,12 @@ module mqc_method_hf
          !! Print SCF iterations
       integer :: device_rank = 0
          !! Node-local MPI rank, for spreading ranks across a node's GPUs
+      logical :: multi_gpu = .false.
+         !! Spread one system's GPU work over every rank's device
+      logical :: df_integral_direct = .false.
+         !! Recompute the three-index DF integrals instead of caching them
+      character(len=16) :: df_derivative_memory = "auto"
+         !! Where the DF gradient keeps its intermediates
       logical :: unrestricted = .false.
          !! Force UHF/UKS even for a closed shell
       character(len=32) :: guess = "auto"
@@ -154,6 +160,9 @@ contains
       settings%spherical = this%options%spherical
       settings%verbose = this%options%verbose
       settings%device_rank = this%options%device_rank
+      settings%multi_gpu = this%options%multi_gpu
+      settings%df_integral_direct = this%options%df_integral_direct
+      settings%df_derivative_memory = this%options%df_derivative_memory
       ! Resolved here rather than carried as a string, so an unknown name fails
       ! once, before any integrals, instead of at each dispatch.
       call parse_backend_name(this%options%backend, settings%backend, backend_error)

--- a/src/mqc_driver.f90
+++ b/src/mqc_driver.f90
@@ -5,7 +5,7 @@ module mqc_driver
    use pic_types, only: int32, int64, dp, default_int
    use pic_mpi_lib, only: comm_t, abort_comm, bcast, allgather
    use mqc_resources, only: resources_t
-   use pic_logger, only: logger => global_logger
+   use pic_logger, only: logger => global_logger, warning_level
    use pic_io, only: to_char
    use omp_lib, only: omp_get_max_threads, omp_set_num_threads
    use mqc_method_types, only: needs_serial_execution
@@ -31,6 +31,10 @@ module mqc_driver
    use mqc_mbe, only: compute_gmbe
    use mqc_result_types, only: calculation_result_t
    use mqc_error, only: error_t
+   use mqc_gpu_team, only: gpu_team_enable, gpu_team_disable, gpu_team_active, &
+                           gpu_team_size
+   use mqc_cuest_iface, only: parse_backend_name, method_runs_on_cuest, &
+                              BACKEND_LIBCINT
    use mqc_fingerprint, only: calculation_fingerprint
    use mqc_checkpoint, only: checkpoint_t
    use mqc_io_helpers, only: set_molecule_suffix, get_output_json_filename
@@ -96,6 +100,12 @@ contains
 
       ! Set max_level from config
       max_level = config%nlevel
+
+      ! Multi-GPU has to be settled before anything dispatches: it decides
+      ! which ranks run the calculation at all, so the fragmented and
+      ! unfragmented paths below both read the answer rather than each
+      ! deciding it.
+      call setup_gpu_team(resources%mpi_comms%world_comm, config, max_level)
 
       ! Log method-specific settings (rank 0 only)
       if (resources%mpi_comms%world_comm%rank() == 0) then
@@ -299,7 +309,19 @@ contains
       ! Check if this is multi-molecule mode or single-molecule mode
       ! In multi-molecule mode, each rank processes its own molecule
       ! In single-molecule mode, only rank 0 should work
-      if (world_comm%size() == 1 .or. world_comm%rank() == 0) then
+      ! Every rank of a GPU team runs the same SCF, each over its own slice of
+      ! the quadrature, so the usual "rank 0 only" gate would leave the other
+      ! ranks out of a collective the SCF makes every iteration and hang the
+      ! run. `gpu_team_active` is only true when the deck asked for the mode
+      ! and there is more than one rank.
+      if (gpu_team_active()) then
+         call logger%info(" ")
+         call logger%info("Running unfragmented calculation across "// &
+                          to_char(gpu_team_size())//" GPUs")
+         call logger%info("  Calculation type: "//calc_type_to_string(config%calc_type))
+         call logger%info(" ")
+         call unfragmented_calculation(sys_geom, config, result_out, json_data)
+      else if (world_comm%size() == 1 .or. world_comm%rank() == 0) then
          ! Either single-rank calculation, or rank 0 in multi-rank setup
          call logger%info(" ")
          call logger%info("Running unfragmented calculation")
@@ -759,7 +781,7 @@ contains
       !! Each molecule is independent, so assign one molecule per rank
       use mqc_config_types, only: mqc_config_t
       use mqc_config_adapter, only: config_to_system_geometry
-      use mqc_error, only: error_t
+      use mqc_error, only: error_t, ERROR_VALIDATION
       use mqc_io_helpers, only: set_molecule_suffix, get_output_json_filename
       use mqc_json, only: merge_multi_molecule_json
 
@@ -1215,5 +1237,85 @@ contains
       end if
       call logger%info("Wrote "//trim(path))
    end subroutine run_makefp
+
+   subroutine setup_gpu_team(world_comm, config, max_level)
+      !! Decide whether this run spreads one system over every rank's GPU
+      !!
+      !! Refusals abort rather than fall back. A deck that asked for several
+      !! GPUs and silently got one would report a wall time and a memory
+      !! footprint for a calculation nobody asked for, and the reason people
+      !! reach for this mode is that the single-GPU version did not fit -- so
+      !! the fallback is not a degraded success, it is the failure they were
+      !! trying to avoid, arriving later and less clearly.
+      type(comm_t), intent(in) :: world_comm
+      type(driver_config_t), intent(in) :: config
+      integer, intent(in) :: max_level
+
+      type(error_t) :: backend_error
+      integer :: backend_kind
+
+      call gpu_team_disable()
+      if (.not. config%method_config%multi_gpu) return
+
+      if (max_level > 0) then
+         if (world_comm%rank() == 0) then
+            call logger%error("system.multi_gpu is not available with fragmentation.")
+            call logger%error("  Fragmentation already gives every rank its own GPU -- one")
+            call logger%error("  rank per subsystem -- so the two want the same ranks for")
+            call logger%error("  different things. Drop keywords.fragmentation, or drop")
+            call logger%error("  system.multi_gpu and let the expansion spread the work.")
+         end if
+         call abort_comm(world_comm, 1)
+      end if
+
+      if (.not. method_runs_on_cuest(config%method_config%method_type)) then
+         if (world_comm%rank() == 0) then
+            call logger%error("system.multi_gpu needs a method that runs on the GPU; "// &
+                              "only HF and DFT do.")
+         end if
+         call abort_comm(world_comm, 1)
+      end if
+
+      call parse_backend_name(config%method_config%backend, backend_kind, backend_error)
+      if (backend_error%has_error()) then
+         if (world_comm%rank() == 0) call logger%error(backend_error%get_message())
+         call abort_comm(world_comm, 1)
+      end if
+      if (backend_kind == BACKEND_LIBCINT) then
+         if (world_comm%rank() == 0) then
+            call logger%error("system.multi_gpu was asked for alongside the CPU backend. "// &
+                              "Set system.gpu, or drop system.multi_gpu.")
+         end if
+         call abort_comm(world_comm, 1)
+      end if
+
+      call gpu_team_enable(world_comm)
+
+      ! Every rank now runs the whole SCF, and every rank's copy of the code
+      ! logs. Without this a four-GPU run prints the iteration table, the
+      ! energy and the gradient four times over, interleaved -- which reads as
+      ! four calculations having happened rather than one. Warnings and errors
+      ! survive on every rank, because a rank that fails has to be able to say
+      ! so; only the running commentary is silenced.
+      if (gpu_team_active() .and. world_comm%rank() /= 0) then
+         call logger%configure(warning_level)
+      end if
+
+      if (world_comm%rank() == 0) then
+         if (gpu_team_active()) then
+            call logger%info(" ")
+            call logger%info("Multi-GPU: one system across "//to_char(gpu_team_size())// &
+                             " ranks, one GPU each")
+            call logger%info("  The exchange-correlation quadrature is divided; J and K are")
+            call logger%info("  not, so every rank still builds a full density-fitting plan.")
+            call logger%info("  For device memory see keywords.scf.df_integral_direct.")
+            call logger%info(" ")
+         else
+            call logger%warning("system.multi_gpu was asked for on a single rank, which "// &
+                                "leaves nothing to spread over; running as an ordinary "// &
+                                "single-GPU calculation.")
+         end if
+      end if
+   end subroutine setup_gpu_team
 
 end module mqc_driver

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -223,7 +223,17 @@ endif()
 if(MQC_ENABLE_CUEST)
   addtestpp(mqc_cuest_spin)
   target_compile_definitions(test_mqc_cuest_spin PRIVATE MQC_WITH_CUEST)
+  # The DF-gradient memory policy names against cuEST's own enumerators. Only
+  # here, because only here do the bindings exist to disagree with.
+  addtestpp(mqc_cuest_memory_policy)
+  target_compile_definitions(test_mqc_cuest_memory_policy
+                             PRIVATE MQC_WITH_CUEST)
 endif()
+
+# The multi-GPU mode's arithmetic: that slicing the radial mesh across ranks
+# partitions it exactly, and that a dormant team is the identity. Unconditional
+# -- neither claim needs a GPU, and both are what the mode rests on.
+addtest(mqc_gpu_team)
 # The continuum cavity radii. Unconditional: the table is ours, a wrong entry
 # gives a wrong solvation energy with nothing to object, and neither cuEST nor
 # libxc is needed to check it.

--- a/test/test_mqc_cuest_memory_policy.F90
+++ b/test/test_mqc_cuest_memory_policy.F90
@@ -1,0 +1,96 @@
+#ifdef MQC_WITH_CUEST
+module test_mqc_cuest_memory_policy
+   !! Ties the hand-copied memory-policy numbers to the real cuEST bindings.
+   !!
+   !! `parse_df_derivative_memory` lives in `mqc_cuest_iface`, which is compiled
+   !! on the fpm path where the cuEST bindings do not exist, so it cannot import
+   !! the enumerators it returns -- it repeats their values as literals. That is
+   !! a copy, and copies drift: the day cuEST renumbers or inserts a policy, a
+   !! deck asking for `recompute` would quietly get `hostcache`, the gradient
+   !! would still be right, and the only symptom would be running out of memory
+   !! anyway. Nothing else in the build would notice.
+   !!
+   !! This test notices. It only builds where the bindings are present, which is
+   !! exactly where the mismatch would matter.
+   use testdrive, only: new_unittest, unittest_type, error_type, check
+   use mqc_error, only: error_t
+   use mqc_cuest_iface, only: parse_df_derivative_memory
+   use cuest, only: CUEST_DFSYMMETRICDERIVATIVECOMPUTE_MEMORY_POLICY_DEVICECACHE, &
+                    CUEST_DFSYMMETRICDERIVATIVECOMPUTE_MEMORY_POLICY_HOSTCACHE, &
+                    CUEST_DFSYMMETRICDERIVATIVECOMPUTE_MEMORY_POLICY_OVERWRITE, &
+                    CUEST_DFSYMMETRICDERIVATIVECOMPUTE_MEMORY_POLICY_RECOMPUTE
+   implicit none
+   private
+   public :: collect_mqc_cuest_memory_policy_tests
+
+contains
+
+   subroutine collect_mqc_cuest_memory_policy_tests(testsuite)
+      type(unittest_type), allocatable, intent(out) :: testsuite(:)
+
+      testsuite = [ &
+                  new_unittest("policy names match the bindings", test_policies_match) &
+                  ]
+   end subroutine collect_mqc_cuest_memory_policy_tests
+
+   subroutine test_policies_match(error)
+      !! Every name resolves to the enumerator cuEST actually defines
+      type(error_type), allocatable, intent(out) :: error
+
+      type(error_t) :: parse_error
+      integer :: policy
+
+      call parse_df_derivative_memory("devicecache", policy, parse_error)
+      call check(error, policy, int(CUEST_DFSYMMETRICDERIVATIVECOMPUTE_MEMORY_POLICY_DEVICECACHE))
+      if (allocated(error)) return
+
+      call parse_df_derivative_memory("hostcache", policy, parse_error)
+      call check(error, policy, int(CUEST_DFSYMMETRICDERIVATIVECOMPUTE_MEMORY_POLICY_HOSTCACHE))
+      if (allocated(error)) return
+
+      call parse_df_derivative_memory("overwrite", policy, parse_error)
+      call check(error, policy, int(CUEST_DFSYMMETRICDERIVATIVECOMPUTE_MEMORY_POLICY_OVERWRITE))
+      if (allocated(error)) return
+
+      call parse_df_derivative_memory("recompute", policy, parse_error)
+      call check(error, policy, int(CUEST_DFSYMMETRICDERIVATIVECOMPUTE_MEMORY_POLICY_RECOMPUTE))
+      if (allocated(error)) return
+
+      ! 'auto' must stay outside the enumeration. If cuEST ever numbered a
+      ! policy -1 this would fire, which is the point: the sentinel and the
+      ! vendor's values share one integer.
+      call parse_df_derivative_memory("auto", policy, parse_error)
+      call check(error, policy < 0, "'auto' is no longer distinguishable from a real policy")
+   end subroutine test_policies_match
+
+end module test_mqc_cuest_memory_policy
+
+program tester
+   use, intrinsic :: iso_fortran_env, only: error_unit
+   use testdrive, only: run_testsuite, new_testsuite, testsuite_type
+   use test_mqc_cuest_memory_policy, only: collect_mqc_cuest_memory_policy_tests
+   implicit none
+   integer :: stat, is
+   type(testsuite_type), allocatable :: testsuites(:)
+   character(len=*), parameter :: fmt = '("#", *(1x, a))'
+
+   stat = 0
+   testsuites = [new_testsuite("mqc_cuest_memory_policy", &
+                               collect_mqc_cuest_memory_policy_tests)]
+
+   do is = 1, size(testsuites)
+      write (error_unit, fmt) "Testing:", testsuites(is)%name
+      call run_testsuite(testsuites(is)%collect, error_unit, stat)
+   end do
+
+   if (stat > 0) then
+      write (error_unit, "(i0, 1x, a)") stat, "test(s) failed!"
+      error stop
+   end if
+end program tester
+#else
+program tester
+   !! cuEST is not in this build, so there are no bindings to check against.
+   implicit none
+end program tester
+#endif

--- a/test/test_mqc_gpu_team.f90
+++ b/test/test_mqc_gpu_team.f90
@@ -1,0 +1,260 @@
+module test_mqc_gpu_team
+   !! What the multi-GPU mode gets right without a GPU in the room.
+   !!
+   !! Two things here are worth more than they look. The first is the radial
+   !! partition: the whole claim of the mode is that slicing the quadrature
+   !! across ranks and adding the pieces back reproduces the single-GPU answer
+   !! *exactly*, not nearly. That claim is arithmetic on the mesh and needs no
+   !! device, so it is checked here rather than discovered later as a two
+   !! millihartree disagreement between one GPU and four.
+   !!
+   !! The second is the memory-policy name table. `parse_df_derivative_memory`
+   !! repeats cuEST's enumerator values by hand, because the module it lives in
+   !! is compiled on the fpm path where the cuEST bindings do not exist. A
+   !! hand-copied enum is exactly the kind of thing that rots silently when the
+   !! vendor renumbers, so the values are pinned here; the companion assertion
+   !! against the real bindings lives in test_mqc_cuest_memory_policy, which
+   !! only builds when they are present.
+   use testdrive, only: new_unittest, unittest_type, error_type, check
+   use pic_types, only: dp
+   use mqc_error, only: error_t
+   use mqc_gpu_team, only: gpu_team_active, gpu_team_rank, gpu_team_size, &
+                           gpu_team_reduce, gpu_team_reduce_scalar, gpu_team_agree, &
+                           gpu_team_disable
+   use mqc_cuest_iface, only: parse_df_derivative_memory
+   implicit none
+   private
+   public :: collect_mqc_gpu_team_tests
+
+contains
+
+   subroutine collect_mqc_gpu_team_tests(testsuite)
+      type(unittest_type), allocatable, intent(out) :: testsuite(:)
+
+      testsuite = [ &
+                  new_unittest("radial shards partition the mesh", test_shards_partition), &
+                  new_unittest("radial shards are balanced", test_shards_balanced), &
+                  new_unittest("one shard is the whole mesh", test_single_shard), &
+                  new_unittest("dormant team is the identity", test_dormant_team), &
+                  new_unittest("memory policy names", test_memory_policy_names), &
+                  new_unittest("memory policy rejects nonsense", test_memory_policy_bad) &
+                  ]
+   end subroutine collect_mqc_gpu_team_tests
+
+   subroutine test_shards_partition(error)
+      !! Every radial point belongs to exactly one shard, and the shards
+      !! together are the whole mesh
+      !!
+      !! This is the multi-GPU mode's correctness argument in one assertion.
+      !! The Becke weight at a point does not depend on which other points
+      !! exist, so if the point sets partition, the quadrature sums do too --
+      !! and the reduced result is bit-for-bit the single-GPU one rather than
+      !! an approximation to it.
+      type(error_type), allocatable, intent(out) :: error
+
+      integer, parameter :: N_RADIAL = 75
+      integer, parameter :: N_SHARDS = 4
+      logical :: seen(N_RADIAL)
+      integer :: shard, i, total
+
+      seen = .false.
+      total = 0
+      do shard = 0, N_SHARDS - 1
+         do i = shard + 1, N_RADIAL, N_SHARDS
+            call check(error,.not. seen(i), "radial point claimed by two shards")
+            if (allocated(error)) return
+            seen(i) = .true.
+            total = total + 1
+         end do
+      end do
+
+      call check(error, total, N_RADIAL)
+      if (allocated(error)) return
+      call check(error, all(seen), "a radial point belongs to no shard")
+   end subroutine test_shards_partition
+
+   subroutine test_shards_balanced(error)
+      !! No shard is more than one point larger than any other
+      !!
+      !! Striding rather than blocking is what buys this. It matters for more
+      !! than tidiness: the ranks run in lockstep and reduce every iteration,
+      !! so the slowest shard sets the pace, and a blocked split would hand one
+      !! rank the dense core of every atom and another the vacuum.
+      type(error_type), allocatable, intent(out) :: error
+
+      integer, parameter :: N_RADIAL = 75
+      integer, parameter :: N_SHARDS = 8
+      integer :: shard, counts(0:N_SHARDS - 1), formula
+
+      do shard = 0, N_SHARDS - 1
+         counts(shard) = count_shard(N_RADIAL, shard, N_SHARDS)
+         ! The closed form the backend uses to size its arrays, checked against
+         ! the loop that actually fills them -- a mismatch here is an
+         ! out-of-bounds write on the GPU path.
+         formula = (N_RADIAL - shard - 1)/N_SHARDS + 1
+         call check(error, counts(shard), formula)
+         if (allocated(error)) return
+      end do
+
+      call check(error, sum(counts), N_RADIAL)
+      if (allocated(error)) return
+      call check(error, maxval(counts) - minval(counts) <= 1, &
+                 "radial shards differ by more than one point")
+   end subroutine test_shards_balanced
+
+   subroutine test_single_shard(error)
+      !! One shard keeps every point, so a single-rank run is untouched
+      type(error_type), allocatable, intent(out) :: error
+
+      integer, parameter :: N_RADIAL = 75
+
+      call check(error, count_shard(N_RADIAL, 0, 1), N_RADIAL)
+      if (allocated(error)) return
+      call check(error, (N_RADIAL - 0 - 1)/1 + 1, N_RADIAL)
+   end subroutine test_single_shard
+
+   subroutine test_dormant_team(error)
+      !! With no team live, every collective is the identity
+      !!
+      !! The reductions are called unconditionally from the SCF, so a serial
+      !! run passes through them on every iteration. If they were not exactly
+      !! the identity, single-GPU answers would change the day this mode
+      !! landed -- which is the regression this catches.
+      type(error_type), allocatable, intent(out) :: error
+
+      real(dp) :: array(3), scalar
+      logical :: flag
+
+      call gpu_team_disable()
+
+      call check(error,.not. gpu_team_active(), "a disabled team reports itself active")
+      if (allocated(error)) return
+      call check(error, gpu_team_size(), 1)
+      if (allocated(error)) return
+      call check(error, gpu_team_rank(), 0)
+      if (allocated(error)) return
+
+      array = [1.0_dp, -2.5_dp, 3.25_dp]
+      call gpu_team_reduce(array)
+      call check(error, array(1), 1.0_dp)
+      if (allocated(error)) return
+      call check(error, array(2), -2.5_dp)
+      if (allocated(error)) return
+      call check(error, array(3), 3.25_dp)
+      if (allocated(error)) return
+
+      scalar = -7.5_dp
+      call gpu_team_reduce_scalar(scalar)
+      call check(error, scalar, -7.5_dp)
+      if (allocated(error)) return
+
+      ! Both branches: a dormant `agree` must not turn a false into a true, and
+      ! must not turn a true into a false either -- it would stall or shorten
+      ! every serial SCF respectively.
+      flag = .true.
+      call gpu_team_agree(flag)
+      call check(error, flag, "dormant agree changed a true")
+      if (allocated(error)) return
+
+      flag = .false.
+      call gpu_team_agree(flag)
+      call check(error,.not. flag, "dormant agree changed a false")
+   end subroutine test_dormant_team
+
+   subroutine test_memory_policy_names(error)
+      !! Each accepted name maps to cuEST's enumerator, and 'auto' to -1
+      type(error_type), allocatable, intent(out) :: error
+
+      type(error_t) :: parse_error
+      integer :: policy
+
+      call parse_df_derivative_memory("auto", policy, parse_error)
+      call check(error,.not. parse_error%has_error(), "'auto' was rejected")
+      if (allocated(error)) return
+      call check(error, policy, -1)
+      if (allocated(error)) return
+
+      ! -1 is not a cuEST value; it is this code's "set nothing at all", which
+      ! has to stay distinguishable from DEVICECACHE = 0. Conflating them would
+      ! mean every gradient silently pinned to one policy.
+      call parse_df_derivative_memory("", policy, parse_error)
+      call check(error, policy, -1)
+      if (allocated(error)) return
+
+      call parse_df_derivative_memory("devicecache", policy, parse_error)
+      call check(error, policy, 0)
+      if (allocated(error)) return
+
+      call parse_df_derivative_memory("hostcache", policy, parse_error)
+      call check(error, policy, 1)
+      if (allocated(error)) return
+
+      call parse_df_derivative_memory("overwrite", policy, parse_error)
+      call check(error, policy, 2)
+      if (allocated(error)) return
+
+      call parse_df_derivative_memory("recompute", policy, parse_error)
+      call check(error, policy, 3)
+      if (allocated(error)) return
+
+      ! Case and surrounding space are a deck author's business, not cuEST's.
+      call parse_df_derivative_memory("  OverWrite  ", policy, parse_error)
+      call check(error,.not. parse_error%has_error(), "a spelled-out name was rejected")
+      if (allocated(error)) return
+      call check(error, policy, 2)
+   end subroutine test_memory_policy_names
+
+   subroutine test_memory_policy_bad(error)
+      !! An unknown policy is refused rather than defaulted
+      !!
+      !! Falling back to 'auto' would mean a typo bought cuEST's default and
+      !! said nothing -- on the one keyword whose entire purpose is to be
+      !! reached for when the default has already run out of memory.
+      type(error_type), allocatable, intent(out) :: error
+
+      type(error_t) :: parse_error
+      integer :: policy
+
+      call parse_df_derivative_memory("hostcahce", policy, parse_error)
+      call check(error, parse_error%has_error(), "a misspelled policy was accepted")
+      if (allocated(error)) return
+      call check(error, index(parse_error%get_message(), "hostcahce") > 0, &
+                 "the refusal does not quote the name it refused")
+   end subroutine test_memory_policy_bad
+
+   pure integer function count_shard(n_radial, shard, n_shards)
+      !! How many radial points a shard actually receives, by the same loop the
+      !! backend uses to fill them
+      integer, intent(in) :: n_radial, shard, n_shards
+      integer :: i
+
+      count_shard = 0
+      do i = shard + 1, n_radial, n_shards
+         count_shard = count_shard + 1
+      end do
+   end function count_shard
+
+end module test_mqc_gpu_team
+
+program tester
+   use, intrinsic :: iso_fortran_env, only: error_unit
+   use testdrive, only: run_testsuite, new_testsuite, testsuite_type
+   use test_mqc_gpu_team, only: collect_mqc_gpu_team_tests
+   implicit none
+   integer :: stat, is
+   type(testsuite_type), allocatable :: testsuites(:)
+   character(len=*), parameter :: fmt = '("#", *(1x, a))'
+
+   stat = 0
+   testsuites = [new_testsuite("mqc_gpu_team", collect_mqc_gpu_team_tests)]
+
+   do is = 1, size(testsuites)
+      write (error_unit, fmt) "Testing:", testsuites(is)%name
+      call run_testsuite(testsuites(is)%collect, error_unit, stat)
+   end do
+
+   if (stat > 0) then
+      write (error_unit, "(i0, 1x, a)") stat, "test(s) failed!"
+      error stop
+   end if
+end program tester

--- a/test/test_mqc_json_reader.f90
+++ b/test/test_mqc_json_reader.f90
@@ -65,6 +65,7 @@ contains
                   new_unittest("backend_keyword", test_backend_keyword), &
                   new_unittest("system_gpu_keyword", test_gpu_keyword), &
                   new_unittest("system_gpu_conflicts_with_backend", test_gpu_conflict), &
+                  new_unittest("multi_gpu_and_memory_keywords", test_multi_gpu_keywords), &
                   new_unittest("cuest_method_allow_list", test_cuest_methods), &
                   new_unittest("pcm_keywords", test_pcm_keywords), &
                   new_unittest("dft_keywords", test_dft_keywords), &
@@ -652,6 +653,63 @@ contains
       call check(error, parse_error%has_error(), &
                  "system.gpu true must be refused for a method cuEST cannot run")
    end subroutine test_gpu_keyword
+
+   subroutine test_multi_gpu_keywords(error)
+      !! `system.multi_gpu` and the two device-memory keys beside it
+      !!
+      !! All three default off/auto, which is the property that matters most:
+      !! they were added to rescue a calculation that did not fit, and a deck
+      !! that never mentions them has to behave exactly as it did before they
+      !! existed. Reading a default wrong here would change every GPU run in
+      !! the suite at once.
+      type(error_type), allocatable, intent(out) :: error
+      type(mqc_config_t) :: config
+      type(error_t) :: parse_error
+
+      ! Absent: the defaults, untouched.
+      call write_deck('"method": "hf", "basis": "sto-3g"', "Energy", "", "", two_atoms())
+      call read_deck(config, parse_error)
+      call check(error,.not. parse_error%has_error(), parse_error%get_message())
+      if (allocated(error)) return
+      call check(error,.not. config%multi_gpu, "system.multi_gpu defaults on")
+      if (allocated(error)) return
+      call check(error,.not. config%scf_df_integral_direct, &
+                 "keywords.scf.df_integral_direct defaults on")
+      if (allocated(error)) return
+      call check(error,.not. allocated(config%scf_df_derivative_memory), &
+                 "an absent df_derivative_memory must stay unallocated, not 'auto'")
+      if (allocated(error)) return
+
+      ! Present: each read into its own field.
+      call write_deck('"method": "hf", "basis": "sto-3g"', "Energy", &
+                      '"scf": {"df_integral_direct": true, '// &
+                      '"df_derivative_memory": "recompute"}', &
+                      '"multi_gpu": true', two_atoms())
+      call read_deck(config, parse_error)
+      call check(error,.not. parse_error%has_error(), parse_error%get_message())
+      if (allocated(error)) return
+      call check(error, config%multi_gpu, "system.multi_gpu true was not read")
+      if (allocated(error)) return
+      call check(error, config%scf_df_integral_direct, &
+                 "keywords.scf.df_integral_direct true was not read")
+      if (allocated(error)) return
+      call check(error, allocated(config%scf_df_derivative_memory), &
+                 "keywords.scf.df_derivative_memory was not read")
+      if (allocated(error)) return
+      call check(error, trim(config%scf_df_derivative_memory) == "recompute", &
+                 "keywords.scf.df_derivative_memory read the wrong value")
+      if (allocated(error)) return
+
+      ! The schema validator rejects what it does not know, so a key added to
+      ! the reader but not to the allow-list would never reach the reader at
+      ! all. A near-miss spelling proves the allow-list is what let the real
+      ! ones through, rather than the validator being off entirely.
+      call write_deck('"method": "hf", "basis": "sto-3g"', "Energy", "", &
+                      '"multi_gpus": true', two_atoms())
+      call read_deck(config, parse_error)
+      call check(error, parse_error%has_error(), &
+                 "an unknown system key was accepted")
+   end subroutine test_multi_gpu_keywords
 
    subroutine test_gpu_conflict(error)
       !! `system.gpu` and `backend` naming different things is refused

--- a/validation/inputs/gpu/cuest/dft/multigpu_gly3_b3lyp_grad.json
+++ b/validation/inputs/gpu/cuest/dft/multigpu_gly3_b3lyp_grad.json
@@ -1,0 +1,32 @@
+{
+    "schema": {
+        "name": "mqc-frag",
+        "version": "1.0"
+    },
+    "molecules": [
+        {
+            "xyz": "../../../sample_inputs/gly3.xyz",
+            "molecular_charge": 0,
+            "molecular_multiplicity": 1
+        }
+    ],
+    "model": {
+        "method": "dft",
+        "basis": "def2-svp",
+        "aux_basis": "def2-universal-jkfit",
+        "functional": "b3lyp"
+    },
+    "keywords": {
+        "scf": {
+            "maxiter": 100,
+            "tolerance": 1e-08
+        }
+    },
+    "system": {
+        "multi_gpu": true,
+        "logger": {
+            "level": "Verbose"
+        }
+    },
+    "driver": "Gradient"
+}

--- a/validation/inputs/gpu/cuest/dft/multigpu_gly3_b3lyp_grad_direct.json
+++ b/validation/inputs/gpu/cuest/dft/multigpu_gly3_b3lyp_grad_direct.json
@@ -1,0 +1,34 @@
+{
+    "schema": {
+        "name": "mqc-frag",
+        "version": "1.0"
+    },
+    "molecules": [
+        {
+            "xyz": "../../../sample_inputs/gly3.xyz",
+            "molecular_charge": 0,
+            "molecular_multiplicity": 1
+        }
+    ],
+    "model": {
+        "method": "dft",
+        "basis": "def2-svp",
+        "aux_basis": "def2-universal-jkfit",
+        "functional": "b3lyp"
+    },
+    "keywords": {
+        "scf": {
+            "maxiter": 100,
+            "tolerance": 1e-08,
+            "df_integral_direct": true,
+            "df_derivative_memory": "recompute"
+        }
+    },
+    "system": {
+        "multi_gpu": true,
+        "logger": {
+            "level": "Verbose"
+        }
+    },
+    "driver": "Gradient"
+}

--- a/validation/run_multigpu_test.sh
+++ b/validation/run_multigpu_test.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+# Check that spreading one system over several GPUs does not change its answer.
+#
+#   ./validation/run_multigpu_test.sh [n_ranks] [path/to/mqc]
+#
+# The claim the multi-GPU mode makes is exact, not approximate: the radial
+# quadrature is partitioned across ranks and the pieces are summed, and a Becke
+# weight does not depend on which other grid points exist, so the reduced
+# integral is the single-GPU integral term for term. This script is what turns
+# that claim into a number.
+#
+# One deck is run twice. At -np 1 the team is dormant -- `gpu_team_active` is
+# false whatever the deck asked for -- so that run IS the single-GPU reference,
+# built by the same code path rather than by a second deck that might drift
+# away from it. At -np N the grid is sliced N ways.
+#
+# What to expect: agreement to the last printed digit. This is not a tolerance
+# test in spirit. The two runs differ only in the ORDER an identical set of
+# quadrature contributions is summed, which in floating point is worth an ulp
+# or two on the total energy -- so a disagreement in the sixth decimal is not
+# "close enough", it means the partition dropped or double-counted points.
+#
+# Needs a GPU of compute capability 8.0 or newer per rank, and at least as many
+# visible GPUs as ranks -- ranks past the device count share a device, which
+# still gives the right answer but measures nothing about memory.
+set -u
+cd "$(dirname "$0")/.."
+NP=${1:-2}
+MQC=${2:-./build/mqc}
+
+if [ ! -x "$MQC" ]; then
+    echo "No mqc binary at $MQC -- build with -DMQC_ENABLE_CUEST=ON first." >&2
+    exit 1
+fi
+
+find_deck() { find validation/inputs -name "$1.json" -print -quit; }
+
+# The energy and the gradient norm both, deliberately. The energy alone would
+# miss a partition that is wrong only in the XC derivative, and the gradient is
+# the calculation this mode exists for.
+extract() {
+    printf '%s' "$1" | awk '
+        /Final energy:/      { e = $NF }
+        /Gradient norm/      { g = $NF }
+        END { printf "%s %s", (e == "" ? "NONE" : e), (g == "" ? "NONE" : g) }'
+}
+
+run_case() {   # $1 = label, $2 = ranks, $3 = deck stem
+    local deck out
+    deck=$(find_deck "$3")
+    if [ -z "$deck" ]; then
+        printf '%-28s %s\n' "$1" "deck '$3' not found"
+        return 1
+    fi
+    if [ "$2" -eq 1 ]; then
+        out=$("$MQC" "$deck" 2>&1)
+    else
+        out=$(mpirun -np "$2" "$MQC" "$deck" 2>&1)
+    fi
+    extract "$out"
+}
+
+echo "Multi-GPU consistency: one system, 1 rank vs $NP ranks"
+echo "-------------------------------------------------------------------"
+
+status=0
+for stem in multigpu_gly3_b3lyp_grad multigpu_gly3_b3lyp_grad_direct; do
+    one=$(run_case "$stem (1 rank)" 1 "$stem") || { status=1; continue; }
+    many=$(run_case "$stem ($NP ranks)" "$NP" "$stem") || { status=1; continue; }
+
+    printf '%-38s\n' "$stem"
+    printf '  %-10s energy=%-22s |grad|=%s\n' "1 rank"  ${one}
+    printf '  %-10s energy=%-22s |grad|=%s\n' "$NP ranks" ${many}
+
+    if [ "$one" = "$many" ]; then
+        echo "  MATCH"
+    else
+        echo "  DIFFER -- the radial partition is not summing back to the whole grid."
+        status=1
+    fi
+    echo
+done
+
+# The second deck adds df_integral_direct and a recompute gradient policy. It
+# must reach the same numbers as the first: those keywords trade time for
+# device memory and are not allowed to change the answer. If deck one matches
+# across ranks and deck two does not, suspect the memory policy rather than the
+# grid.
+echo "Both decks should also agree with EACH OTHER: integral-direct and the"
+echo "gradient memory policy trade time for memory and must not move the energy."
+
+exit $status


### PR DESCRIPTION
…mory

Two things, because the first does not do what it was asked to do alone.

system.multi_gpu gives one system every rank's GPU instead of giving every rank its own system, using the per-rank device binding mqc_cuest_context already had -- cudaSetDevice(mod(local_rank, device_count)), which is what cuEST's basic_multigpu_usage sample does with pthreads rather than ranks.

Only the exchange-correlation quadrature actually divides. cuEST 0.2 offers no way to split a density-fitted J or K: cuestAOPairListCreate takes a screening threshold rather than a list of pairs, splitting the auxiliary basis changes the fitting metric instead of partitioning it, and the B^P C intermediate a distributed K would reduce is never exposed. The grid is different because we build it: mqc_cuest_grid computes the radial mesh itself, so rank g of N keeps shells g, g+N, g+2N of every atom while all nuclear coordinates still reach cuestMolecularGridCreate. A Becke weight depends on its point and the nuclei, not on which other points exist, so the slices partition the quadrature exactly and the reduced result is the single-GPU one term for term. Vxc, Exc and dExc/dR are reduced inside mqc_cuest_integrals, so neither the SCF nor the gradient learns the mode exists.

Striding, not blocking: the mesh is dense at the nucleus and sparse in the tail, so a contiguous split would hand one rank the core and another the vacuum. Fewer radial shells than ranks is refused rather than tolerated -- a rank without an XC plan cannot query the functional's exact-exchange fraction, so it would build a differently defined Fock operator rather than contribute nothing.

Refused with fragmentation, which already means one rank per subsystem, and on the CPU backend. Those abort rather than fall back: the reason to reach for this is that one GPU did not fit, so a silent fallback is the same failure arriving later. On one rank the mode is inert, which makes -np 1 a valid reference for -np N.

Every rank still builds a full DF plan, so multi-GPU does not fix a DF-driven OOM. What does:

  keywords.scf.df_integral_direct    -> THREE_INDEX_INTEGRAL_DIRECT
  keywords.scf.df_derivative_memory  -> the DF gradient's MEMORY_POLICY

Neither was wired up before. The plan's persistent workspace holds the cached three-index integrals and is the largest allocation a run makes -- NVIDIA's own reference SCF marks that line as the likely point of failure. Its size is now queried and logged against free device memory before it is allocated, and if it will not fit the plan is rebuilt integral-direct automatically with a warning naming both numbers. A failure that survives that says what it needed, what was free, and which knob is still unused.

Non-root ranks drop to warning level, so four GPUs report one calculation rather than four interleaved copies.

Tested: the radial partition and the dormant-team identity as unit tests, the memory-policy names pinned against cuEST's real enumerators wherever the bindings exist, and the new deck keys through the JSON reader. The backend compiles against the real bindings. None of it has run on a GPU -- this box has V100s, which cuEST refuses -- so validation/run_multigpu_test.sh compares 1 rank against N on hardware that can.