### PR TITLE
Add a spatial-orbital coupled cluster path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,7 +183,12 @@ Ab initio on the CPU, via libcint (`backends/libcint/`):
   `model.functional`. LDA through double hybrid, including range-separated
   hybrids, whose long-range exchange needs the direct build
 - `MP2`, `SCS-MP2`, `SOS-MP2`, `RI-MP2` - RHF reference only
-- `CCSD`, `CCSD(T)`, `RI-CCSD`, `RI-CCSD(T)` - spin orbital, RHF reference
+- `CCSD`, `CCSD(T)`, `RI-CCSD`, `RI-CCSD(T)` - RHF reference, spin-adapted
+  (spatial orbitals) by default. `keywords.cc.spin_adapted: false` selects the
+  spin-orbital formulation instead; the two are exact for a closed shell and
+  agree to machine precision, so that flag chooses how a number is computed and
+  not which number. Spatial is the default because it is roughly sixteen times
+  smaller and several times faster.
 
 An `RI-`/`DF-` prefix parses to the same method type as the bare name, so the
 intent is recovered in the reader by `method_wants_density_fitting` while the

--- a/backends/libcint/CMakeLists.txt
+++ b/backends/libcint/CMakeLists.txt
@@ -38,6 +38,7 @@ target_sources(
           mqc_libcint_mp2_gradient.f90
           mqc_libcint_ri_mp2_gradient.f90
           mqc_libcint_cc.f90
+          mqc_libcint_rcc.f90
           mqc_libcint_ao_data.f90
           mqc_libcint_ao.f90
           mqc_libcint_xc.F90

--- a/backends/libcint/mqc_libcint_bridge.f90
+++ b/backends/libcint/mqc_libcint_bridge.f90
@@ -34,6 +34,7 @@ module mqc_libcint_bridge
    use mqc_libcint_ri_mp2_gradient, only: libcint_ri_mp2_gradient
    use mqc_libcint_mp2, only: mp2_result_t, run_libcint_mp2, run_libcint_ri_mp2
    use mqc_libcint_cc, only: cc_result_t, run_libcint_ccsd
+   use mqc_libcint_rcc, only: rcc_result_t, run_libcint_rccsd
    use mqc_libcint_bonding, only: run_quao_analysis, bonding_analysis_kind, &
                                   BONDING_GMS_QUAO
    use mqc_libcint_casci, only: casci_result_t, run_libcint_casci
@@ -1038,7 +1039,10 @@ contains
       if (settings%run_cc) then
          block
             type(cc_result_t) :: cc
-            integer :: frozen
+            type(rcc_result_t) :: rcc
+            integer :: frozen, cc_iterations
+            logical :: cc_converged, spin_adapted
+            real(dp) :: cc_mp2, cc_singles, cc_doubles, cc_triples
 
             ! The same frozen-core rule the MP2 block applies, deliberately
             ! duplicated rather than hoisted: the two blocks are independent, and
@@ -1048,6 +1052,14 @@ contains
             if (frozen < 0) frozen = core_orbital_count(fragment%element_numbers)
             if (.not. settings%freeze_core) frozen = 0
 
+            ! Which formulation. Both are exact for a closed shell and agree to
+            ! machine precision -- that identity is asserted by
+            ! test_mqc_libcint_rcc -- so this chooses how the same number is
+            ! computed, not which number. Spatial by default because it is
+            ! smaller and faster; the spin-orbital path is what a doubtful
+            ! result gets checked against.
+            spin_adapted = settings%cc_spin_adapted
+
             if (settings%corr_density_fitting) then
                call correlation_aux_basis(settings, fragment, symbols, corr_aux, error)
                if (error%has_error()) then
@@ -1056,18 +1068,34 @@ contains
                   call mol%destroy()
                   return
                end if
-               call run_libcint_ccsd(mol, scf%orbitals, scf%orbital_energies, &
-                                     fragment%nelec/2, frozen, settings%cc_max_iter, &
-                                     settings%cc_tolerance, settings%cc_triples, &
-                                     settings%verbose, cc, error, &
-                                     diis_vectors=settings%cc_diis_size, aux=corr_aux)
+               if (spin_adapted) then
+                  call run_libcint_rccsd(mol, scf%orbitals, scf%orbital_energies, &
+                                         fragment%nelec/2, frozen, settings%cc_max_iter, &
+                                         settings%cc_tolerance, settings%cc_triples, &
+                                         settings%verbose, rcc, error, &
+                                         diis_vectors=settings%cc_diis_size, aux=corr_aux)
+               else
+                  call run_libcint_ccsd(mol, scf%orbitals, scf%orbital_energies, &
+                                        fragment%nelec/2, frozen, settings%cc_max_iter, &
+                                        settings%cc_tolerance, settings%cc_triples, &
+                                        settings%verbose, cc, error, &
+                                        diis_vectors=settings%cc_diis_size, aux=corr_aux)
+               end if
                call corr_aux%destroy()
             else
-               call run_libcint_ccsd(mol, scf%orbitals, scf%orbital_energies, &
-                                     fragment%nelec/2, frozen, settings%cc_max_iter, &
-                                     settings%cc_tolerance, settings%cc_triples, &
-                                     settings%verbose, cc, error, &
-                                     diis_vectors=settings%cc_diis_size)
+               if (spin_adapted) then
+                  call run_libcint_rccsd(mol, scf%orbitals, scf%orbital_energies, &
+                                         fragment%nelec/2, frozen, settings%cc_max_iter, &
+                                         settings%cc_tolerance, settings%cc_triples, &
+                                         settings%verbose, rcc, error, &
+                                         diis_vectors=settings%cc_diis_size)
+               else
+                  call run_libcint_ccsd(mol, scf%orbitals, scf%orbital_energies, &
+                                        fragment%nelec/2, frozen, settings%cc_max_iter, &
+                                        settings%cc_tolerance, settings%cc_triples, &
+                                        settings%verbose, cc, error, &
+                                        diis_vectors=settings%cc_diis_size)
+               end if
             end if
             if (error%has_error()) then
                call result%error%set(ERROR_VALIDATION, "CCSD: "//error%get_message())
@@ -1076,24 +1104,51 @@ contains
                return
             end if
 
+            ! The two result types carry the same components under the same
+            ! names, so everything below this line is written once.
+            if (spin_adapted) then
+               cc_mp2 = rcc%e_mp2
+               cc_singles = rcc%e_singles
+               cc_doubles = rcc%e_doubles
+               cc_triples = rcc%e_triples
+               cc_iterations = rcc%iterations
+               cc_converged = rcc%converged
+            else
+               cc_mp2 = cc%e_mp2
+               cc_singles = cc%e_singles
+               cc_doubles = cc%e_doubles
+               cc_triples = cc%e_triples
+               cc_iterations = cc%iterations
+               cc_converged = cc%converged
+            end if
+
             ! energy_t sums scf + mp2%total() + cc%total(), so only the components
             ! go in. All three are filled rather than a lumped correlation energy:
             ! a total cannot be taken apart afterwards, and the singles/doubles
             ! split is what says whether the T1 amplitudes are doing anything.
-            result%energy%cc%singles = cc%e_singles
-            result%energy%cc%doubles = cc%e_doubles
-            result%energy%cc%triples = cc%e_triples
+            result%energy%cc%singles = cc_singles
+            result%energy%cc%doubles = cc_doubles
+            result%energy%cc%triples = cc_triples
             if (settings%verbose) then
-               write (line, "(a,i0,a,l1)") "  CCSD: iterations ", cc%iterations, "  converged ", cc%converged
+               ! Which formulation ran is said out loud. The two agree to
+               ! machine precision, so nothing in the numbers below would
+               ! otherwise reveal it -- and it is exactly what someone
+               ! comparing a timing or a memory figure needs to know.
+               if (spin_adapted) then
+                  call logger%info("  CCSD: spin-adapted (spatial orbitals)")
+               else
+                  call logger%info("  CCSD: spin orbitals")
+               end if
+               write (line, "(a,i0,a,l1)") "  CCSD: iterations ", cc_iterations, "  converged ", cc_converged
                call logger%info(trim(line))
-               write (line, "(a,f20.12)") "  E(MP2)         ", cc%e_mp2
+               write (line, "(a,f20.12)") "  E(MP2)         ", cc_mp2
                call logger%info(trim(line))
-               write (line, "(a,f20.12)") "  E(singles)     ", cc%e_singles
+               write (line, "(a,f20.12)") "  E(singles)     ", cc_singles
                call logger%info(trim(line))
-               write (line, "(a,f20.12)") "  E(doubles)     ", cc%e_doubles
+               write (line, "(a,f20.12)") "  E(doubles)     ", cc_doubles
                call logger%info(trim(line))
                if (settings%cc_triples) then
-                  write (line, "(a,f20.12)") "  E(T)           ", cc%e_triples
+                  write (line, "(a,f20.12)") "  E(T)           ", cc_triples
                   call logger%info(trim(line))
                end if
                write (line, "(a,f20.12)") "  E(corr)        ", result%energy%cc%total()

--- a/backends/libcint/mqc_libcint_rcc.f90
+++ b/backends/libcint/mqc_libcint_rcc.f90
@@ -1,0 +1,1290 @@
+!! Closed-shell coupled cluster in spatial orbitals
+module mqc_libcint_rcc
+   !! Spin-adapted (restricted) CCSD over an RHF reference.
+   !!
+   !! The companion to `mqc_libcint_cc`, which does the same physics in spin
+   !! orbitals. That module says of itself that spin orbitals are the reference
+   !! formulation and to "revisit if CCSD becomes something people run rather
+   !! than something people check against". This is that revisit. Neither
+   !! replaces the other: the spin-orbital path stays as the oracle, because for
+   !! a closed shell the two must agree to machine precision and that identity
+   !! is a far sharper test than any reference energy.
+   !!
+   !! **Why.** Everything the spin-orbital path indexes is twice as long in each
+   !! of four dimensions. `t2` is `nv^2 no^2` where this is `n_v^2 n_o^2` --
+   !! sixteen times -- and DIIS keeps sixteen copies of it, which is the single
+   !! largest allocation a CCSD run makes and is invisible until measured. The
+   !! `n_occ n_vir^3` integral blocks carry the same factor. Benzene/cc-pVDZ
+   !! goes from about 17 GB to 2.2 GB, and on the fitted path, where the
+   !! `n_act^4` tensor never exists, from 15.9 GB to 0.9 GB.
+   !!
+   !! **Equations.** Hirata, Podeszwa, Tobita and Bartlett, JCP 120, 2581 (2004),
+   !! Eqs. (35)-(45), followed term for term as PySCF's `cc/rccsd.py` and
+   !! `cc/rintermediates.py` write them. That source rather than the paper on
+   !! purpose: every reference energy in `validation/check_cc.f90` was generated
+   !! by PySCF, so matching its equations means matching its answer by
+   !! construction, and a disagreement is debuggable against a readable
+   !! implementation instead of against a table.
+   !!
+   !! **Notation.** Chemists', spatial, and each array is indexed in the order
+   !! its name reads: `ovov(i,a,j,b)` is `(ia|jb)`. The einsum string from the
+   !! reference is quoted above every contraction, because the translation from
+   !! row-major numpy to column-major Fortran is the one place this can go
+   !! quietly wrong, and a transposed index gives a converged wrong number.
+   !!
+   !! Real orbitals throughout, which is what lets `(ia|bj)` be read straight out
+   !! of `ovov` as `(ia|jb)` and `(ia|jk)` out of `ooov` as `(jk|ia)`. Both
+   !! identities need `(pq|rs) = (pq|sr) = (rs|pq)` and would not hold for
+   !! complex orbitals; PySCF carries separate `ovvo` and `ovoo` blocks because
+   !! it supports those.
+   !!
+   !! **Canonical orbitals are assumed**, as they are next door. The Fock matrix
+   !! is then diagonal, so `f_ov` vanishes and the occupied-occupied and
+   !! virtual-virtual blocks are exactly the orbital energies that go into the
+   !! denominators. The reference adds `foo`/`fvv` into the intermediates and
+   !! subtracts the same diagonal back out a few lines later; here neither
+   !! happens, which is the same arithmetic with two fewer chances to get a sign
+   !! wrong.
+   !!
+   !! **What is not held.** `(vv|vv)` is never materialised in the fitted case
+   !! and is read once in the conventional one. The particle-particle ladder is
+   !! the only consumer, and it works a batch of `(cd)` columns at a time -- the
+   !! same argument, and the same batching, as `particle_ladder` next door.
+   use pic_types, only: dp
+   use pic_blas_interfaces, only: pic_gemm
+   use mqc_timing, only: timing_report_t
+   use mqc_error, only: error_t, ERROR_VALIDATION
+   use mqc_diis, only: diis_state_t
+   use mqc_libcint_integrals, only: libcint_molecule_t, build_df_mo_block
+   use mqc_libcint_mp2, only: transform_block
+   use pic_logger, only: logger => global_logger
+   use mqc_convergence_report, only: convergence_header, convergence_footer
+   use mqc_program_limits, only: MAX_LINE_LENGTH
+   implicit none
+   private
+
+   public :: rcc_result_t
+   public :: run_libcint_rccsd
+   public :: rcc_eris_t              !! Exported so a test can build them directly
+   public :: build_rcc_eris_conventional
+   public :: rccsd_correlation_energy  !! Exported for the MP2 identity test
+
+   !> Columns of the compound (cd) index assembled per pass of the ladder.
+   !> Same role and same reasoning as LADDER_BATCH in the spin-orbital module:
+   !> the array held is n_vir^2 by this, so the memory stays O(n_vir^2).
+   integer, parameter :: LADDER_BATCH = 256
+
+   character(len=*), parameter :: STAGE_ITER = "RCCSD iterations"
+
+   type :: rcc_eris_t
+      !! Spatial MO integrals in chemists' notation, by block
+      !!
+      !! Exactly the five blocks with at least one occupied index, plus whichever
+      !! of `vvvv` and `b_vv` the ladder is to read. Those two are alternatives
+      !! and never both: `vvvv` is the conventional path's, `b_vv` the fitted
+      !! one's three-index tensor, and every routine below decides which it has
+      !! by which one is allocated.
+      real(dp), allocatable :: oooo(:, :, :, :)   !! (ij|kl)
+      real(dp), allocatable :: ooov(:, :, :, :)   !! (ij|ka)
+      real(dp), allocatable :: oovv(:, :, :, :)   !! (ij|ab)
+      real(dp), allocatable :: ovov(:, :, :, :)   !! (ia|jb)
+      real(dp), allocatable :: ovvv(:, :, :, :)   !! (ia|bc)
+      real(dp), allocatable :: vvvv(:, :, :, :)   !! (ab|cd), conventional only
+      real(dp), allocatable :: b_vv(:, :)         !! (ab, P), fitted only
+   end type rcc_eris_t
+
+   type :: rcc_result_t
+      !! What a converged spin-adapted coupled cluster calculation leaves behind
+      real(dp) :: e_singles = 0.0_dp
+      real(dp) :: e_doubles = 0.0_dp
+      real(dp) :: e_triples = 0.0_dp   !! (T); not implemented on this path yet
+      real(dp) :: e_mp2 = 0.0_dp
+         !! MP2 from these same spatial integrals -- the first iteration's
+         !! energy, so free, and the sharpest check available on the block
+         !! layout before any amplitude equation runs.
+      real(dp) :: e_correlation = 0.0_dp
+      integer :: iterations = 0
+      logical :: converged = .false.
+   end type rcc_result_t
+
+contains
+
+   pure function rcc_megabytes(no, nv, conventional) result(mb)
+      !! What the integral blocks cost, in MB
+      integer, intent(in) :: no, nv
+      logical, intent(in) :: conventional
+      real(dp) :: mb
+
+      real(dp) :: elements
+
+      elements = real(no, dp)**4 &                          ! oooo
+                 + real(no, dp)**3*real(nv, dp) &           ! ooov
+                 + 2.0_dp*real(no, dp)**2*real(nv, dp)**2 &  ! oovv, ovov
+                 + real(no, dp)*real(nv, dp)**3 &           ! ovvv
+                 + real(nv, dp)**2*real(LADDER_BATCH, dp)   ! the ladder batch
+      if (conventional) elements = elements + real(nv, dp)**4
+      mb = elements*8.0_dp/1.0e6_dp
+   end function rcc_megabytes
+
+   subroutine build_rcc_eris_conventional(mol, c_occ, c_vir, eris)
+      !! The five occupied-bearing blocks and (vv|vv), by direct transform
+      !!
+      !! Six calls to `transform_block` rather than one whole-active-space
+      !! transform and six slices of it. The total arithmetic is the same --
+      !! these blocks partition that tensor -- but the `n_act^4` array is never
+      !! allocated, and it is the term the conventional path's memory used to be
+      !! set by. `(vv|vv)` at `n_vir^4` is what remains, and it is smaller by
+      !! roughly `(n_act/n_vir)^4`.
+      type(libcint_molecule_t), intent(in) :: mol
+      real(dp), intent(in) :: c_occ(:, :), c_vir(:, :)
+      type(rcc_eris_t), intent(out) :: eris
+
+      real(dp), allocatable :: eri(:, :)
+
+      call mol%eris_packed(eri)
+      call transform_block(eri, c_occ, c_occ, c_occ, c_occ, eris%oooo)
+      call transform_block(eri, c_occ, c_occ, c_occ, c_vir, eris%ooov)
+      call transform_block(eri, c_occ, c_occ, c_vir, c_vir, eris%oovv)
+      call transform_block(eri, c_occ, c_vir, c_occ, c_vir, eris%ovov)
+      call transform_block(eri, c_occ, c_vir, c_vir, c_vir, eris%ovvv)
+      call transform_block(eri, c_vir, c_vir, c_vir, c_vir, eris%vvvv)
+      deallocate (eri)
+   end subroutine build_rcc_eris_conventional
+
+   subroutine build_rcc_eris_fitted(mol, aux, c_occ, c_vir, eris, error)
+      !! The same blocks from the three-index fitted tensor
+      !!
+      !! `b_vv` outlives this routine because the ladder builds `(ac|bd)` from it
+      !! a batch at a time; nothing of fourth order in the virtuals is ever
+      !! allocated on this path, which is the whole of what RI buys here.
+      type(libcint_molecule_t), intent(in) :: mol, aux
+      real(dp), intent(in) :: c_occ(:, :), c_vir(:, :)
+      type(rcc_eris_t), intent(out) :: eris
+      type(error_t), intent(inout) :: error
+
+      real(dp), allocatable :: b_oo(:, :), b_ov(:, :), b_vv_pq(:, :)
+      integer :: no, nv
+
+      no = size(c_occ, 2)
+      nv = size(c_vir, 2)
+
+      call build_df_mo_block(mol, aux, c_occ, c_occ, b_oo, error)
+      if (error%has_error()) return
+      call build_df_mo_block(mol, aux, c_occ, c_vir, b_ov, error)
+      if (error%has_error()) return
+      call build_df_mo_block(mol, aux, c_vir, c_vir, b_vv_pq, error)
+      if (error%has_error()) return
+
+      allocate (eris%oooo(no, no, no, no), eris%ooov(no, no, no, nv))
+      allocate (eris%oovv(no, no, nv, nv), eris%ovov(no, nv, no, nv))
+      allocate (eris%ovvv(no, nv, nv, nv))
+
+      call df_block_gemm(b_oo, b_oo, no*no, no*no, eris%oooo)
+      call df_block_gemm(b_oo, b_ov, no*no, no*nv, eris%ooov)
+      call df_block_gemm(b_oo, b_vv_pq, no*no, nv*nv, eris%oovv)
+      call df_block_gemm(b_ov, b_ov, no*nv, no*nv, eris%ovov)
+      call df_block_gemm(b_ov, b_vv_pq, no*nv, nv*nv, eris%ovvv)
+
+      deallocate (b_oo, b_ov)
+
+      ! Kept as (ab, P): the ladder slices it by compound virtual pair, which is
+      ! the leading dimension here and so contiguous.
+      call move_alloc(b_vv_pq, eris%b_vv)
+   end subroutine build_rcc_eris_fitted
+
+   subroutine df_block_gemm(bl, br, nl, nr, block)
+      !! (left|right) = sum_P B_left(left,P) B_right(right,P)
+      !!
+      !! Explicit-shape destination so sequence association lets the gemm write
+      !! straight into a rank-four array, exactly as the spin-orbital module's
+      !! namesake does and for the same reason: at `(ov|vv)` the reshaping
+      !! temporary would be the peak allocation.
+      real(dp), intent(in) :: bl(:, :), br(:, :)
+      integer, intent(in) :: nl, nr
+      real(dp), intent(out) :: block(nl, nr)
+
+      call pic_gemm(bl, br, block, transb="T")
+   end subroutine df_block_gemm
+
+   !===========================================================================
+   ! Intermediates -- Hirata Eqs. (37)-(45), as rintermediates.py writes them
+   !
+   ! Every routine quotes the einsum it implements. Two index identities are
+   ! used throughout to avoid storing blocks that are transposes of ones we
+   ! already have, and both need real orbitals:
+   !
+   !     eris.ovvo(k,c,a,i) = (kc|ai) = (kc|ia) = ovov(k,c,i,a)
+   !     eris.ovoo(i,a,j,k) = (ia|jk) = (jk|ia) = ooov(j,k,i,a)
+   !===========================================================================
+
+   subroutine build_tau(t1, t2, no, nv, tau)
+      !! tau(i,j,a,b) = t2(i,j,a,b) + t1(i,a) t1(j,b)
+      real(dp), intent(in) :: t1(:, :), t2(:, :, :, :)
+      integer, intent(in) :: no, nv
+      real(dp), intent(out) :: tau(:, :, :, :)
+
+      integer :: i, j, a, b
+
+      do b = 1, nv
+         do a = 1, nv
+            do j = 1, no
+               do i = 1, no
+                  tau(i, j, a, b) = t2(i, j, a, b) + t1(i, a)*t1(j, b)
+               end do
+            end do
+         end do
+      end do
+   end subroutine build_tau
+
+   pure function lvec(ovov, k, c, l, d) result(v)
+      !! The recurring 2(kc|ld) - (kd|lc) combination
+      !!
+      !! It appears in Foo, Fvv, Fov and the energy, and writing it once is what
+      !! keeps the "2 minus exchange" spin-adaptation factor from being typed
+      !! four times with four chances to swap c and d.
+      real(dp), intent(in) :: ovov(:, :, :, :)
+      integer, intent(in) :: k, c, l, d
+      real(dp) :: v
+
+      v = 2.0_dp*ovov(k, c, l, d) - ovov(k, d, l, c)
+   end function lvec
+
+   subroutine cc_foo(eris, t1, tau, no, nv, fki)
+      !! Fki = sum_lcd [2(kc|ld) - (kd|lc)] tau(i,l,c,d)
+      !!
+      !! rintermediates.cc_Foo, with its four terms folded into tau: the two t2
+      !! ones and the two t1 t1 ones differ only by which of t2 and t1 t1 they
+      !! carry, which is the definition of tau.
+      !!
+      !! The bare `foo` the reference adds here is absent: for canonical
+      !! orbitals it is diagonal and `update_amps` subtracts that same diagonal
+      !! back out immediately afterwards.
+      type(rcc_eris_t), intent(in) :: eris
+      real(dp), intent(in) :: t1(:, :), tau(:, :, :, :)
+      integer, intent(in) :: no, nv
+      real(dp), intent(out) :: fki(:, :)
+
+      integer :: k, i, l, c, d
+
+      fki = 0.0_dp
+      do i = 1, no
+         do d = 1, nv
+            do c = 1, nv
+               do l = 1, no
+                  do k = 1, no
+                     fki(k, i) = fki(k, i) + lvec(eris%ovov, k, c, l, d)*tau(i, l, c, d)
+                  end do
+               end do
+            end do
+         end do
+      end do
+   end subroutine cc_foo
+
+   subroutine cc_fvv(eris, t1, tau, no, nv, fac)
+      !! Fac = -sum_kld [2(kc|ld) - (kd|lc)] tau(k,l,a,d)
+      type(rcc_eris_t), intent(in) :: eris
+      real(dp), intent(in) :: t1(:, :), tau(:, :, :, :)
+      integer, intent(in) :: no, nv
+      real(dp), intent(out) :: fac(:, :)
+
+      integer :: a, c, k, l, d
+
+      fac = 0.0_dp
+      do d = 1, nv
+         do l = 1, no
+            do k = 1, no
+               do c = 1, nv
+                  do a = 1, nv
+                     fac(a, c) = fac(a, c) - lvec(eris%ovov, k, c, l, d)*tau(k, l, a, d)
+                  end do
+               end do
+            end do
+         end do
+      end do
+   end subroutine cc_fvv
+
+   subroutine cc_fov(eris, t1, no, nv, fkc)
+      !! Fkc = sum_ld [2(kc|ld) - (kd|lc)] t1(l,d)
+      type(rcc_eris_t), intent(in) :: eris
+      real(dp), intent(in) :: t1(:, :)
+      integer, intent(in) :: no, nv
+      real(dp), intent(out) :: fkc(:, :)
+
+      integer :: k, c, l, d
+
+      fkc = 0.0_dp
+      do d = 1, nv
+         do l = 1, no
+            do c = 1, nv
+               do k = 1, no
+                  fkc(k, c) = fkc(k, c) + lvec(eris%ovov, k, c, l, d)*t1(l, d)
+               end do
+            end do
+         end do
+      end do
+   end subroutine cc_fov
+
+   subroutine cc_loo(eris, fki, t1, no, nv, lki)
+      !! Lki = Fki + sum_lc [2 ooov(k,i,l,c) - ooov(l,i,k,c)] t1(l,c)
+      !!
+      !! rintermediates.Loo. Its `2 einsum('lcki,lc->ki', ovoo, t1)` reads
+      !! `(lc|ki) = ooov(k,i,l,c)`, and its exchange partner `(kc|li) =
+      !! ooov(l,i,k,c)`.
+      type(rcc_eris_t), intent(in) :: eris
+      real(dp), intent(in) :: fki(:, :), t1(:, :)
+      integer, intent(in) :: no, nv
+      real(dp), intent(out) :: lki(:, :)
+
+      integer :: k, i, l, c
+
+      lki = fki
+      do c = 1, nv
+         do l = 1, no
+            do i = 1, no
+               do k = 1, no
+                  lki(k, i) = lki(k, i) &
+                              + (2.0_dp*eris%ooov(k, i, l, c) - eris%ooov(l, i, k, c))*t1(l, c)
+               end do
+            end do
+         end do
+      end do
+   end subroutine cc_loo
+
+   subroutine cc_lvv(eris, fac, t1, no, nv, lac)
+      !! Lac = Fac + sum_kd [2 ovvv(k,d,a,c) - ovvv(k,c,a,d)] t1(k,d)
+      type(rcc_eris_t), intent(in) :: eris
+      real(dp), intent(in) :: fac(:, :), t1(:, :)
+      integer, intent(in) :: no, nv
+      real(dp), intent(out) :: lac(:, :)
+
+      integer :: a, c, k, d
+
+      lac = fac
+      do d = 1, nv
+         do k = 1, no
+            do c = 1, nv
+               do a = 1, nv
+                  lac(a, c) = lac(a, c) &
+                              + (2.0_dp*eris%ovvv(k, d, a, c) - eris%ovvv(k, c, a, d))*t1(k, d)
+               end do
+            end do
+         end do
+      end do
+   end subroutine cc_lvv
+
+   subroutine cc_woooo(eris, t1, tau, no, nv, w)
+      !! W(k,l,i,j) = (ki|lj) + sum_c ooov(k,i,l,c) t1(j,c) + sum_c ooov(l,j,k,c) t1(i,c)
+      !!                      + sum_cd (kc|ld) tau(i,j,c,d)
+      type(rcc_eris_t), intent(in) :: eris
+      real(dp), intent(in) :: t1(:, :), tau(:, :, :, :)
+      integer, intent(in) :: no, nv
+      real(dp), intent(out) :: w(:, :, :, :)
+
+      integer :: k, l, i, j, c, d
+
+      do j = 1, no
+         do i = 1, no
+            do l = 1, no
+               do k = 1, no
+                  w(k, l, i, j) = eris%oooo(k, i, l, j)
+               end do
+            end do
+         end do
+      end do
+
+      do c = 1, nv
+         do j = 1, no
+            do i = 1, no
+               do l = 1, no
+                  do k = 1, no
+                     w(k, l, i, j) = w(k, l, i, j) &
+                                     + eris%ooov(k, i, l, c)*t1(j, c) &
+                                     + eris%ooov(l, j, k, c)*t1(i, c)
+                  end do
+               end do
+            end do
+         end do
+      end do
+
+      do d = 1, nv
+         do c = 1, nv
+            do j = 1, no
+               do i = 1, no
+                  do l = 1, no
+                     do k = 1, no
+                        w(k, l, i, j) = w(k, l, i, j) + eris%ovov(k, c, l, d)*tau(i, j, c, d)
+                     end do
+                  end do
+               end do
+            end do
+         end do
+      end do
+   end subroutine cc_woooo
+
+   subroutine cc_wvoov(eris, t1, t2, no, nv, w)
+      !! W(a,k,i,c), rintermediates.cc_Wvoov
+      !!
+      !!   + sum_d ovvv(k,c,a,d) t1(i,d)
+      !!   - sum_l ooov(l,i,k,c) t1(l,a)
+      !!   + ovov(k,c,i,a)
+      !!   - 1/2 sum_ld ovov(l,d,k,c) t2(i,l,d,a)
+      !!   - 1/2 sum_ld ovov(l,c,k,d) t2(i,l,a,d)
+      !!   -     sum_ld ovov(l,d,k,c) t1(i,d) t1(l,a)
+      !!   +     sum_ld ovov(l,d,k,c) t2(i,l,a,d)
+      type(rcc_eris_t), intent(in) :: eris
+      real(dp), intent(in) :: t1(:, :), t2(:, :, :, :)
+      integer, intent(in) :: no, nv
+      real(dp), intent(out) :: w(:, :, :, :)
+
+      integer :: a, k, i, c, d, l
+
+      do c = 1, nv
+         do i = 1, no
+            do k = 1, no
+               do a = 1, nv
+                  w(a, k, i, c) = eris%ovov(k, c, i, a)
+               end do
+            end do
+         end do
+      end do
+
+      do d = 1, nv
+         do c = 1, nv
+            do i = 1, no
+               do k = 1, no
+                  do a = 1, nv
+                     w(a, k, i, c) = w(a, k, i, c) + eris%ovvv(k, c, a, d)*t1(i, d)
+                  end do
+               end do
+            end do
+         end do
+      end do
+
+      do l = 1, no
+         do c = 1, nv
+            do i = 1, no
+               do k = 1, no
+                  do a = 1, nv
+                     w(a, k, i, c) = w(a, k, i, c) - eris%ooov(l, i, k, c)*t1(l, a)
+                  end do
+               end do
+            end do
+         end do
+      end do
+
+      do d = 1, nv
+         do l = 1, no
+            do c = 1, nv
+               do i = 1, no
+                  do k = 1, no
+                     do a = 1, nv
+                        w(a, k, i, c) = w(a, k, i, c) &
+                                        - 0.5_dp*eris%ovov(l, d, k, c)*t2(i, l, d, a) &
+                                        - 0.5_dp*eris%ovov(l, c, k, d)*t2(i, l, a, d) &
+                                        - eris%ovov(l, d, k, c)*t1(i, d)*t1(l, a) &
+                                        + eris%ovov(l, d, k, c)*t2(i, l, a, d)
+                     end do
+                  end do
+               end do
+            end do
+         end do
+      end do
+   end subroutine cc_wvoov
+
+   subroutine cc_wvovo(eris, t1, t2, no, nv, w)
+      !! W(a,k,c,i), rintermediates.cc_Wvovo
+      !!
+      !!   + sum_d ovvv(k,d,a,c) t1(i,d)
+      !!   - sum_l ooov(k,i,l,c) t1(l,a)
+      !!   + oovv(k,i,a,c)
+      !!   - 1/2 sum_ld ovov(l,c,k,d) t2(i,l,d,a)
+      !!   -     sum_ld ovov(l,c,k,d) t1(i,d) t1(l,a)
+      type(rcc_eris_t), intent(in) :: eris
+      real(dp), intent(in) :: t1(:, :), t2(:, :, :, :)
+      integer, intent(in) :: no, nv
+      real(dp), intent(out) :: w(:, :, :, :)
+
+      integer :: a, k, c, i, d, l
+
+      do i = 1, no
+         do c = 1, nv
+            do k = 1, no
+               do a = 1, nv
+                  w(a, k, c, i) = eris%oovv(k, i, a, c)
+               end do
+            end do
+         end do
+      end do
+
+      do d = 1, nv
+         do i = 1, no
+            do c = 1, nv
+               do k = 1, no
+                  do a = 1, nv
+                     w(a, k, c, i) = w(a, k, c, i) + eris%ovvv(k, d, a, c)*t1(i, d)
+                  end do
+               end do
+            end do
+         end do
+      end do
+
+      do l = 1, no
+         do i = 1, no
+            do c = 1, nv
+               do k = 1, no
+                  do a = 1, nv
+                     w(a, k, c, i) = w(a, k, c, i) - eris%ooov(k, i, l, c)*t1(l, a)
+                  end do
+               end do
+            end do
+         end do
+      end do
+
+      do d = 1, nv
+         do l = 1, no
+            do i = 1, no
+               do c = 1, nv
+                  do k = 1, no
+                     do a = 1, nv
+                        w(a, k, c, i) = w(a, k, c, i) &
+                                        - 0.5_dp*eris%ovov(l, c, k, d)*t2(i, l, d, a) &
+                                        - eris%ovov(l, c, k, d)*t1(i, d)*t1(l, a)
+                     end do
+                  end do
+               end do
+            end do
+         end do
+      end do
+   end subroutine cc_wvovo
+
+   !===========================================================================
+   ! Energy and amplitudes -- Hirata Eqs. (35)-(36), as rccsd.py writes them
+   !===========================================================================
+
+   subroutine rccsd_correlation_energy(eris, t1, t2, no, nv, e_singles, e_doubles)
+      !! E = sum_ijab [2(ia|jb) - (ib|ja)] (t2(i,j,a,b) + t1(i,a) t1(j,b))
+      !!
+      !! Split at the tau that produced it rather than by diagram: the doubles
+      !! part is what t2 alone gives and the singles part what the t1 t1 product
+      !! adds, which is the decomposition the spin-orbital module reports and so
+      !! the one the two can be compared term by term with. The bare `2 f_ov t1`
+      !! term of the reference is zero for canonical orbitals.
+      type(rcc_eris_t), intent(in) :: eris
+      real(dp), intent(in) :: t1(:, :), t2(:, :, :, :)
+      integer, intent(in) :: no, nv
+      real(dp), intent(out) :: e_singles, e_doubles
+
+      integer :: i, j, a, b
+      real(dp) :: l
+
+      e_singles = 0.0_dp
+      e_doubles = 0.0_dp
+      do b = 1, nv
+         do a = 1, nv
+            do j = 1, no
+               do i = 1, no
+                  l = 2.0_dp*eris%ovov(i, a, j, b) - eris%ovov(i, b, j, a)
+                  e_doubles = e_doubles + l*t2(i, j, a, b)
+                  e_singles = e_singles + l*t1(i, a)*t1(j, b)
+               end do
+            end do
+         end do
+      end do
+   end subroutine rccsd_correlation_energy
+
+   subroutine mp2_guess(eris, eps_o, eps_v, no, nv, t2, e_mp2)
+      !! First-order doubles and the MP2 energy they give
+      !!
+      !!     t2(i,j,a,b) = (ia|jb) / (e_i + e_j - e_a - e_b)
+      !!
+      !! The checkpoint before any amplitude equation runs: this must reproduce
+      !! `run_libcint_mp2` exactly, and if it does then the block layout, the
+      !! denominators and the frozen-core offset are all right.
+      type(rcc_eris_t), intent(in) :: eris
+      real(dp), intent(in) :: eps_o(:), eps_v(:)
+      integer, intent(in) :: no, nv
+      real(dp), intent(out) :: t2(:, :, :, :)
+      real(dp), intent(out) :: e_mp2
+
+      integer :: i, j, a, b
+      real(dp) :: d, dummy
+
+      do b = 1, nv
+         do a = 1, nv
+            do j = 1, no
+               do i = 1, no
+                  d = eps_o(i) + eps_o(j) - eps_v(a) - eps_v(b)
+                  t2(i, j, a, b) = eris%ovov(i, a, j, b)/d
+               end do
+            end do
+         end do
+      end do
+
+      block
+         real(dp), allocatable :: t1zero(:, :)
+         allocate (t1zero(no, nv))
+         t1zero = 0.0_dp
+         call rccsd_correlation_energy(eris, t1zero, t2, no, nv, dummy, e_mp2)
+      end block
+   end subroutine mp2_guess
+
+   subroutine add_symmetrised(t2new, tmp, no, nv, factor)
+      !! t2new(i,j,a,b) += factor * [tmp(i,j,a,b) + tmp(j,i,b,a)]
+      !!
+      !! The `tmp + tmp.transpose(1,0,3,2)` that appears eight times in the
+      !! reference's T2 equation. Written once: the permutation is the same
+      !! every time and typing it eight times is eight chances to swap one pair
+      !! and not the other, which is a symmetric-looking error that still
+      !! converges.
+      real(dp), intent(inout) :: t2new(:, :, :, :)
+      real(dp), intent(in) :: tmp(:, :, :, :)
+      integer, intent(in) :: no, nv
+      real(dp), intent(in) :: factor
+
+      integer :: i, j, a, b
+
+      do b = 1, nv
+         do a = 1, nv
+            do j = 1, no
+               do i = 1, no
+                  t2new(i, j, a, b) = t2new(i, j, a, b) &
+                                      + factor*(tmp(i, j, a, b) + tmp(j, i, b, a))
+               end do
+            end do
+         end do
+      end do
+   end subroutine add_symmetrised
+
+   subroutine rccsd_iteration(eris, eps_o, eps_v, no, nv, t1, t2, t1n, t2n)
+      !! One amplitude update: Hirata Eqs. (35) and (36)
+      !!
+      !! Correctness before speed, deliberately. The contractions below are
+      !! written as loops that read as the einsum strings quoted above them,
+      !! except the particle-particle ladder, which is a gemm because it is both
+      !! the asymptotically dominant term and the one whose memory this module
+      !! exists to fix. Turning the O(n_o^3 n_v^3) ring terms into gemms is the
+      !! obvious next step and is deliberately a separate change: it is a
+      !! rearrangement of arithmetic that must not move a digit, and that is
+      !! only checkable against a version already known to be right.
+      type(rcc_eris_t), intent(in) :: eris
+      real(dp), intent(in) :: eps_o(:), eps_v(:)
+      integer, intent(in) :: no, nv
+      real(dp), intent(in) :: t1(:, :), t2(:, :, :, :)
+      real(dp), intent(out) :: t1n(:, :), t2n(:, :, :, :)
+
+      real(dp), allocatable :: tau(:, :, :, :), tmp(:, :, :, :)
+      real(dp), allocatable :: fki(:, :), fac(:, :), fkc(:, :), lki(:, :), lac(:, :)
+      real(dp), allocatable :: woooo(:, :, :, :), wvoov(:, :, :, :), wvovo(:, :, :, :)
+      real(dp), allocatable :: tmp2(:, :, :, :), tmp2b(:, :, :, :)
+      integer :: i, j, k, l, a, b, c, d
+      real(dp) :: acc, den
+
+      allocate (tau(no, no, nv, nv))
+      call build_tau(t1, t2, no, nv, tau)
+
+      allocate (fki(no, no), fac(nv, nv), fkc(no, nv), lki(no, no), lac(nv, nv))
+      call cc_foo(eris, t1, tau, no, nv, fki)
+      call cc_fvv(eris, t1, tau, no, nv, fac)
+      call cc_fov(eris, t1, no, nv, fkc)
+      call cc_loo(eris, fki, t1, no, nv, lki)
+      call cc_lvv(eris, fac, t1, no, nv, lac)
+
+      ! ---- T1, Eq. (35) ----------------------------------------------------
+      t1n = 0.0_dp
+
+      ! 'ac,ic->ia' and '-ki,ka->ia'
+      do c = 1, nv
+         do a = 1, nv
+            do i = 1, no
+               t1n(i, a) = t1n(i, a) + fac(a, c)*t1(i, c)
+            end do
+         end do
+      end do
+      do k = 1, no
+         do i = 1, no
+            do a = 1, nv
+               t1n(i, a) = t1n(i, a) - fki(k, i)*t1(k, a)
+            end do
+         end do
+      end do
+
+      ! '2 kc,kica->ia', '-kc,ikca->ia', 'kc,ic,ka->ia'
+      do c = 1, nv
+         do k = 1, no
+            do a = 1, nv
+               do i = 1, no
+                  t1n(i, a) = t1n(i, a) + fkc(k, c)*(2.0_dp*t2(k, i, c, a) - t2(i, k, c, a)) &
+                              + fkc(k, c)*t1(i, c)*t1(k, a)
+               end do
+            end do
+         end do
+      end do
+
+      ! '2 kcai,kc->ia' with (kc|ai) = ovov(k,c,i,a); '-kiac,kc->ia'
+      do c = 1, nv
+         do k = 1, no
+            do a = 1, nv
+               do i = 1, no
+                  t1n(i, a) = t1n(i, a) &
+                              + (2.0_dp*eris%ovov(k, c, i, a) - eris%oovv(k, i, a, c))*t1(k, c)
+               end do
+            end do
+         end do
+      end do
+
+      ! '2 kdac,ikcd->ia' - 'kcad,ikcd->ia', and the same pair with t2 -> t1 t1
+      do d = 1, nv
+         do c = 1, nv
+            do k = 1, no
+               do a = 1, nv
+                  do i = 1, no
+                     t1n(i, a) = t1n(i, a) &
+                                 + 2.0_dp*eris%ovvv(k, d, a, c)*(t2(i, k, c, d) + t1(k, d)*t1(i, c)) &
+                                 - eris%ovvv(k, c, a, d)*(t2(i, k, c, d) + t1(k, d)*t1(i, c))
+                  end do
+               end do
+            end do
+         end do
+      end do
+
+      ! '-2 lcki,klac->ia' + 'kcli,klac->ia' with (lc|ki) = ooov(k,i,l,c),
+      ! (kc|li) = ooov(l,i,k,c); and the same pair with t2 -> t1 t1
+      do c = 1, nv
+         do l = 1, no
+            do k = 1, no
+               do a = 1, nv
+                  do i = 1, no
+                     t1n(i, a) = t1n(i, a) &
+                                 - 2.0_dp*eris%ooov(k, i, l, c)*(t2(k, l, a, c) + t1(l, c)*t1(k, a)) &
+                                 + eris%ooov(l, i, k, c)*(t2(k, l, a, c) + t1(l, c)*t1(k, a))
+                  end do
+               end do
+            end do
+         end do
+      end do
+
+      do a = 1, nv
+         do i = 1, no
+            t1n(i, a) = t1n(i, a)/(eps_o(i) - eps_v(a))
+         end do
+      end do
+
+      ! ---- T2, Eq. (36) ----------------------------------------------------
+      allocate (tmp(no, no, nv, nv))
+      t2n = 0.0_dp
+
+      ! t2new += ovov(i,a,j,b)   ['eris.ovov.transpose(0,2,1,3)']
+      do b = 1, nv
+         do a = 1, nv
+            do j = 1, no
+               do i = 1, no
+                  t2n(i, j, a, b) = eris%ovov(i, a, j, b)
+               end do
+            end do
+         end do
+      end do
+
+      ! tmp2(a,b,i,c) = ovvv(i,a,c,b) - sum_k oovv(k,i,b,c) t1(k,a)
+      ! tmp(i,j,a,b)  = sum_c tmp2(a,b,i,c) t1(j,c);  t2new += tmp + P(ij,ab) tmp
+      allocate (tmp2(nv, nv, no, nv))
+      do c = 1, nv
+         do i = 1, no
+            do b = 1, nv
+               do a = 1, nv
+                  acc = eris%ovvv(i, a, c, b)
+                  do k = 1, no
+                     acc = acc - eris%oovv(k, i, b, c)*t1(k, a)
+                  end do
+                  tmp2(a, b, i, c) = acc
+               end do
+            end do
+         end do
+      end do
+      tmp = 0.0_dp
+      do c = 1, nv
+         do b = 1, nv
+            do a = 1, nv
+               do j = 1, no
+                  do i = 1, no
+                     tmp(i, j, a, b) = tmp(i, j, a, b) + tmp2(a, b, i, c)*t1(j, c)
+                  end do
+               end do
+            end do
+         end do
+      end do
+      call add_symmetrised(t2n, tmp, no, nv, 1.0_dp)
+      deallocate (tmp2)
+
+      ! tmp2b(a,k,i,j) = sum_c ovov(k,c,i,a) t1(j,c) + ooov(j,k,i,a)
+      ! tmp(i,j,a,b)   = sum_k tmp2b(a,k,i,j) t1(k,b);  t2new -= tmp + P tmp
+      allocate (tmp2b(nv, no, no, no))
+      do j = 1, no
+         do i = 1, no
+            do k = 1, no
+               do a = 1, nv
+                  acc = eris%ooov(j, k, i, a)
+                  do c = 1, nv
+                     acc = acc + eris%ovov(k, c, i, a)*t1(j, c)
+                  end do
+                  tmp2b(a, k, i, j) = acc
+               end do
+            end do
+         end do
+      end do
+      tmp = 0.0_dp
+      do k = 1, no
+         do b = 1, nv
+            do a = 1, nv
+               do j = 1, no
+                  do i = 1, no
+                     tmp(i, j, a, b) = tmp(i, j, a, b) + tmp2b(a, k, i, j)*t1(k, b)
+                  end do
+               end do
+            end do
+         end do
+      end do
+      call add_symmetrised(t2n, tmp, no, nv, -1.0_dp)
+      deallocate (tmp2b)
+
+      ! 'klij,klab->ijab' with the four-occupied intermediate
+      allocate (woooo(no, no, no, no))
+      call cc_woooo(eris, t1, tau, no, nv, woooo)
+      do b = 1, nv
+         do a = 1, nv
+            do j = 1, no
+               do i = 1, no
+                  acc = 0.0_dp
+                  do l = 1, no
+                     do k = 1, no
+                        acc = acc + woooo(k, l, i, j)*tau(k, l, a, b)
+                     end do
+                  end do
+                  t2n(i, j, a, b) = t2n(i, j, a, b) + acc
+               end do
+            end do
+         end do
+      end do
+      deallocate (woooo)
+
+      ! 'abcd,ijcd->ijab' -- the particle-particle ladder, never held whole
+      call particle_ladder(eris, t1, tau, no, nv, t2n)
+
+      ! 'ac,ijcb->ijab' and '-ki,kjab->ijab', each symmetrised
+      tmp = 0.0_dp
+      do c = 1, nv
+         do b = 1, nv
+            do a = 1, nv
+               do j = 1, no
+                  do i = 1, no
+                     tmp(i, j, a, b) = tmp(i, j, a, b) + lac(a, c)*t2(i, j, c, b)
+                  end do
+               end do
+            end do
+         end do
+      end do
+      call add_symmetrised(t2n, tmp, no, nv, 1.0_dp)
+
+      tmp = 0.0_dp
+      do k = 1, no
+         do b = 1, nv
+            do a = 1, nv
+               do j = 1, no
+                  do i = 1, no
+                     tmp(i, j, a, b) = tmp(i, j, a, b) + lki(k, i)*t2(k, j, a, b)
+                  end do
+               end do
+            end do
+         end do
+      end do
+      call add_symmetrised(t2n, tmp, no, nv, -1.0_dp)
+
+      ! The three ring terms
+      allocate (wvoov(nv, no, no, nv), wvovo(nv, no, nv, no))
+      call cc_wvoov(eris, t1, t2, no, nv, wvoov)
+      call cc_wvovo(eris, t1, t2, no, nv, wvovo)
+
+      ! '2 akic,kjcb->ijab' - 'akci,kjcb->ijab'
+      tmp = 0.0_dp
+      do c = 1, nv
+         do k = 1, no
+            do b = 1, nv
+               do a = 1, nv
+                  do j = 1, no
+                     do i = 1, no
+                        tmp(i, j, a, b) = tmp(i, j, a, b) &
+                                          + (2.0_dp*wvoov(a, k, i, c) - wvovo(a, k, c, i)) &
+                                          *t2(k, j, c, b)
+                     end do
+                  end do
+               end do
+            end do
+         end do
+      end do
+      call add_symmetrised(t2n, tmp, no, nv, 1.0_dp)
+
+      ! '-akic,kjbc->ijab'
+      tmp = 0.0_dp
+      do c = 1, nv
+         do k = 1, no
+            do b = 1, nv
+               do a = 1, nv
+                  do j = 1, no
+                     do i = 1, no
+                        tmp(i, j, a, b) = tmp(i, j, a, b) + wvoov(a, k, i, c)*t2(k, j, b, c)
+                     end do
+                  end do
+               end do
+            end do
+         end do
+      end do
+      call add_symmetrised(t2n, tmp, no, nv, -1.0_dp)
+
+      ! '-bkci,kjac->ijab'
+      tmp = 0.0_dp
+      do c = 1, nv
+         do k = 1, no
+            do b = 1, nv
+               do a = 1, nv
+                  do j = 1, no
+                     do i = 1, no
+                        tmp(i, j, a, b) = tmp(i, j, a, b) + wvovo(b, k, c, i)*t2(k, j, a, c)
+                     end do
+                  end do
+               end do
+            end do
+         end do
+      end do
+      call add_symmetrised(t2n, tmp, no, nv, -1.0_dp)
+      deallocate (wvoov, wvovo)
+
+      do b = 1, nv
+         do a = 1, nv
+            do j = 1, no
+               do i = 1, no
+                  den = eps_o(i) + eps_o(j) - eps_v(a) - eps_v(b)
+                  t2n(i, j, a, b) = t2n(i, j, a, b)/den
+               end do
+            end do
+         end do
+      end do
+   end subroutine rccsd_iteration
+
+   subroutine particle_ladder(eris, t1, tau, no, nv, t2n)
+      !! t2new(i,j,a,b) += sum_cd Wvvvv(a,b,c,d) tau(i,j,c,d), never holding Wvvvv
+      !!
+      !!     Wvvvv(a,b,c,d) = (ac|bd) - sum_k ovvv(k,d,a,c) t1(k,b)
+      !!                              - sum_k ovvv(k,c,b,d) t1(k,a)
+      !!
+      !! `n_vir^4` is the largest thing coupled cluster asks for and it is read
+      !! exactly once, here, which is what makes batching it possible rather
+      !! than merely desirable: a block of `(cd)` columns is built, contracted
+      !! and dropped. Same argument, same structure and the same batch size as
+      !! `particle_ladder` in the spin-orbital module -- the difference is that
+      !! every index here is already spatial, so there is no spin map to hoist.
+      !!
+      !! **Where (ac|bd) comes from.** Exactly one of `vvvv` and `b_vv` is
+      !! allocated. `vvvv` is the conventional path's, read at permuted indices.
+      !! `b_vv` is the fitted three-index block laid out `(ab, P)`, and for a
+      !! fixed `(c,d)` the matrix `(ac|bd)` over `a` and `b` is one gemm over the
+      !! auxiliary index between two contiguous row ranges of it -- which is why
+      !! the fitted path never allocates anything of fourth order in the
+      !! virtuals at all.
+      type(rcc_eris_t), intent(in) :: eris
+      real(dp), intent(in) :: t1(:, :), tau(:, :, :, :)
+      integer, intent(in) :: no, nv
+      real(dp), intent(inout) :: t2n(:, :, :, :)
+
+      real(dp), allocatable :: wblk(:, :, :), gvv(:, :)
+      integer :: nv2, cd0, cd1, nb, col, cd, a, b, c, d, i, j, k, naux
+      logical :: fitted
+      real(dp) :: acc
+
+      nv2 = nv*nv
+      fitted = allocated(eris%b_vv)
+      if (fitted) naux = size(eris%b_vv, 2)
+
+      allocate (wblk(nv, nv, LADDER_BATCH))
+      if (fitted) allocate (gvv(nv, nv))
+
+      do cd0 = 1, nv2, LADDER_BATCH
+         cd1 = min(cd0 + LADDER_BATCH - 1, nv2)
+         nb = cd1 - cd0 + 1
+
+         do col = 1, nb
+            cd = cd0 + col - 1
+            c = mod(cd - 1, nv) + 1
+            d = (cd - 1)/nv + 1
+
+            if (fitted) then
+               ! (ac|bd) over a and b: rows (c-1)nv+1 .. c nv of b_vv against
+               ! rows (d-1)nv+1 .. d nv, contracted over the auxiliary index.
+               call pic_gemm(eris%b_vv((c - 1)*nv + 1:c*nv, 1:naux), &
+                             eris%b_vv((d - 1)*nv + 1:d*nv, 1:naux), gvv, transb="T")
+               do b = 1, nv
+                  do a = 1, nv
+                     wblk(a, b, col) = gvv(a, b)
+                  end do
+               end do
+            else
+               do b = 1, nv
+                  do a = 1, nv
+                     wblk(a, b, col) = eris%vvvv(a, c, b, d)
+                  end do
+               end do
+            end if
+
+            ! The t1 dressing. n_occ n_vir^4 an iteration, the same order as the
+            ! contraction it feeds.
+            do b = 1, nv
+               do a = 1, nv
+                  acc = 0.0_dp
+                  do k = 1, no
+                     acc = acc - eris%ovvv(k, d, a, c)*t1(k, b) &
+                           - eris%ovvv(k, c, b, d)*t1(k, a)
+                  end do
+                  wblk(a, b, col) = wblk(a, b, col) + acc
+               end do
+            end do
+         end do
+
+         do col = 1, nb
+            cd = cd0 + col - 1
+            c = mod(cd - 1, nv) + 1
+            d = (cd - 1)/nv + 1
+            do b = 1, nv
+               do a = 1, nv
+                  acc = wblk(a, b, col)
+                  if (acc == 0.0_dp) cycle
+                  do j = 1, no
+                     do i = 1, no
+                        t2n(i, j, a, b) = t2n(i, j, a, b) + acc*tau(i, j, c, d)
+                     end do
+                  end do
+               end do
+            end do
+         end do
+      end do
+
+      deallocate (wblk)
+      if (allocated(gvv)) deallocate (gvv)
+   end subroutine particle_ladder
+
+   !===========================================================================
+   ! Driver
+   !===========================================================================
+
+   subroutine run_libcint_rccsd(mol, coeff, orbital_energies, n_occ, frozen, &
+                                max_iter, energy_tol, want_triples, verbose, &
+                                result, error, diis_vectors, aux)
+      !! Drive spin-adapted CCSD to convergence
+      !!
+      !! Signature deliberately identical to `run_libcint_ccsd` so the bridge can
+      !! choose between them without knowing which it called, and so the two can
+      !! be run back to back on one set of orbitals -- which is what the identity
+      !! test does.
+      type(libcint_molecule_t), intent(in) :: mol
+      real(dp), intent(in) :: coeff(:, :)
+      real(dp), intent(in) :: orbital_energies(:)
+      integer, intent(in) :: n_occ                  !! Spatial occupied count
+      integer, intent(in) :: frozen
+      integer, intent(in) :: max_iter
+      real(dp), intent(in) :: energy_tol
+      logical, intent(in) :: want_triples
+      logical, intent(in) :: verbose
+      type(rcc_result_t), intent(out) :: result
+      type(error_t), intent(inout) :: error
+      integer, intent(in), optional :: diis_vectors
+      type(libcint_molecule_t), intent(in), optional :: aux
+
+      type(rcc_eris_t) :: eris
+      real(dp), allocatable :: c_act(:, :), eps_o(:), eps_v(:)
+      real(dp), allocatable :: t1(:, :), t2(:, :, :, :), t1n(:, :), t2n(:, :, :, :)
+      real(dp), allocatable :: flat(:), err_flat(:)
+      type(diis_state_t) :: diis
+      logical :: extrapolated
+      integer :: n_ao, n_mo, n_act, no, nv, iter, diis_size, i, a
+      real(dp) :: e_corr, e_old, de, t_iter
+      character(len=MAX_LINE_LENGTH) :: line
+      type(timing_report_t) :: clk
+
+      n_ao = size(coeff, 1)
+      n_mo = size(coeff, 2)
+
+      if (frozen < 0 .or. frozen >= n_occ) then
+         call error%set(ERROR_VALIDATION, "RCCSD: the frozen core count must leave at "// &
+                        "least one occupied orbital")
+         return
+      end if
+      n_act = n_mo - frozen
+      no = n_occ - frozen
+      nv = n_mo - n_occ
+      if (nv < 1) then
+         call error%set(ERROR_VALIDATION, "RCCSD: no virtual orbitals -- the basis is "// &
+                        "saturated by the occupied space and there is nothing to excite into")
+         return
+      end if
+
+      ! (T) is not on this path yet. Refused rather than silently returning zero:
+      ! a CCSD(T) deck that got CCSD and a zero triples term would report a
+      ! number that is wrong by exactly the thing that was asked for.
+      if (want_triples) then
+         call error%set(ERROR_VALIDATION, "RCCSD: the perturbative triples are not "// &
+                        "implemented in the spatial-orbital path yet. Run CCSD, or take "// &
+                        "CCSD(T) through the spin-orbital path.")
+         return
+      end if
+
+      diis_size = 8
+      if (present(diis_vectors)) diis_size = diis_vectors
+
+      if (verbose) then
+         write (line, "(a,i0,a,i0,a,i0,a)") "  spin-adapted coupled cluster: ", n_act, &
+            " spatial orbitals, ", no, " occupied, ", nv, " virtual"
+         call logger%info(trim(line))
+         if (frozen > 0) then
+            write (line, "(a,i0,a)") "  frozen core: ", frozen, " spatial orbitals"
+            call logger%info(trim(line))
+         end if
+         ! Against what the spin-orbital path would have taken for the same
+         ! system, because that difference is the entire reason this exists.
+         write (line, "(a,f0.1,a,f0.1,a)") "  integrals: ", &
+            rcc_megabytes(no, nv,.not. present(aux)), " MB in blocks, against ", &
+            rcc_megabytes(2*no, 2*nv,.not. present(aux)), " MB in spin orbitals"
+         call logger%info(trim(line))
+      end if
+
+      call clk%start()
+      allocate (c_act(n_ao, n_act))
+      c_act = coeff(:, frozen + 1:n_mo)
+      if (present(aux)) then
+         call build_rcc_eris_fitted(mol, aux, c_act(:, 1:no), c_act(:, no + 1:n_act), &
+                                    eris, error)
+         if (error%has_error()) return
+      else
+         call build_rcc_eris_conventional(mol, c_act(:, 1:no), c_act(:, no + 1:n_act), eris)
+      end if
+      deallocate (c_act)
+      call clk%lap("AO->MO integrals")
+
+      allocate (eps_o(no), eps_v(nv))
+      do i = 1, no
+         eps_o(i) = orbital_energies(frozen + i)
+      end do
+      do a = 1, nv
+         eps_v(a) = orbital_energies(n_occ + a)
+      end do
+
+      ! ---- MP2, the checkpoint before any amplitude equation ----------------
+      allocate (t1(no, nv), t2(no, no, nv, nv))
+      t1 = 0.0_dp
+      call mp2_guess(eris, eps_o, eps_v, no, nv, t2, result%e_mp2)
+      call clk%lap("MP2 amplitudes")
+      if (verbose) then
+         write (line, "(a,f20.12)") "  MP2 (spin adapted) = ", result%e_mp2
+         call logger%info(trim(line))
+      end if
+
+      ! ---- CCSD -------------------------------------------------------------
+      allocate (t1n(no, nv), t2n(no, no, nv, nv))
+      allocate (flat(no*nv + no*no*nv*nv), err_flat(no*nv + no*no*nv*nv))
+      call diis%init(diis_size, size(flat), size(err_flat))
+
+      e_old = 0.0_dp
+      result%converged = .false.
+      call convergence_header(verbose, "RCCSD iterations", &
+                              "    iter                 E_corr          dE   diis       time", 60)
+
+      do iter = 1, max_iter
+         t_iter = clk%seconds_of(STAGE_ITER)
+         call rccsd_iteration(eris, eps_o, eps_v, no, nv, t1, t2, t1n, t2n)
+         call clk%lap(STAGE_ITER)
+         t_iter = clk%seconds_of(STAGE_ITER) - t_iter
+
+         call pack_amplitudes(t1n, t2n, no, nv, flat)
+         call pack_step(t1n, t2n, t1, t2, no, nv, err_flat)
+         call diis%push(flat, err_flat)
+         call diis%extrapolate(flat, extrapolated)
+         if (extrapolated) call unpack_amplitudes(flat, no, nv, t1n, t2n)
+
+         t1 = t1n
+         t2 = t2n
+
+         call rccsd_correlation_energy(eris, t1, t2, no, nv, result%e_singles, result%e_doubles)
+         e_corr = result%e_singles + result%e_doubles
+         de = abs(e_corr - e_old)
+         if (verbose) then
+            write (line, "(i8,f23.12,es12.3,i7,f9.2,a)") &
+               iter, e_corr, de, diis%count(), t_iter, " s"
+            call logger%info(trim(line))
+         end if
+
+         e_old = e_corr
+         result%iterations = iter
+         if (iter > 1 .and. de < energy_tol) then
+            result%converged = .true.
+            exit
+         end if
+      end do
+      call diis%destroy()
+      call convergence_footer(verbose, result%converged, result%iterations, "iterations", 50)
+
+      result%e_correlation = result%e_singles + result%e_doubles + result%e_triples
+
+      if (.not. result%converged) then
+         call error%set(ERROR_VALIDATION, "RCCSD did not converge")
+         return
+      end if
+   end subroutine run_libcint_rccsd
+
+   pure function int_text(n) result(text)
+      !! An integer as a trimmed string, for message building
+      integer, intent(in) :: n
+      character(len=16) :: text
+
+      write (text, "(i0)") n
+   end function int_text
+
+   subroutine pack_amplitudes(t1, t2, no, nv, flat)
+      !! t1 then t2, one contiguous vector for DIIS
+      real(dp), intent(in) :: t1(:, :), t2(:, :, :, :)
+      integer, intent(in) :: no, nv
+      real(dp), intent(out) :: flat(:)
+
+      integer :: n1
+
+      n1 = no*nv
+      flat(1:n1) = reshape(t1, [n1])
+      flat(n1 + 1:) = reshape(t2, [no*no*nv*nv])
+   end subroutine pack_amplitudes
+
+   subroutine unpack_amplitudes(flat, no, nv, t1, t2)
+      !! The inverse of `pack_amplitudes`
+      real(dp), intent(in) :: flat(:)
+      integer, intent(in) :: no, nv
+      real(dp), intent(out) :: t1(:, :), t2(:, :, :, :)
+
+      integer :: n1
+
+      n1 = no*nv
+      t1 = reshape(flat(1:n1), [no, nv])
+      t2 = reshape(flat(n1 + 1:), [no, no, nv, nv])
+   end subroutine unpack_amplitudes
+
+   subroutine pack_step(t1n, t2n, t1, t2, no, nv, err_flat)
+      !! The step between two iterations, flattened
+      !!
+      !! DIIS extrapolates the amplitudes against the change in them: the step
+      !! vanishes exactly at convergence, so it is the right thing to drive to
+      !! zero. Same choice as the spin-orbital path.
+      real(dp), intent(in) :: t1n(:, :), t2n(:, :, :, :), t1(:, :), t2(:, :, :, :)
+      integer, intent(in) :: no, nv
+      real(dp), intent(out) :: err_flat(:)
+
+      integer :: n1
+
+      n1 = no*nv
+      err_flat(1:n1) = reshape(t1n - t1, [n1])
+      err_flat(n1 + 1:) = reshape(t2n - t2, [no*no*nv*nv])
+   end subroutine pack_step
+
+end module mqc_libcint_rcc

--- a/backends/libcint/mqc_libcint_rcc.f90
+++ b/backends/libcint/mqc_libcint_rcc.f90
@@ -76,6 +76,13 @@ module mqc_libcint_rcc
 
    character(len=*), parameter :: STAGE_ITER = "RCCSD iterations"
 
+   !> Orderings of a triple of labels. Three distinct virtual orbitals name the
+   !> same physical triple six ways, and the (T) energy expression sums over
+   !> every pairing of one such ordering with one ordering of the occupied
+   !> labels -- so this six is 3! and nothing else, and appears wherever either
+   !> set is enumerated.
+   integer, parameter :: N_TRIPLE_PERMS = 6
+
    type :: rcc_eris_t
       !! Spatial MO integrals in chemists' notation, by block
       !!
@@ -1124,16 +1131,6 @@ contains
          return
       end if
 
-      ! (T) is not on this path yet. Refused rather than silently returning zero:
-      ! a CCSD(T) deck that got CCSD and a zero triples term would report a
-      ! number that is wrong by exactly the thing that was asked for.
-      if (want_triples) then
-         call error%set(ERROR_VALIDATION, "RCCSD: the perturbative triples are not "// &
-                        "implemented in the spatial-orbital path yet. Run CCSD, or take "// &
-                        "CCSD(T) through the spin-orbital path.")
-         return
-      end if
-
       diis_size = 8
       if (present(diis_vectors)) diis_size = diis_vectors
 
@@ -1228,12 +1225,29 @@ contains
       call diis%destroy()
       call convergence_footer(verbose, result%converged, result%iterations, "iterations", 50)
 
-      result%e_correlation = result%e_singles + result%e_doubles + result%e_triples
-
       if (.not. result%converged) then
          call error%set(ERROR_VALIDATION, "RCCSD did not converge")
          return
       end if
+
+      ! (T) only on a converged reference: it is a correction evaluated once at
+      ! the fixed point, and taking it on amplitudes that are still moving would
+      ! give a number with no meaning rather than a slightly worse one.
+      if (want_triples) then
+         call triples_correction(eris, eps_o, eps_v, t1, t2, no, nv, result%e_triples)
+         call clk%lap("(T) correction")
+         if (verbose) then
+            write (line, "(a,f20.12)") "  (T)                = ", result%e_triples
+            call logger%info(trim(line))
+         end if
+      end if
+
+      result%e_correlation = result%e_singles + result%e_doubles + result%e_triples
+
+      ! Same breakdown the spin-orbital driver prints, and under the same stage
+      ! names, so the two can be laid side by side without translating.
+      call clk%finish()
+      call clk%report("RCCSD", verbose)
    end subroutine run_libcint_rccsd
 
    pure function int_text(n) result(text)
@@ -1286,5 +1300,220 @@ contains
       err_flat(1:n1) = reshape(t1n - t1, [n1])
       err_flat(n1 + 1:) = reshape(t2n - t2, [no*no*nv*nv])
    end subroutine pack_step
+
+   !===========================================================================
+   ! Perturbative triples
+   !
+   ! JCP 94, 442 (1991), as PySCF's cc/ccsd_t_slow.py writes it. The paper's
+   ! Eq. (1) has a known error in its restriction, which that file notes and
+   ! corrects to [ia] >= [jb] >= [kc]; the loop below follows the corrected
+   ! form rather than the printed one.
+   !
+   ! Three index identities let the reordered blocks that file builds be read
+   ! straight out of the ones already held, so no fourth transposed copy of
+   ! `ovvv` -- the largest block -- is ever allocated:
+   !
+   !     vvov(a,b,i,f) = ovvv(i,a,f,b)     (ia|fb)
+   !     vooo(a,i,j,m) = ooov(j,m,i,a)     (ia|jm)
+   !     vvoo(a,b,i,j) = ovov(i,a,j,b)     (ia|jb)
+   !
+   ! Memory is `n_occ^3` per intermediate and twelve of them are live at once,
+   ! which is kilobytes -- the triples are a time problem, not a space one, and
+   ! deliberately hold no `t3`.
+   !===========================================================================
+
+   pure subroutine permuted_triple(p, i, j, k, pi, pj, pk)
+      !! The six orderings of (i,j,k), in the same order as those of (a,b,c)
+      !!
+      !! Pairing the two is the whole trick of the energy expression: the
+      !! permutation applied to the virtual labels is mirrored in the occupied
+      !! ones, so one index into a table of six covers both.
+      integer, intent(in) :: p, i, j, k
+      integer, intent(out) :: pi, pj, pk
+
+      !> Which of (i,j,k) lands in each slot, for the six orderings in the
+      !> order they are named in the reference: ijk, ikj, jik, jki, kij, kji.
+      integer, parameter :: SLOT(3, N_TRIPLE_PERMS) = reshape([ &
+                                                              1, 2, 3, &
+                                                              1, 3, 2, &
+                                                              2, 1, 3, &
+                                                              2, 3, 1, &
+                                                              3, 1, 2, &
+                                                              3, 2, 1], [3, N_TRIPLE_PERMS])
+
+      integer :: t(3)
+
+      t = [i, j, k]
+      pi = t(SLOT(1, p))
+      pj = t(SLOT(2, p))
+      pk = t(SLOT(3, p))
+   end subroutine permuted_triple
+
+   subroutine triples_w(eris, t2, no, nv, a, b, c, w)
+      !! w(i,j,k) = sum_f (ia|fb) t2(k,j,c,f) - sum_m (ia|jm) t2(m,k,b,c)
+      type(rcc_eris_t), intent(in) :: eris
+      real(dp), intent(in) :: t2(:, :, :, :)
+      integer, intent(in) :: no, nv, a, b, c
+      real(dp), intent(out) :: w(:, :, :)
+
+      integer :: i, j, k, f, m
+      real(dp) :: acc
+
+      do k = 1, no
+         do j = 1, no
+            do i = 1, no
+               acc = 0.0_dp
+               do f = 1, nv
+                  acc = acc + eris%ovvv(i, a, f, b)*t2(k, j, c, f)
+               end do
+               do m = 1, no
+                  acc = acc - eris%ooov(j, m, i, a)*t2(m, k, b, c)
+               end do
+               w(i, j, k) = acc
+            end do
+         end do
+      end do
+   end subroutine triples_w
+
+   subroutine triples_v(eris, t1, no, a, b, c, v)
+      !! v(i,j,k) = (ia|jb) t1(k,c)
+      !!
+      !! The reference's second term, `t2(i,j,a,b) f_vo(c,k)`, is absent: the
+      !! occupied-virtual Fock block vanishes for canonical orbitals, which this
+      !! module assumes throughout.
+      type(rcc_eris_t), intent(in) :: eris
+      real(dp), intent(in) :: t1(:, :)
+      integer, intent(in) :: no, a, b, c
+      real(dp), intent(out) :: v(:, :, :)
+
+      integer :: i, j, k
+
+      do k = 1, no
+         do j = 1, no
+            do i = 1, no
+               v(i, j, k) = eris%ovov(i, a, j, b)*t1(k, c)
+            end do
+         end do
+      end do
+   end subroutine triples_v
+
+   subroutine triples_r3(x, d3, no, z)
+      !! z = [4x(i,j,k) + x(k,i,j) + x(j,k,i) - 2x(k,j,i) - 2x(i,k,j) - 2x(j,i,k)] / d3
+      real(dp), intent(in) :: x(:, :, :), d3(:, :, :)
+      integer, intent(in) :: no
+      real(dp), intent(out) :: z(:, :, :)
+
+      integer :: i, j, k
+
+      do k = 1, no
+         do j = 1, no
+            do i = 1, no
+               z(i, j, k) = (4.0_dp*x(i, j, k) + x(k, i, j) + x(j, k, i) &
+                             - 2.0_dp*x(k, j, i) - 2.0_dp*x(i, k, j) &
+                             - 2.0_dp*x(j, i, k))/d3(i, j, k)
+            end do
+         end do
+      end do
+   end subroutine triples_r3
+
+   subroutine triples_correction(eris, eps_o, eps_v, t1, t2, no, nv, e_triples)
+      !! The (T) correction, one virtual triple at a time
+      !!
+      !! The outer loop runs a >= b >= c and weights the denominator to recover
+      !! the terms it skipped -- six-fold when all three coincide, two-fold when
+      !! exactly two do. That is where the factor of six in the cost goes, and
+      !! it is worth having: the six W intermediates a triple needs are the same
+      !! six whichever order the virtuals are named in.
+      type(rcc_eris_t), intent(in) :: eris
+      real(dp), intent(in) :: eps_o(:), eps_v(:)
+      real(dp), intent(in) :: t1(:, :), t2(:, :, :, :)
+      integer, intent(in) :: no, nv
+      real(dp), intent(out) :: e_triples
+
+      !> Which W pairs with which occupied permutation, for each Z. Row is the
+      !> Z's virtual permutation, column the occupied one, entry the W's. This
+      !> is the S3 multiplication table and is written out rather than derived:
+      !> deriving it needs a convention for whether a permutation acts on
+      !> positions or on labels, and getting that backwards transposes half the
+      !> table into a still-symmetric, still-plausible, wrong answer.
+      integer, parameter :: WMAP(N_TRIPLE_PERMS, N_TRIPLE_PERMS) = reshape([ &
+                                                                           1, 2, 3, 4, 5, 6, &
+                                                                           2, 1, 5, 6, 3, 4, &
+                                                                           3, 4, 1, 2, 6, 5, &
+                                                                           4, 3, 6, 5, 1, 2, &
+                                                                           5, 6, 2, 1, 4, 3, &
+                                                                           6, 5, 4, 3, 2, 1], &
+                                                                           [N_TRIPLE_PERMS, N_TRIPLE_PERMS], order=[2, 1])
+
+      real(dp), allocatable :: w(:, :, :, :), z(:, :, :, :), x(:, :, :), d3(:, :, :)
+      integer :: a, b, c, i, j, k, p, q, pi, pj, pk
+      integer :: trip(3), perm(3, N_TRIPLE_PERMS)
+      real(dp) :: scale, acc
+
+      allocate (w(no, no, no, N_TRIPLE_PERMS), z(no, no, no, N_TRIPLE_PERMS))
+      allocate (x(no, no, no), d3(no, no, no))
+
+      e_triples = 0.0_dp
+
+      do a = 1, nv
+         do b = 1, a
+            do c = 1, b
+               ! The six orderings of this virtual triple, in the same order
+               ! `permuted_triple` gives the occupied ones.
+               perm(:, 1) = [a, b, c]
+               perm(:, 2) = [a, c, b]
+               perm(:, 3) = [b, a, c]
+               perm(:, 4) = [b, c, a]
+               perm(:, 5) = [c, a, b]
+               perm(:, 6) = [c, b, a]
+
+               scale = 1.0_dp
+               if (a == c) then
+                  scale = 6.0_dp          ! a == b == c
+               else if (a == b .or. b == c) then
+                  scale = 2.0_dp
+               end if
+
+               do k = 1, no
+                  do j = 1, no
+                     do i = 1, no
+                        d3(i, j, k) = scale*(eps_o(i) + eps_o(j) + eps_o(k) &
+                                             - eps_v(a) - eps_v(b) - eps_v(c))
+                     end do
+                  end do
+               end do
+
+               do p = 1, N_TRIPLE_PERMS
+                  trip = perm(:, p)
+                  call triples_w(eris, t2, no, nv, trip(1), trip(2), trip(3), w(:, :, :, p))
+                  call triples_v(eris, t1, no, trip(1), trip(2), trip(3), x)
+                  x = w(:, :, :, p) + 0.5_dp*x
+                  call triples_r3(x, d3, no, z(:, :, :, p))
+               end do
+
+               ! The thirty-six terms: every Z against every occupied
+               ! permutation of the W the table pairs it with.
+               do p = 1, N_TRIPLE_PERMS
+                  do q = 1, N_TRIPLE_PERMS
+                     acc = 0.0_dp
+                     do k = 1, no
+                        do j = 1, no
+                           do i = 1, no
+                              call permuted_triple(q, i, j, k, pi, pj, pk)
+                              acc = acc + w(pi, pj, pk, WMAP(p, q))*z(i, j, k, p)
+                           end do
+                        end do
+                     end do
+                     e_triples = e_triples + acc
+                  end do
+               end do
+            end do
+         end do
+      end do
+
+      e_triples = 2.0_dp*e_triples
+
+      deallocate (w, z, x, d3)
+   end subroutine triples_correction
 
 end module mqc_libcint_rcc

--- a/src/io/mqc_config_adapter.f90
+++ b/src/io/mqc_config_adapter.f90
@@ -255,6 +255,7 @@ contains
       driver_config%method_config%cc%amplitude_convergence = mqc_config%cc_tolerance
       driver_config%method_config%cc%use_diis = mqc_config%cc_diis
       driver_config%method_config%cc%diis_size = mqc_config%cc_diis_size
+      driver_config%method_config%cc%spin_adapted = mqc_config%cc_spin_adapted
       ! The method name settles the triples unless a deck said otherwise:
       ! "ccsd(t)" and "ccsd" are separate method types, so the distinction
       ! survives the parse and does not have to be recovered from the spelling

--- a/src/io/mqc_config_types.f90
+++ b/src/io/mqc_config_types.f90
@@ -166,6 +166,16 @@ module mqc_config_types
       logical :: cc_triples = .false.
       logical :: cc_diis = .true.
       integer :: cc_diis_size = 8
+      logical :: cc_spin_adapted = .true.
+         !! Which coupled-cluster formulation runs: spin-adapted (spatial
+         !! orbitals) when true, spin orbitals when false.
+         !!
+         !! Defaults to spin-adapted because for the closed-shell reference
+         !! that is the only one either formulation supports, it is strictly
+         !! better on both axes -- about sixteen times less memory and several
+         !! times faster. The spin-orbital path stays reachable, and is what the
+         !! two are cross-checked against: they must agree to machine precision,
+         !! so a deck can settle any doubt about a number by running it twice.
       ! keywords.mcscf -- the active space, for CASSCF and CASCI
       character(len=:), allocatable :: mcscf_avas_orbitals(:)
          !! Atomic orbital labels from `keywords.mcscf.avas.orbitals`, e.g.

--- a/src/io/mqc_json_config_reader.f90
+++ b/src/io/mqc_json_config_reader.f90
@@ -244,6 +244,7 @@ contains
       call optional_real(json, "keywords.cc.tolerance", config%cc_tolerance)
       call optional_logical(json, "keywords.cc.diis", config%cc_diis)
       call optional_int(json, "keywords.cc.diis_size", config%cc_diis_size)
+      call optional_logical(json, "keywords.cc.spin_adapted", config%cc_spin_adapted)
       ! Recorded as "was it named" as well as "what was it", because the method
       ! name is the usual source of this and only an explicit keyword may
       ! override it. `optional_logical` leaves its target alone when the key is

--- a/src/io/mqc_json_schema.f90
+++ b/src/io/mqc_json_schema.f90
@@ -347,6 +347,7 @@ contains
       call allow(keys, "triples")
       call allow(keys, "diis")
       call allow(keys, "diis_size")
+      call allow(keys, "spin_adapted")
    end function cc_keys
 
    function mcscf_keys() result(keys)

--- a/src/methods/mqc_cuest_iface.f90
+++ b/src/methods/mqc_cuest_iface.f90
@@ -59,6 +59,9 @@ module mqc_cuest_iface
       integer :: cc_max_iter = 100
       real(dp) :: cc_tolerance = 1.0e-8_dp
       integer :: cc_diis_size = 8
+      logical :: cc_spin_adapted = .true.
+         !! Run coupled cluster in spatial orbitals rather than spin orbitals.
+         !! CPU backend only; cuEST has no coupled cluster at all.
       ! Kohn-Sham grid. `grid_level` picks per-element radial and angular counts
       ! from the standard tables; radial_points/angular_points override it for
       ! every atom, which is what a convergence study wants.

--- a/src/methods/mqc_method_config.f90
+++ b/src/methods/mqc_method_config.f90
@@ -277,6 +277,9 @@ module mqc_method_config
          !! Use DIIS for amplitude equations
       integer :: diis_size = 8
          !! DIIS subspace size
+      logical :: spin_adapted = .true.
+         !! Spatial-orbital (spin-adapted) formulation rather than spin orbitals.
+         !! See mqc_config_types for why this is the default.
 
       ! EOM-CC for excited states
       integer :: n_roots = 0

--- a/src/methods/mqc_method_factory.F90
+++ b/src/methods/mqc_method_factory.F90
@@ -180,6 +180,7 @@ contains
       m%options%cc_tolerance = config%cc%amplitude_convergence
       ! Zero turns DIIS off, which is how the SCF spells the same thing.
       m%options%cc_diis_size = config%cc%diis_size
+      m%options%cc_spin_adapted = config%cc%spin_adapted
       if (.not. config%cc%use_diis) m%options%cc_diis_size = 0
       ! From config%corr, not config%scf: the reference and the correlation
       ! treatment are configured separately and may disagree.

--- a/src/methods/mqc_method_hf.F90
+++ b/src/methods/mqc_method_hf.F90
@@ -60,6 +60,8 @@ module mqc_method_hf
       integer :: cc_max_iter = 100
       real(dp) :: cc_tolerance = 1.0e-8_dp
       integer :: cc_diis_size = 8
+      logical :: cc_spin_adapted = .true.
+         !! Spatial-orbital coupled cluster rather than spin orbitals
          !! Fit J and K rather than computing exact integrals (CPU backend)
       logical :: spherical = .true.
          !! Use spherical (true) or Cartesian (false) basis
@@ -143,6 +145,7 @@ contains
       settings%cc_max_iter = this%options%cc_max_iter
       settings%cc_tolerance = this%options%cc_tolerance
       settings%cc_diis_size = this%options%cc_diis_size
+      settings%cc_spin_adapted = this%options%cc_spin_adapted
       settings%scs_ss = this%options%scs_ss
       settings%scs_os = this%options%scs_os
       settings%functional = ""        ! empty selects pure Hartree-Fock

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -175,6 +175,14 @@ if(MQC_ENABLE_LIBCINT)
   addtest(mqc_libcint_cc)
   target_link_libraries(test_mqc_libcint_cc PRIVATE cint_fortran cint)
 
+  # Spin-adapted coupled cluster, tied to the spin-orbital path above. For a
+  # closed shell the two are the same theory written twice and must agree to
+  # machine precision, which catches the transposed index that a reference
+  # energy alone would not -- see the module header for why that is the failure
+  # mode worth designing against.
+  addtest(mqc_libcint_rcc)
+  target_link_libraries(test_mqc_libcint_rcc PRIVATE cint_fortran cint)
+
   # Conventional MP2: the structural properties a reference energy cannot see,
   # chiefly that the four-index transform keeps (ia|jb) == (jb|ia).
   addtest(mqc_libcint_mp2)

--- a/test/test_mqc_json_reader.f90
+++ b/test/test_mqc_json_reader.f90
@@ -59,6 +59,7 @@ contains
                   new_unittest("error_missing_schema", test_missing_schema), &
                   new_unittest("error_missing_molecules", test_missing_molecules), &
                   new_unittest("cc_keywords", test_cc_keywords), &
+                  new_unittest("cc_spin_adapted_keyword", test_cc_spin_adapted), &
                   new_unittest("mcscf_keywords", test_mcscf_keywords), &
                   new_unittest("casci_spelling_fixes_the_orbitals", test_casci_spelling), &
                   new_unittest("backend_keyword", test_backend_keyword), &
@@ -785,6 +786,46 @@ contains
       if (allocated(error)) return
       call check(error, config%dft_angular_points, 590)
    end subroutine test_dft_keywords
+
+   subroutine test_cc_spin_adapted(error)
+      !! `keywords.cc.spin_adapted`, and that its default is on
+      !!
+      !! The default is the whole point of the case. Both formulations are exact
+      !! for the closed-shell reference coupled cluster supports and agree to
+      !! machine precision, so nothing in a deck's output would reveal which one
+      !! ran -- only the time and the memory would move. A default flipped by
+      !! accident is therefore a silent change of what every CCSD deck does.
+      type(error_type), allocatable, intent(out) :: error
+      type(mqc_config_t) :: config
+      type(error_t) :: parse_error
+
+      ! Absent: spin-adapted, which is the faster and smaller of the two.
+      call write_deck('"method": "ccsd", "basis": "sto-3g"', "Energy", "", "", two_atoms())
+      call read_deck(config, parse_error)
+      call check(error,.not. parse_error%has_error(), parse_error%get_message())
+      if (allocated(error)) return
+      call check(error, config%cc_spin_adapted, &
+                 "coupled cluster must default to the spin-adapted formulation")
+      if (allocated(error)) return
+
+      ! Named false: the spin-orbital path, which is what a doubtful number is
+      ! checked against.
+      call write_deck('"method": "ccsd", "basis": "sto-3g"', "Energy", &
+                      '"cc": {"spin_adapted": false}', "", two_atoms())
+      call read_deck(config, parse_error)
+      call check(error,.not. parse_error%has_error(), parse_error%get_message())
+      if (allocated(error)) return
+      call check(error,.not. config%cc_spin_adapted, &
+                 "keywords.cc.spin_adapted false was not read")
+      if (allocated(error)) return
+
+      ! And the allow-list is what let it through, not a validator that is off.
+      call write_deck('"method": "ccsd", "basis": "sto-3g"', "Energy", &
+                      '"cc": {"spin_adapated": false}', "", two_atoms())
+      call read_deck(config, parse_error)
+      call check(error, parse_error%has_error(), &
+                 "a misspelled cc key was accepted")
+   end subroutine test_cc_spin_adapted
 
    subroutine test_cc_keywords(error)
       !! keywords.cc, and that "triples" records whether it was named

--- a/test/test_mqc_libcint_rcc.f90
+++ b/test/test_mqc_libcint_rcc.f90
@@ -1,0 +1,319 @@
+module test_mqc_libcint_rcc
+   !! Ties the spatial-orbital coupled cluster to the spin-orbital one.
+   !!
+   !! For a closed shell the two formulations are the same theory written twice,
+   !! so they must agree to machine precision -- not to a tolerance, and not
+   !! merely to the accuracy of some external reference. That identity is the
+   !! whole reason `mqc_libcint_cc` was kept when this module was added, and it
+   !! is a far sharper instrument than a PySCF number: a reference energy checks
+   !! the total, while this checks the total, the singles/doubles split and the
+   !! MP2 starting point, against an implementation that shares none of this
+   !! one's index conventions.
+   !!
+   !! That last point is what makes it worth the runtime. The translation from
+   !! PySCF's row-major einsum strings to column-major Fortran is where a
+   !! spin-adapted implementation actually goes wrong, and a transposed index
+   !! does not produce garbage -- it produces a converged, plausible, wrong
+   !! number. The spin-orbital path indexes everything differently and cannot
+   !! share such a mistake.
+   use testdrive, only: new_unittest, unittest_type, error_type, check
+   use pic_types, only: dp
+   use mqc_error, only: error_t
+   use mqc_libcint_integrals, only: libcint_molecule_t, build_libcint_molecule
+   use mqc_libcint_rhf, only: rhf_result_t, run_libcint_rhf
+   use mqc_libcint_mp2, only: mp2_result_t, run_libcint_mp2
+   use mqc_libcint_cc, only: cc_result_t, run_libcint_ccsd
+   use mqc_libcint_rcc, only: rcc_result_t, run_libcint_rccsd
+   implicit none
+   private
+   public :: collect_mqc_libcint_rcc_tests
+
+   real(dp), parameter :: ANG = 1.8897261254578281_dp
+
+contains
+
+   subroutine collect_mqc_libcint_rcc_tests(testsuite)
+      type(unittest_type), allocatable, intent(out) :: testsuite(:)
+
+      testsuite = [ &
+                  new_unittest("spatial_mp2_equals_spin_orbital_mp2", test_mp2_identity), &
+                  new_unittest("spatial_ccsd_equals_spin_orbital_ccsd", test_ccsd_identity), &
+                  new_unittest("spatial_ccsd_matches_pyscf_cc_pvdz", test_pyscf_reference), &
+                  new_unittest("fitted_path_agrees_with_spin_orbital", test_fitted_identity), &
+                  new_unittest("frozen_core_agrees_between_formulations", test_frozen_identity), &
+                  new_unittest("triples_are_refused_not_silently_zero", test_triples_refused) &
+                  ]
+   end subroutine collect_mqc_libcint_rcc_tests
+
+   subroutine water(mol, err, basis)
+      type(libcint_molecule_t), intent(out) :: mol
+      type(error_t), intent(inout) :: err
+      character(len=*), intent(in) :: basis
+      real(dp) :: c(3, 3)
+
+      c = reshape([0.0_dp, 0.0_dp, 0.10077199490609_dp*ANG, &
+                   0.0_dp, 0.77250895271063_dp*ANG, -0.46780199741728_dp*ANG, &
+                   0.0_dp, -0.77250895280218_dp*ANG, -0.46780199748881_dp*ANG], [3, 3])
+      call build_libcint_molecule([8, 1, 1], ["O ", "H ", "H "], c, basis, mol, err)
+   end subroutine water
+
+   subroutine converged_water(mol, scf, err, basis)
+      type(libcint_molecule_t), intent(out) :: mol
+      type(rhf_result_t), intent(out) :: scf
+      type(error_t), intent(inout) :: err
+
+      character(len=*), intent(in) :: basis
+
+      call water(mol, err, basis)
+      if (err%has_error()) return
+      call run_libcint_rhf(mol, 10, 200, 1.0e-11_dp, 1.0e-9_dp, .false., scf, err, &
+                           in_core=.true.)
+   end subroutine converged_water
+
+   subroutine both_paths(basis, frozen, spin, spatial, ok)
+      !! Run the two formulations over one set of converged orbitals
+      !!
+      !! One SCF, not two: the amplitudes are being compared, so any difference
+      !! in the reference would show up as a difference in them and would be
+      !! indistinguishable from an error in the equations.
+      character(len=*), intent(in) :: basis
+      integer, intent(in) :: frozen
+      type(cc_result_t), intent(out) :: spin
+      type(rcc_result_t), intent(out) :: spatial
+      logical, intent(out) :: ok
+
+      type(libcint_molecule_t) :: mol
+      type(rhf_result_t) :: scf
+      type(error_t) :: err
+
+      ok = .false.
+      call converged_water(mol, scf, err, basis)
+      if (err%has_error() .or. .not. scf%converged) return
+
+      call run_libcint_ccsd(mol, scf%orbitals, scf%orbital_energies, 5, frozen, &
+                            60, 1.0e-10_dp, .false., .false., spin, err)
+      if (err%has_error()) then
+         call mol%destroy()
+         return
+      end if
+
+      call run_libcint_rccsd(mol, scf%orbitals, scf%orbital_energies, 5, frozen, &
+                             60, 1.0e-10_dp, .false., .false., spatial, err)
+      if (err%has_error()) then
+         call mol%destroy()
+         return
+      end if
+
+      call mol%destroy()
+      ok = spin%converged .and. spatial%converged
+   end subroutine both_paths
+
+   subroutine test_mp2_identity(error)
+      !! The MP2 starting points must agree exactly
+      !!
+      !! Checked before CCSD because it isolates the half of the work that can
+      !! fail on its own: the block layout, the chemists'-to-spatial index
+      !! mapping and the frozen-core offset. If this passes and CCSD does not,
+      !! the fault is in an amplitude equation and not in the integrals.
+      type(error_type), allocatable, intent(out) :: error
+      type(cc_result_t) :: spin
+      type(rcc_result_t) :: spatial
+      logical :: ok
+
+      call both_paths("sto-3g", 0, spin, spatial, ok)
+      call check(error, ok, "both coupled cluster paths must converge")
+      if (allocated(error)) return
+
+      call check(error, abs(spatial%e_mp2 - spin%e_mp2) < 1.0e-10_dp, &
+                 "spatial and spin-orbital MP2 must agree")
+   end subroutine test_mp2_identity
+
+   subroutine test_ccsd_identity(error)
+      !! The converged correlation energies must agree to machine precision
+      !!
+      !! And the singles and doubles parts separately. A total can agree while
+      !! the two halves are individually wrong in opposite directions -- which
+      !! is exactly what a misplaced t1 t1 product in tau does, since it moves
+      !! weight between them without changing the sum.
+      type(error_type), allocatable, intent(out) :: error
+      type(cc_result_t) :: spin
+      type(rcc_result_t) :: spatial
+      logical :: ok
+
+      call both_paths("sto-3g", 0, spin, spatial, ok)
+      call check(error, ok, "both coupled cluster paths must converge")
+      if (allocated(error)) return
+
+      call check(error, abs(spatial%e_correlation - spin%e_singles - spin%e_doubles) &
+                 < 1.0e-9_dp, "spatial and spin-orbital CCSD correlation must agree")
+      if (allocated(error)) return
+
+      call check(error, abs(spatial%e_doubles - spin%e_doubles) < 1.0e-9_dp, &
+                 "the doubles parts must agree, not just the total")
+      if (allocated(error)) return
+
+      call check(error, abs(spatial%e_singles - spin%e_singles) < 1.0e-9_dp, &
+                 "the singles parts must agree, not just the total")
+      if (allocated(error)) return
+
+      ! Sanity, in case both paths were wrong in the same direction: CCSD must
+      ! lie below MP2 for a closed-shell molecule at its minimum.
+      call check(error, spatial%e_correlation < spatial%e_mp2, &
+                 "CCSD correlation must lie below MP2")
+   end subroutine test_ccsd_identity
+
+   subroutine test_pyscf_reference(error)
+      !! cc-pVDZ against the PySCF number the spin-orbital path is validated on
+      !!
+      !! STO-3G has four virtual orbitals, which is few enough that several
+      !! terms are nearly degenerate and a wrong contraction can hide. cc-pVDZ
+      !! has nineteen and a d shell, so the particle-particle ladder does real
+      !! work and an angular-momentum error in the transform would show.
+      !!
+      !! The reference is `validation/check_cc.f90`'s, quoted rather than
+      !! recomputed: pyscf.cc.CCSD on this geometry, and the value the
+      !! spin-orbital path already reproduces to 1e-8. Two implementations
+      !! hitting one external number is a stronger statement than either hitting
+      !! it alone.
+      type(error_type), allocatable, intent(out) :: error
+      type(cc_result_t) :: spin
+      type(rcc_result_t) :: spatial
+      logical :: ok
+
+      real(dp), parameter :: E_CCSD_PYSCF = -0.213190638318_dp
+      real(dp), parameter :: E_MP2_PYSCF = -0.203838686392_dp
+
+      call both_paths("cc-pvdz", 0, spin, spatial, ok)
+      call check(error, ok, "both paths must converge in cc-pVDZ")
+      if (allocated(error)) return
+
+      call check(error, abs(spatial%e_mp2 - E_MP2_PYSCF) < 1.0e-7_dp, &
+                 "spatial MP2 must reproduce PySCF in cc-pVDZ")
+      if (allocated(error)) return
+
+      call check(error, abs(spatial%e_correlation - E_CCSD_PYSCF) < 1.0e-8_dp, &
+                 "spatial CCSD must reproduce PySCF in cc-pVDZ")
+      if (allocated(error)) return
+
+      ! And still equal to the spin-orbital path, which is the tighter of the
+      ! two statements -- an external reference is quoted to eight decimals and
+      ! these two share a machine.
+      call check(error, abs(spatial%e_correlation - spin%e_singles - spin%e_doubles) &
+                 < 1.0e-9_dp, "the two formulations must agree in cc-pVDZ too")
+   end subroutine test_pyscf_reference
+
+   subroutine test_fitted_identity(error)
+      !! The density-fitted spatial path against the fitted spin-orbital one
+      !!
+      !! Its own case because the fitted route reaches `(ac|bd)` a completely
+      !! different way -- a gemm over the auxiliary index inside the ladder,
+      !! against a permuted read of a stored tensor -- and that is the one part
+      !! of this module the conventional tests never exercise.
+      !!
+      !! Compared against the fitted spin-orbital path rather than against the
+      !! conventional spatial one: the fitting error is 1.4e-4, three orders
+      !! above the agreement being asserted, so conventional CCSD is not the
+      !! yardstick here and cannot be.
+      type(error_type), allocatable, intent(out) :: error
+      type(libcint_molecule_t) :: mol, aux
+      type(rhf_result_t) :: scf
+      type(error_t) :: err
+      type(cc_result_t) :: spin
+      type(rcc_result_t) :: spatial
+
+      call converged_water(mol, scf, err, "sto-3g")
+      call check(error,.not. err%has_error() .and. scf%converged, "water SCF must converge")
+      if (allocated(error)) return
+
+      call water(aux, err, "cc-pvdz-rifit")
+      call check(error,.not. err%has_error(), "the auxiliary basis must load")
+      if (allocated(error)) return
+
+      call run_libcint_ccsd(mol, scf%orbitals, scf%orbital_energies, 5, 0, &
+                            60, 1.0e-10_dp, .false., .false., spin, err, aux=aux)
+      call check(error,.not. err%has_error(), "fitted spin-orbital CCSD must converge")
+      if (allocated(error)) return
+
+      call run_libcint_rccsd(mol, scf%orbitals, scf%orbital_energies, 5, 0, &
+                             60, 1.0e-10_dp, .false., .false., spatial, err, aux=aux)
+      call check(error,.not. err%has_error(), "fitted spatial CCSD must converge")
+      if (allocated(error)) return
+
+      call check(error, abs(spatial%e_correlation - spin%e_singles - spin%e_doubles) &
+                 < 1.0e-9_dp, "the two fitted formulations must agree")
+
+      call mol%destroy()
+      call aux%destroy()
+   end subroutine test_fitted_identity
+
+   subroutine test_frozen_identity(error)
+      !! And they must still agree with a core orbital frozen
+      !!
+      !! Its own case because the frozen-core offset enters the two paths
+      !! differently -- one indexes orbital energies through a spin-to-spatial
+      !! map, the other slices the coefficient matrix -- so an off-by-one in
+      !! either is invisible until the counts differ from zero.
+      type(error_type), allocatable, intent(out) :: error
+      type(cc_result_t) :: spin
+      type(rcc_result_t) :: spatial
+      logical :: ok
+
+      call both_paths("sto-3g", 1, spin, spatial, ok)
+      call check(error, ok, "both paths must converge with a frozen core")
+      if (allocated(error)) return
+
+      call check(error, abs(spatial%e_mp2 - spin%e_mp2) < 1.0e-10_dp, &
+                 "frozen-core MP2 must agree between formulations")
+      if (allocated(error)) return
+
+      call check(error, abs(spatial%e_correlation - spin%e_singles - spin%e_doubles) &
+                 < 1.0e-9_dp, "frozen-core CCSD must agree between formulations")
+   end subroutine test_frozen_identity
+
+   subroutine test_triples_refused(error)
+      !! Asking for (T) on the spatial path fails rather than returning zero
+      !!
+      !! The triples are not implemented here yet. Returning a zero for them
+      !! would report a CCSD(T) energy that is wrong by exactly the term that
+      !! was asked for, and nothing downstream could tell -- `e_triples` is zero
+      !! for a genuine CCSD run too.
+      type(error_type), allocatable, intent(out) :: error
+      type(libcint_molecule_t) :: mol
+      type(rhf_result_t) :: scf
+      type(error_t) :: err
+      type(rcc_result_t) :: spatial
+
+      call converged_water(mol, scf, err, "sto-3g")
+      call check(error,.not. err%has_error() .and. scf%converged, "water SCF must converge")
+      if (allocated(error)) return
+
+      call run_libcint_rccsd(mol, scf%orbitals, scf%orbital_energies, 5, 0, &
+                             60, 1.0e-10_dp, .true., .false., spatial, err)
+      call check(error, err%has_error(), "(T) on the spatial path must be refused")
+      call mol%destroy()
+   end subroutine test_triples_refused
+
+end module test_mqc_libcint_rcc
+
+program tester
+   use, intrinsic :: iso_fortran_env, only: error_unit
+   use testdrive, only: run_testsuite, new_testsuite, testsuite_type
+   use test_mqc_libcint_rcc, only: collect_mqc_libcint_rcc_tests
+   implicit none
+   integer :: stat, is
+   type(testsuite_type), allocatable :: testsuites(:)
+   character(len=*), parameter :: fmt = '("#", *(1x, a))'
+
+   stat = 0
+   testsuites = [new_testsuite("mqc_libcint_rcc", collect_mqc_libcint_rcc_tests)]
+
+   do is = 1, size(testsuites)
+      write (error_unit, fmt) "Testing:", testsuites(is)%name
+      call run_testsuite(testsuites(is)%collect, error_unit, stat)
+   end do
+
+   if (stat > 0) then
+      write (error_unit, "(i0, 1x, a)") stat, "test(s) failed!"
+      error stop
+   end if
+end program tester

--- a/test/test_mqc_libcint_rcc.f90
+++ b/test/test_mqc_libcint_rcc.f90
@@ -41,7 +41,7 @@ contains
                   new_unittest("spatial_ccsd_matches_pyscf_cc_pvdz", test_pyscf_reference), &
                   new_unittest("fitted_path_agrees_with_spin_orbital", test_fitted_identity), &
                   new_unittest("frozen_core_agrees_between_formulations", test_frozen_identity), &
-                  new_unittest("triples_are_refused_not_silently_zero", test_triples_refused) &
+                  new_unittest("spatial_triples_equal_spin_orbital_triples", test_triples_identity) &
                   ]
    end subroutine collect_mqc_libcint_rcc_tests
 
@@ -70,7 +70,7 @@ contains
                            in_core=.true.)
    end subroutine converged_water
 
