### PR TITLE
Give the fitted ladder both algorithms and choose between them

### DIFF
--- a/backends/libcint/mqc_libcint_rcc.f90
+++ b/backends/libcint/mqc_libcint_rcc.f90
@@ -68,6 +68,7 @@ module mqc_libcint_rcc
    public :: rcc_eris_t              !! Exported so a test can build them directly
    public :: build_rcc_eris_conventional
    public :: rccsd_correlation_energy  !! Exported for the MP2 identity test
+   public :: ri_ladder_prefers_direct  !! Exported so a test can assert which ladder ran
 
    !> Columns of the compound (cd) index assembled per pass of the ladder.
    !> Same role and same reasoning as LADDER_BATCH in the spin-orbital module:
@@ -1145,6 +1146,98 @@ contains
       call pic_gemm(tau_cols, wblk, t2n, transb="T", beta=1.0_dp)
    end subroutine ladder_accumulate
 
+   pure function ri_ladder_prefers_direct(no, nv, naux) result(direct)
+      !! Whether to contract the fitted tensor against tau without forming (ac|bd)
+      !!
+      !! Two ways to reach the same sum, and neither wins everywhere:
+      !!
+      !!   assemble   naux n_vir^4 to build (ac|bd), then n_occ^2 n_vir^4 to
+      !!              contract it -- what the conventional path does too, with
+      !!              the build replacing a read
+      !!   direct     2 naux n_vir^3 n_occ^2, never forming (ac|bd) at all
+      !!
+      !! Direct wins when n_vir exceeds roughly 2 n_occ^2, which is a small
+      !! molecule in a large basis; assemble wins with many occupied orbitals,
+      !! which is where anyone actually reaches for density fitting. Water in
+      !! cc-pVTZ is 1.0 GFlop against 0.6; benzene in cc-pVDZ is 63 against 284
+      !! the other way. Choosing on measured counts rather than picking one is
+      !! the only honest option, because the ratio spans two orders of magnitude
+      !! across ordinary cases.
+      !!
+      !! The comparison is on operation counts only. Both forms are gemms of
+      !! comparable shape, so the counts predict the ordering; what they do not
+      !! predict is the constant, which is why the crossover is written as the
+      !! full expression rather than the tidy `nv > 2 no^2` it reduces to when
+      !! naux dominates n_occ^2.
+      integer, intent(in) :: no, nv, naux
+      logical :: direct
+
+      real(dp) :: assemble_ops, direct_ops
+
+      assemble_ops = (real(naux, dp) + real(no, dp)**2)*real(nv, dp)**4
+      direct_ops = 2.0_dp*real(naux, dp)*real(nv, dp)**3*real(no, dp)**2
+      direct = (direct_ops < assemble_ops)
+   end function ri_ladder_prefers_direct
+
+   subroutine ri_ladder_pair(nv, gp, tauij, work, accab)
+      !! accab(a,b) += sum_cd G(a,c) tau(c,d) G(b,d), one auxiliary function
+      !!
+      !! `gp` is one column of `b_vv` seen as the n_vir by n_vir matrix its
+      !! memory already is: the compound index runs virtual-fastest, so column P
+      !! laid out as (a,c) is exactly B^P_ac with nothing moved.
+      integer, intent(in) :: nv
+      real(dp), intent(in) :: gp(nv, nv)      !! B^P_ac
+      real(dp), intent(in) :: tauij(nv, nv)   !! tau(i,j,c,d) at fixed (i,j)
+      real(dp), intent(inout) :: work(nv, nv)
+      real(dp), intent(inout) :: accab(nv, nv)
+
+      call pic_gemm(gp, tauij, work)
+      call pic_gemm(work, gp, accab, transb="T", beta=1.0_dp)
+   end subroutine ri_ladder_pair
+
+   subroutine ri_ladder_direct(eris, tau, no, nv, naux, t2n)
+      !! The fitted ladder without ever forming (ac|bd)
+      !!
+      !!     sum_cd (ac|bd) tau(i,j,c,d) = sum_P [ G_P tau_ij G_P^T ](a,b)
+      !!
+      !! which is two n_vir-cubed products per auxiliary function per occupied
+      !! pair, against the n_vir^4 of assembling the integral first. Nothing
+      !! held here exceeds n_vir^2, and `G_P` is not held at all -- it is a
+      !! column of `b_vv` read in place.
+      type(rcc_eris_t), intent(in) :: eris
+      integer, intent(in) :: no, nv, naux
+      real(dp), intent(in) :: tau(no, no, nv, nv)
+      real(dp), intent(inout) :: t2n(no, no, nv, nv)
+
+      real(dp), allocatable :: tauij(:, :), work(:, :), accab(:, :)
+      integer :: i, j, a, b, c, d, p
+
+      allocate (tauij(nv, nv), work(nv, nv), accab(nv, nv))
+
+      do j = 1, no
+         do i = 1, no
+            do d = 1, nv
+               do c = 1, nv
+                  tauij(c, d) = tau(i, j, c, d)
+               end do
+            end do
+
+            accab = 0.0_dp
+            do p = 1, naux
+               call ri_ladder_pair(nv, eris%b_vv(1, p), tauij, work, accab)
+            end do
+
+            do b = 1, nv
+               do a = 1, nv
+                  t2n(i, j, a, b) = t2n(i, j, a, b) + accab(a, b)
+               end do
+            end do
+         end do
+      end do
+
+      deallocate (tauij, work, accab)
+   end subroutine ri_ladder_direct
+
    subroutine ladder_t1_dressing(eris, t1, tau, no, nv, t2n)
       !! The t1 half of the particle-particle ladder, without forming it
       !!
