### PR TITLE
Cover RI-CCSD(T) on the spatial path

### DIFF
--- a/test/test_mqc_libcint_rcc.f90
+++ b/test/test_mqc_libcint_rcc.f90
@@ -207,48 +207,119 @@ contains
                  < 1.0e-9_dp, "the two formulations must agree in cc-pVDZ too")
    end subroutine test_pyscf_reference
 
+   subroutine fitted_both_paths(basis, frozen, triples, spin, spatial, ok)
+      !! Run both formulations density-fitted, over one set of exact orbitals
+      !!
+      !! The reference this is checked against is pyscf.cc.dfccsd on a
+      !! *conventional* mean field, so the SCF here is exact too -- fitting it
+      !! as well would mix a second approximation into a comparison meant to
+      !! isolate the first.
+      character(len=*), intent(in) :: basis
+      integer, intent(in) :: frozen
+      logical, intent(in) :: triples
+      type(cc_result_t), intent(out) :: spin
+      type(rcc_result_t), intent(out) :: spatial
+      logical, intent(out) :: ok
+
+      type(libcint_molecule_t) :: mol, aux
+      type(rhf_result_t) :: scf
+      type(error_t) :: err
+
+      ok = .false.
+      call converged_water(mol, scf, err, basis)
+      if (err%has_error() .or. .not. scf%converged) return
+
+      call water(aux, err, "cc-pvdz-rifit")
+      if (err%has_error()) then
+         call mol%destroy()
+         return
+      end if
+
+      call run_libcint_ccsd(mol, scf%orbitals, scf%orbital_energies, 5, frozen, &
+                            60, 1.0e-10_dp, triples, .false., spin, err, aux=aux)
+      if (.not. err%has_error()) then
+         call run_libcint_rccsd(mol, scf%orbitals, scf%orbital_energies, 5, frozen, &
+                                60, 1.0e-10_dp, triples, .false., spatial, err, aux=aux)
+      end if
+
+      call mol%destroy()
+      call aux%destroy()
+      if (err%has_error()) return
+      ok = spin%converged .and. spatial%converged
+   end subroutine fitted_both_paths
+
    subroutine test_fitted_identity(error)
-      !! The density-fitted spatial path against the fitted spin-orbital one
+      !! The density-fitted spatial path, CCSD and (T), against every reference
       !!
       !! Its own case because the fitted route reaches `(ac|bd)` a completely
       !! different way -- a gemm over the auxiliary index inside the ladder,
       !! against a permuted read of a stored tensor -- and that is the one part
       !! of this module the conventional tests never exercise.
       !!
-      !! Compared against the fitted spin-orbital path rather than against the
-      !! conventional spatial one: the fitting error is 1.4e-4, three orders
-      !! above the agreement being asserted, so conventional CCSD is not the
-      !! yardstick here and cannot be.
+      !! The triples needed no fitted route of their own, which is what the
+      !! second half of this asserts rather than assumes: the particle half
+      !! wants (ia|bc) and the ring half (ij|ka), and `build_rcc_eris_fitted`
+      !! already produces both. Nothing in `triples_correction` reads a block
+      !! that only the conventional path builds.
+      !!
+      !! Compared against the fitted spin-orbital path, and against
+      !! pyscf.cc.dfccsd -- never against conventional CCSD. The fitting error
+      !! is 1.4e-4, three orders above the agreement asserted here, so the
+      !! conventional answer is not the yardstick and cannot be.
       type(error_type), allocatable, intent(out) :: error
-      type(libcint_molecule_t) :: mol, aux
-      type(rhf_result_t) :: scf
-      type(error_t) :: err
       type(cc_result_t) :: spin
       type(rcc_result_t) :: spatial
+      logical :: ok
 