-   subroutine both_paths(basis, frozen, spin, spatial, ok)
+   subroutine both_paths(basis, frozen, spin, spatial, ok, triples)
       !! Run the two formulations over one set of converged orbitals
       !!
       !! One SCF, not two: the amplitudes are being compared, so any difference
@@ -81,24 +81,29 @@ contains
       type(cc_result_t), intent(out) :: spin
       type(rcc_result_t), intent(out) :: spatial
       logical, intent(out) :: ok
+      logical, intent(in), optional :: triples
 
       type(libcint_molecule_t) :: mol
       type(rhf_result_t) :: scf
       type(error_t) :: err
+      logical :: want_t
+
+      want_t = .false.
+      if (present(triples)) want_t = triples
 
       ok = .false.
       call converged_water(mol, scf, err, basis)
       if (err%has_error() .or. .not. scf%converged) return
 
       call run_libcint_ccsd(mol, scf%orbitals, scf%orbital_energies, 5, frozen, &
-                            60, 1.0e-10_dp, .false., .false., spin, err)
+                            60, 1.0e-10_dp, want_t, .false., spin, err)
       if (err%has_error()) then
          call mol%destroy()
          return
       end if
 
       call run_libcint_rccsd(mol, scf%orbitals, scf%orbital_energies, 5, frozen, &
-                             60, 1.0e-10_dp, .false., .false., spatial, err)
+                             60, 1.0e-10_dp, want_t, .false., spatial, err)
       if (err%has_error()) then
          call mol%destroy()
          return