@@ -1275,7 +1368,15 @@ contains
 
       nv2 = nv*nv
       fitted = allocated(eris%b_vv)
-      if (fitted) naux = size(eris%b_vv, 2)
+      if (fitted) then
+         naux = size(eris%b_vv, 2)
+         ! Which way round to do the fitted ladder. See `ri_ladder_prefers_direct`.
+         if (ri_ladder_prefers_direct(no, nv, naux)) then
+            call ri_ladder_direct(eris, tau, no, nv, naux, t2n)
+            call ladder_t1_dressing(eris, t1, tau, no, nv, t2n)
+            return
+         end if
+      end if
 
       allocate (wblk(nv, nv, LADDER_BATCH))
       if (fitted) allocate (gvv(nv, nv))

--- a/test/test_mqc_libcint_rcc.f90
+++ b/test/test_mqc_libcint_rcc.f90
@@ -23,7 +23,7 @@ module test_mqc_libcint_rcc
    use mqc_libcint_rhf, only: rhf_result_t, run_libcint_rhf
    use mqc_libcint_mp2, only: mp2_result_t, run_libcint_mp2
    use mqc_libcint_cc, only: cc_result_t, run_libcint_ccsd
-   use mqc_libcint_rcc, only: rcc_result_t, run_libcint_rccsd
+   use mqc_libcint_rcc, only: rcc_result_t, run_libcint_rccsd, ri_ladder_prefers_direct
    implicit none
    private
    public :: collect_mqc_libcint_rcc_tests
@@ -40,6 +40,7 @@ contains
                   new_unittest("spatial_ccsd_equals_spin_orbital_ccsd", test_ccsd_identity), &
                   new_unittest("spatial_ccsd_matches_pyscf_cc_pvdz", test_pyscf_reference), &
                   new_unittest("fitted_path_agrees_with_spin_orbital", test_fitted_identity), &
+                  new_unittest("direct_ri_ladder_agrees_with_assembled", test_ri_ladder_direct), &
                   new_unittest("frozen_core_agrees_between_formulations", test_frozen_identity), &
                   new_unittest("spatial_triples_equal_spin_orbital_triples", test_triples_identity) &
                   ]
@@ -321,6 +322,82 @@ contains
       call check(error, abs(spatial%e_triples - spin%e_triples) < 1.0e-9_dp, &
                  "the two fitted (T) corrections must agree, frozen core")
    end subroutine test_fitted_identity
+
+   subroutine test_ri_ladder_direct(error)
+      !! The fitted ladder's other algorithm, on a system that selects it
+      !!
+      !! `ri_ladder_prefers_direct` chooses between assembling (ac|bd) and
+      !! contracting the fitted tensor against tau without ever forming it, on
+      !! measured operation counts. Every other fitted case in this file lands
+      !! on the assembling side -- water has five occupied orbitals and the
+      !! crossover needs roughly n_vir > 2 n_occ^2 -- so without this the whole
+      !! direct path would be dead code as far as the suite is concerned.
+      !!
+      !! H2 in cc-pVDZ has one occupied orbital and nine virtual, which selects
+      !! direct by a wide margin and costs almost nothing to run.
+      !!
+      !! The choice is asserted, not assumed. If the crossover is ever retuned
+      !! so that this case stops selecting direct, this fails rather than
+      !! quietly going back to testing the branch that was already covered.
+      type(error_type), allocatable, intent(out) :: error
+      type(libcint_molecule_t) :: mol, aux
+      type(rhf_result_t) :: scf
+      type(error_t) :: err
+      type(cc_result_t) :: spin
+      type(rcc_result_t) :: spatial
+      real(dp) :: c(3, 2)
+
+      ! Representative counts for this case: one occupied, nine virtual, and an
+      ! auxiliary basis of a few tens. The exact naux does not move the answer
+      ! anywhere near the crossover.
+      call check(error, ri_ladder_prefers_direct(1, 9, 50), &
+                 "H2/cc-pVDZ must select the direct fitted ladder")
+      if (allocated(error)) return
+      call check(error,.not. ri_ladder_prefers_direct(5, 19, 84), &
+                 "water/cc-pVDZ must select the assembled fitted ladder")
+      if (allocated(error)) return
+
+      c = reshape([0.0_dp, 0.0_dp, -0.3707_dp*ANG, &
+                   0.0_dp, 0.0_dp, 0.3707_dp*ANG], [3, 2])
+      call build_libcint_molecule([1, 1], ["H ", "H "], c, "cc-pvdz", mol, err)
+      call check(error,.not. err%has_error(), "H2 basis must load")
+      if (allocated(error)) return
+
+      call build_libcint_molecule([1, 1], ["H ", "H "], c, "cc-pvdz-rifit", aux, err)
+      call check(error,.not. err%has_error(), "H2 auxiliary basis must load")
+      if (allocated(error)) return
+
+      call run_libcint_rhf(mol, 2, 200, 1.0e-11_dp, 1.0e-9_dp, .false., scf, err, &
+                           in_core=.true.)
+      call check(error,.not. err%has_error() .and. scf%converged, "H2 SCF must converge")
+      if (allocated(error)) return
+
+      call run_libcint_ccsd(mol, scf%orbitals, scf%orbital_energies, 1, 0, &
+                            60, 1.0e-10_dp, .true., .false., spin, err, aux=aux)
+      call check(error,.not. err%has_error(), "fitted spin-orbital CCSD(T) must converge")
+      if (allocated(error)) return
+
+      call run_libcint_rccsd(mol, scf%orbitals, scf%orbital_energies, 1, 0, &
+                             60, 1.0e-10_dp, .true., .false., spatial, err, aux=aux)
+      call check(error,.not. err%has_error(), "fitted spatial CCSD(T) must converge")
+      if (allocated(error)) return
+
+      ! The spin-orbital path has only the one ladder, so this compares the
+      ! direct algorithm against an assembled one -- which is the whole point.
+      call check(error, abs(spatial%e_correlation - spin%e_singles - spin%e_doubles &
+                            - spin%e_triples) < 1.0e-10_dp, &
+                 "the direct fitted ladder must reproduce the assembled one")
+      if (allocated(error)) return
+
+      ! Two electrons in one orbital: CCSD is exact for a two-electron system,
+      ! so the triples must be zero to numerical noise. A ladder that dropped
+      ! or double-counted a term would not respect that.
+      call check(error, abs(spatial%e_triples) < 1.0e-12_dp, &
+                 "(T) must vanish for two electrons, where CCSD is already exact")
+
+      call mol%destroy()
+      call aux%destroy()
+   end subroutine test_ri_ladder_direct
 
    subroutine test_frozen_identity(error)
       !! And they must still agree with a core orbital frozen