-      call converged_water(mol, scf, err, "sto-3g")
-      call check(error,.not. err%has_error() .and. scf%converged, "water SCF must converge")
+      ! validation/check_cc.f90's ri_case references, pyscf.cc.dfccsd.RCCSD
+      real(dp), parameter :: E_CC_STO3G = -0.049173482895_dp
+      real(dp), parameter :: E_T_STO3G = -0.000072751429_dp
+      real(dp), parameter :: E_CC_PVDZ = -0.213326680500_dp
+      real(dp), parameter :: E_T_PVDZ = -0.003041992009_dp
+      real(dp), parameter :: E_CC_PVDZ_F1 = -0.211233849569_dp
+      real(dp), parameter :: E_T_PVDZ_F1 = -0.003019775484_dp
+
+      call fitted_both_paths("sto-3g", 0, .true., spin, spatial, ok)
+      call check(error, ok, "both fitted paths must converge in STO-3G")
+      if (allocated(error)) return
+      call check(error, abs(spatial%e_correlation - spatial%e_triples - E_CC_STO3G) &
+                 < 1.0e-9_dp, "fitted spatial CCSD must reproduce dfccsd, STO-3G")
+      if (allocated(error)) return
+      call check(error, abs(spatial%e_triples - E_T_STO3G) < 1.0e-9_dp, &
+                 "fitted spatial (T) must reproduce dfccsd, STO-3G")
+      if (allocated(error)) return
+      call check(error, abs(spatial%e_triples - spin%e_triples) < 1.0e-10_dp, &
+                 "the two fitted (T) corrections must agree, STO-3G")
       if (allocated(error)) return
 
-      call water(aux, err, "cc-pvdz-rifit")
-      call check(error,.not. err%has_error(), "the auxiliary basis must load")
+      ! cc-pVDZ, where the ladder's auxiliary-index gemm does real work and a
+      ! d shell is present.
+      call fitted_both_paths("cc-pvdz", 0, .true., spin, spatial, ok)
+      call check(error, ok, "both fitted paths must converge in cc-pVDZ")
+      if (allocated(error)) return
+      call check(error, abs(spatial%e_correlation - spatial%e_triples - E_CC_PVDZ) &
+                 < 1.0e-8_dp, "fitted spatial CCSD must reproduce dfccsd, cc-pVDZ")
+      if (allocated(error)) return
+      call check(error, abs(spatial%e_triples - E_T_PVDZ) < 1.0e-8_dp, &
+                 "fitted spatial (T) must reproduce dfccsd, cc-pVDZ")
+      if (allocated(error)) return
+      call check(error, abs(spatial%e_correlation - spin%e_singles - spin%e_doubles &
+                            - spin%e_triples) < 1.0e-9_dp, &
+                 "the two fitted formulations must agree, cc-pVDZ")
       if (allocated(error)) return
 
-      call run_libcint_ccsd(mol, scf%orbitals, scf%orbital_energies, 5, 0, &
-                            60, 1.0e-10_dp, .false., .false., spin, err, aux=aux)
-      call check(error,.not. err%has_error(), "fitted spin-orbital CCSD must converge")
+      ! And with a core frozen, which the triples index three times over.
+      call fitted_both_paths("cc-pvdz", 1, .true., spin, spatial, ok)
+      call check(error, ok, "both fitted paths must converge, frozen core")
       if (allocated(error)) return
-
-      call run_libcint_rccsd(mol, scf%orbitals, scf%orbital_energies, 5, 0, &
-                             60, 1.0e-10_dp, .false., .false., spatial, err, aux=aux)
-      call check(error,.not. err%has_error(), "fitted spatial CCSD must converge")
+      call check(error, abs(spatial%e_correlation - spatial%e_triples - E_CC_PVDZ_F1) &
+                 < 1.0e-8_dp, "fitted spatial CCSD must reproduce dfccsd, frozen core")
       if (allocated(error)) return