@@ -258,6 +263,8 @@ contains
       type(rcc_result_t) :: spatial
       logical :: ok
 
+      real(dp), parameter :: E_T_PVDZ_F1 = -0.003015723855_dp   ! PySCF, check_cc.f90
+
       call both_paths("sto-3g", 1, spin, spatial, ok)
       call check(error, ok, "both paths must converge with a frozen core")
       if (allocated(error)) return
@@ -268,30 +275,72 @@ contains
 
       call check(error, abs(spatial%e_correlation - spin%e_singles - spin%e_doubles) &
                  < 1.0e-9_dp, "frozen-core CCSD must agree between formulations")
-   end subroutine test_frozen_identity
-
-   subroutine test_triples_refused(error)
-      !! Asking for (T) on the spatial path fails rather than returning zero
-      !!
-      !! The triples are not implemented here yet. Returning a zero for them
-      !! would report a CCSD(T) energy that is wrong by exactly the term that
-      !! was asked for, and nothing downstream could tell -- `e_triples` is zero
-      !! for a genuine CCSD run too.
-      type(error_type), allocatable, intent(out) :: error
-      type(libcint_molecule_t) :: mol
-      type(rhf_result_t) :: scf
-      type(error_t) :: err
-      type(rcc_result_t) :: spatial
-
-      call converged_water(mol, scf, err, "sto-3g")
-      call check(error,.not. err%has_error() .and. scf%converged, "water SCF must converge")
       if (allocated(error)) return
 