### PR DESCRIPTION
### 📚 Stacked PR — review & merge bottom → top

| # | PR | Title |
|---|----|-------|
| 1 | #223 | Add a spatial-orbital coupled cluster path |
| 2 | #224 | Turn the spatial CCSD iteration into matrix products |
| 3 | #225 | Batch the perturbative triples over the innermost virtual |
| 4 | #226 | Cover RI-CCSD(T) on the spatial path |
| 5 | #227 | Give the fitted ladder both algorithms and choose between them 👈 **this PR** |
| 6 | #228 | Thread the perturbative triples over virtual pairs |
| 7 | #229 | Thread the CCSD iteration, conventional and fitted |

Base of this PR: `feat/spatial_ri_ccsd_t`. Each PR targets the branch below it; GitHub retargets the next onto `main` as each base merges.

---

Give the fitted ladder both algorithms and choose between them

Water/cc-pVTZ, frozen core, per CCSD iteration:

  assemble (ac|bd), then contract   0.119 s
  contract the fitted tensor direct 0.065 s   1.8x

E(corr) is -0.276889060170 either way, identical in every printed digit --
checked by forcing each algorithm on the same deck, not inferred. That puts
the fitted path level with the conventional one's 0.058 s while still holding
11.3 MB against 74.4.

Neither algorithm wins everywhere, which is why both are here:

    assemble   naux n_vir^4  to build (ac|bd), then n_occ^2 n_vir^4
    direct     2 naux n_vir^3 n_occ^2, never forming it

    water/cc-pVTZ    no=4  nv=53    1.0 G vs   0.6 G   direct
    water/cc-pVQZ    no=4  nv=110  38.9 G vs  10.6 G   direct
    benzene/cc-pVDZ  no=21 nv=93   62.9 G vs 283.8 G   assemble
    gly3/cc-pVDZ     no=40 nv=200   3.8 T vs  20.5 T   assemble

The ratio spans two orders of magnitude across ordinary cases, so picking one
would have been wrong for half of them. The choice is made on the operation
counts themselves rather than on the tidy nv > 2 no^2 they reduce to, because
that reduction assumes naux dominates n_occ^2 and it does not always.

The direct form is two n_vir-cubed products per auxiliary function per
occupied pair. G_P needs no packing: `b_vv` runs virtual-fastest, so column P
read as an n_vir by n_vir matrix already is B^P_ac. Nothing held exceeds
n_vir^2.

A note on what the tests were not covering. Every fitted case in the suite --
water in STO-3G and cc-pVDZ, with and without a frozen core -- lands on the
assembling side of the crossover, so the direct path would have been dead code
as far as the suite could tell. H2 in cc-pVDZ has one occupied orbital against
nine virtual, selects direct by a wide margin, and costs nothing to run. The
new case asserts the selection as well as the answer, so that retuning the
crossover cannot silently go back to testing only the branch that was already
covered. It also checks that (T) vanishes there: CCSD is exact for two
electrons, and a ladder that dropped or double-counted a term would not
respect that.