-
-      call check(error, abs(spatial%e_correlation - spin%e_singles - spin%e_doubles) &
-                 < 1.0e-9_dp, "the two fitted formulations must agree")
-
-      call mol%destroy()
-      call aux%destroy()
+      call check(error, abs(spatial%e_triples - E_T_PVDZ_F1) < 1.0e-8_dp, &
+                 "fitted spatial (T) must reproduce dfccsd, frozen core")
+      if (allocated(error)) return
+      call check(error, abs(spatial%e_triples - spin%e_triples) < 1.0e-9_dp, &
+                 "the two fitted (T) corrections must agree, frozen core")
    end subroutine test_fitted_identity
 
    subroutine test_frozen_identity(error)


### PR DESCRIPTION
### 📚 Stacked PR — review & merge bottom → top

| # | PR | Title |
|---|----|-------|
| 1 | #223 | Add a spatial-orbital coupled cluster path |
| 2 | #224 | Turn the spatial CCSD iteration into matrix products |
| 3 | #225 | Batch the perturbative triples over the innermost virtual |
| 4 | #226 | Cover RI-CCSD(T) on the spatial path 👈 **this PR** |
| 5 | #227 | Give the fitted ladder both algorithms and choose between them |
| 6 | #228 | Thread the perturbative triples over virtual pairs |
| 7 | #229 | Thread the CCSD iteration, conventional and fitted |

Base of this PR: `feat/spatial_cc_triples_opt`. Each PR targets the branch below it; GitHub retargets the next onto `main` as each base merges.

---

Cover RI-CCSD(T) on the spatial path, which already worked

No implementation. The fitted route needed no triples code of its own and
never did: the particle half of W wants (ia|bc) and the ring half (ij|ka), and
build_rcc_eris_fitted already produces both, so triples_correction reads
nothing that only the conventional path builds. This asserts that rather than
leaving it inferred from the absence of a failure.

All four of validation/check_cc.f90's ri_case references are now checked from
the unit tests, CCSD and (T), in STO-3G and cc-pVDZ and with a frozen core.
Each is checked twice over: against pyscf.cc.dfccsd, and against the fitted
spin-orbital path, which shares none of this one's index conventions. The
end-to-end deck agrees too -- cpu_water_cc-pvdz_riccsdt_f1 gives (T) =
-0.003019775698 against the reference -0.003019775484.

Never against conventional CCSD, and the helper says so where someone might
be tempted: the fitting error is 1.4e-4, three orders above the agreement
asserted here, so the conventional answer cannot be the yardstick. The SCF
underneath stays exact for the same reason the reference was produced that
way -- fitting it as well would mix a second approximation into a comparison
meant to isolate the first.

What this does surface is where the fitted path costs something. Water/cc-pVTZ
with a frozen core:

                          conventional        RI
    integrals held           74.4 MB       11.3 MB    6.6x less
    CCSD per iteration        0.058 s       0.118 s   2.0x slower
    (T)                       0.356 s       0.351 s   unchanged

The triples are indifferent, as they should be -- they read blocks that are
the same size either way. The iteration is not, and the ladder is where it
goes: assembling (ac|bd) from the three-index tensor is 55% of an iteration,
measured by removing it. It is not running badly -- about 14 Gflop/s -- there
is simply a lot of it, naux n_vir^4 against the n_occ^2 n_vir^4 of the
contraction it feeds. The 2x is structural rather than a defect: RI rebuilds
every iteration what the conventional path reads out of an array it could not
afford to store in the first place.

Contracting the fitted tensor against tau directly, never forming (ac|bd),
costs 2 naux n_vir^3 n_occ^2 instead, and which of the two wins depends
entirely on the system:

    water/cc-pVTZ      no=4  nv=53    1.0 G vs   0.6 G   direct
    water/cc-pVQZ      no=4  nv=110  38.9 G vs  10.6 G   direct
    benzene/cc-pVDZ    no=21 nv=93   62.9 G vs 283.8 G   assemble
    gly3/cc-pVDZ       no=40 nv=200  3.8 T vs  20.5 T    assemble

The crossover is nv > 2 no^2. The benchmark above sits on the favourable side,
but it is a small molecule in a large basis and that is not where RI-CCSD
earns its place; at benzene the direct form is 4.5x worse. So the follow-up is
to implement both and choose, not to replace one with the other.