-      call run_libcint_rccsd(mol, scf%orbitals, scf%orbital_energies, 5, 0, &
-                             60, 1.0e-10_dp, .true., .false., spatial, err)
-      call check(error, err%has_error(), "(T) on the spatial path must be refused")
-      call mol%destroy()
-   end subroutine test_triples_refused
+      ! And the triples with a core frozen, in cc-pVDZ where the reference is
+      ! quoted. The triples index the occupied space three times over, so a
+      ! frozen-core offset that survives CCSD can still fail here.
+      call both_paths("cc-pvdz", 1, spin, spatial, ok, triples=.true.)
+      call check(error, ok, "both paths must converge, frozen core with triples")
+      if (allocated(error)) return
+
+      call check(error, abs(spatial%e_triples - spin%e_triples) < 1.0e-9_dp, &
+                 "frozen-core (T) must agree between formulations")
+      if (allocated(error)) return
+
+      call check(error, abs(spatial%e_triples - E_T_PVDZ_F1) < 1.0e-8_dp, &
+                 "frozen-core (T) must reproduce PySCF")
+   end subroutine test_frozen_identity
+
+   subroutine test_triples_identity(error)
+      !! The (T) corrections must agree, and match PySCF
+      !!
+      !! Its own case rather than folded into the CCSD comparison because (T)
+      !! is a separate algorithm reading the same amplitudes: it can be wrong
+      !! while CCSD is right, and a converged CCSD is the precondition for it
+      !! meaning anything at all.
+      !!
+      !! Checked in both bases. STO-3G is where a wrong permutation table still
+      !! gives a plausible magnitude -- four virtual orbitals leave few distinct
+      !! triples -- and cc-pVDZ is where it cannot hide.
+      type(error_type), allocatable, intent(out) :: error
+      type(cc_result_t) :: spin
+      type(rcc_result_t) :: spatial
+      logical :: ok
+
+      real(dp), parameter :: E_T_STO3G = -0.000072742387_dp   ! PySCF, check_cc.f90
+      real(dp), parameter :: E_T_PVDZ = -0.003037892387_dp
+
+      call both_paths("sto-3g", 0, spin, spatial, ok, triples=.true.)
+      call check(error, ok, "both paths must converge with triples")
+      if (allocated(error)) return
+
+      call check(error, abs(spatial%e_triples - spin%e_triples) < 1.0e-10_dp, &
+                 "spatial and spin-orbital (T) must agree in STO-3G")
+      if (allocated(error)) return
+
+      call check(error, abs(spatial%e_triples - E_T_STO3G) < 1.0e-9_dp, &
+                 "spatial (T) must reproduce PySCF in STO-3G")
+      if (allocated(error)) return
+
+      call both_paths("cc-pvdz", 0, spin, spatial, ok, triples=.true.)
+      call check(error, ok, "both paths must converge with triples in cc-pVDZ")
+      if (allocated(error)) return
+
+      call check(error, abs(spatial%e_triples - spin%e_triples) < 1.0e-9_dp, &
+                 "spatial and spin-orbital (T) must agree in cc-pVDZ")
+      if (allocated(error)) return
+
+      call check(error, abs(spatial%e_triples - E_T_PVDZ) < 1.0e-8_dp, &
+                 "spatial (T) must reproduce PySCF in cc-pVDZ")
+      if (allocated(error)) return
+
+      ! (T) must lower the energy further for a closed-shell molecule at its
+      ! minimum. A sign error in the permutation table is the failure this
+      ! catches that the magnitude comparisons above might not.
+      call check(error, spatial%e_triples < 0.0_dp, &
+                 "(T) must be negative here")
+   end subroutine test_triples_identity
 
 end module test_mqc_libcint_rcc
 


### PR DESCRIPTION
### 📚 Stacked PR — review & merge bottom → top

| # | PR | Title |
|---|----|-------|
| 1 | #223 | Add a spatial-orbital coupled cluster path 👈 **this PR** |
| 2 | #224 | Turn the spatial CCSD iteration into matrix products |
| 3 | #225 | Batch the perturbative triples over the innermost virtual |
| 4 | #226 | Cover RI-CCSD(T) on the spatial path |
| 5 | #227 | Give the fitted ladder both algorithms and choose between them |
| 6 | #228 | Thread the perturbative triples over virtual pairs |
| 7 | #229 | Thread the CCSD iteration, conventional and fitted |

Base of this PR: `main`. Each PR targets the branch below it; GitHub retargets the next onto `main` as each base merges.

---

Add a spatial-orbital CCSD beside the spin-orbital one

The spin-orbital module says of itself that it is the reference formulation
and to "revisit if CCSD becomes something people run rather than something
people check against". This is that revisit, and it is an addition rather
than a replacement: the spin-orbital path stays, because for a closed shell
the two are the same theory written twice and must agree to machine
precision, which is a sharper instrument than any reference energy.

Everything the spin-orbital path indexes is twice as long in four
dimensions. Measured on water/cc-pVDZ, one iteration:

                  integrals                       per iteration
  spin orbital    15.9 MB blocks + 42.5 MB tensor      0.070 s
  spatial          2.2 MB                              0.010 s

The largest single term was not an integral block but DIIS, which keeps
sixteen copies of the flat t1+t2 vector and so carried the full factor of
sixteen on t2. It shrinks with everything else and needed no change.

Two savings beyond the formulation itself. The conventional path builds its
five occupied-bearing blocks by direct transform_block calls rather than
slicing them out of the whole active-space tensor, so n_act^4 is never
allocated on either path now -- only (vv|vv) remains, smaller by roughly
(n_act/n_vir)^4. And the fitted route needed no new integral code at all:
fitted_chem_blocks already produced exactly the spatial block set a
closed-shell CCSD wants, and the 16x expansion into spin orbitals that used
to follow it is simply gone.

Equations are Hirata et al., JCP 120, 2581 (2004), Eqs. (35)-(45), followed
as PySCF's cc/rccsd.py and cc/rintermediates.py write them. That source
rather than the paper deliberately: every reference in validation/check_cc
was generated by PySCF, so matching its equations matches its answer by
construction, and a disagreement is debuggable against a readable
implementation instead of against a table. Each contraction quotes the
einsum string it implements, because the translation from row-major numpy to
column-major Fortran is where this goes wrong, and a transposed index does
not produce garbage -- it produces a converged, plausible, wrong number.

Which is what the new test exists for. The spin-orbital path shares none of
this one's index conventions and so cannot share such a mistake: it pins the
MP2 starting point, the converged correlation energy, and the singles and
doubles parts separately, conventional and fitted, with and without a frozen
core. The singles/doubles split matters on its own -- a misplaced t1 t1
product in tau moves weight between them without changing the sum. cc-pVDZ
is included because STO-3G has four virtual orbitals, few enough that a
wrong contraction can hide, and because it is where PySCF's own number can
be checked.

The perturbative triples are not on this path yet and are refused rather
than returned as zero: e_triples is zero for a genuine CCSD run too, so a
CCSD(T) deck given CCSD would be wrong by exactly the term it asked for with
nothing downstream able to tell. Nothing reaches this module from a deck
yet either; wiring, then the triples, then turning the O(n_o^3 n_v^3) ring
terms into gemms, are separate changes. The gemm work especially: it is a
rearrangement of arithmetic that must not move a digit, which is only
checkable against a version already known to be right.

Add the perturbative triples to the spatial-orbital path

CCSD(T) now runs end to end in spatial orbitals. Equations are JCP 94, 442
(1991) as PySCF's cc/ccsd_t_slow.py writes it -- including its correction to
that paper's Eq. (1), whose printed restriction is wrong and should read
[ia] >= [jb] >= [kc].

Water/cc-pVDZ, the triples step alone:

                  all electron    frozen core
  spin orbital       0.127 s        0.137 s
  spatial            0.076 s        0.044 s

Less than the sixteen-fold the integrals gave, and expectedly so: the
spin-orbital triples get antisymmetry for free where this pays for it with a
six-fold permutation sum over each virtual triple. The memory argument is
unchanged and was never the point here -- both paths hold no t3, working one
virtual triple at a time, so (T) is kilobytes on either.

No fourth transposed copy of ovvv is allocated. The reference builds three
reordered integral blocks up front, the largest of them n_occ n_vir^3; all
three are read here straight out of the blocks already held, through index
identities that hold for real orbitals:

    vvov(a,b,i,f) = ovvv(i,a,f,b)
    vooo(a,i,j,m) = ooov(j,m,i,a)
    vvoo(a,b,i,j) = ovov(i,a,j,b)

The occupied-virtual Fock block vanishes for canonical orbitals, which drops
one of the two terms in V.

The thirty-six-term energy expression pairs each ordering of the virtual
labels with one of the occupied labels, and which W goes with which is
written out as a table rather than derived. Deriving it needs a convention
for whether a permutation acts on positions or on labels, and getting that
backwards transposes half the table into an answer that is still symmetric,
still the right magnitude, and wrong.

Which is what the tests are for. (T) is now checked against the spin-orbital
path and against PySCF in both bases and with a frozen core -- its own case
rather than folded into the CCSD comparison, because it is a separate
algorithm reading the same amplitudes and can be wrong while CCSD is right.
The frozen-core case earns its place separately again: the triples index the
occupied space three times over, so an offset that survives CCSD can still
fail there. STO-3G is kept alongside cc-pVDZ because four virtual orbitals
leave few distinct triples and a wrong permutation table still lands on a
plausible magnitude.

(T) runs only on a converged reference, and the driver now prints the same
timing breakdown under the same stage names as its spin-orbital neighbour,
so the two can be laid side by side without translating.

Make spatial-orbital coupled cluster the default a deck gets

`keywords.cc.spin_adapted`, defaulting to true, so CCSD and CCSD(T) decks now
run in spatial orbitals and reach the smaller, faster path without asking.

The default rather than an opt-in because there is nothing to weigh. Coupled
cluster here is restricted-reference only -- an unrestricted one is refused a
few hundred lines up -- and for a closed shell the two formulations are exact
and agree to machine precision, so the flag chooses how a number is computed
and not which number. Water/cc-pVDZ with a frozen core, the same deck twice
through the binary:

  spin-adapted    E(corr) = -0.214113670065   E(T) = -0.003015724067
  spin orbitals   E(corr) = -0.214113670177   E(T) = -0.003015724067

1.1e-10 apart on the correlation energy and identical on the triples. The
iteration counts differ, 14 against 12, because DIIS takes a different route
to the same fixed point -- worth knowing before it is read as a discrepancy.

The spin-orbital path stays reachable, and is what a doubtful number gets
checked against: two implementations sharing no index conventions landing on
one energy is a stronger statement than either landing on a reference. Which
one ran is now logged, because nothing in the numbers would otherwise say,
and it is exactly what someone comparing a time or a footprint needs.

Only `hf_options_t` carries the flag. That is not an omission: `model.method`
selects one method type, `ccsd`/`ccsd(t)` build a Hartree-Fock method with
`run_cc` set, and `dft` builds a method that never sets it -- so coupled
cluster only ever runs through the Hartree-Fock path. A correlated
correction on a Kohn-Sham reference does exist, but it is the double hybrid's
perturbative term and rides on `xc%pt2_fraction` rather than on `run_cc`.
Coupled cluster over Kohn-Sham orbitals is not expressible in the input model
at all, which is a separate question from this one.

