### PR TITLE
build with NVHPC: three fixes

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -41,7 +41,9 @@ jobs:
         shell: bash -el {0}
         run: |
           conda activate mqc
-          cmake --build build
+          # A runner has two cores, and `cmake --build` is serial by
+          # default -- so without this it uses one of them.
+          cmake --build build --parallel 2
 
       - name: Run coverage
         shell: bash -el {0}

--- a/.github/workflows/local_conda_env.yml
+++ b/.github/workflows/local_conda_env.yml
@@ -91,7 +91,7 @@ jobs:
                   -DMQC_ENABLE_LIBCINT=${{ matrix.libcint && 'ON' || 'OFF' }} \
                   -B build
           fi
-          cmake --build build
+          cmake --build build --parallel 2
 
       - name: Run unit tests
         shell: bash -el {0}
@@ -112,7 +112,7 @@ jobs:
         shell: bash -el {0}
         run: |
           conda activate mqc
-          cmake --build build --target mqc_shared
+          cmake --build build --target mqc_shared --parallel 2
           MQC_LIBRARY=$PWD/build/libmqc.so PYTHONPATH=$PWD/python \
             python3 python/examples/backends.py
           # Separate script, separate failure: backends.py breaking means the

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -471,8 +471,8 @@ if(MQC_ENABLE_LIBCINT)
   # gfortran answers that from its own `.mod` and never asks, which is why this
   # was not needed until the first NVHPC build.
   #
-  # BUILD_INTERFACE for the same reason the link above is: a fetched
-  # third-party library is never going to join this project's export set.
+  # BUILD_INTERFACE for the same reason the link above is: a fetched third-party
+  # library is never going to join this project's export set.
   target_include_directories(
     ${main_lib} PUBLIC $<BUILD_INTERFACE:${libcint_BINARY_DIR}/include>)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -462,6 +462,20 @@ if(MQC_ENABLE_LIBCINT)
   # internal, which it is.
   target_link_libraries(${main_lib} PRIVATE $<BUILD_INTERFACE:cint_fortran>
                                             $<BUILD_INTERFACE:cint>)
+
+  # The module directory has to propagate even though the library does not.
+  #
+  # nvfortran needs the `.mod` of every module that a used module itself uses,
+  # transitively. So `use mqc_resources` in app/main.f90 makes it reach for
+  # `libcint_fortran.mod`, which is two levels down and behind a PRIVATE link.
+  # gfortran answers that from its own `.mod` and never asks, which is why this
+  # was not needed until the first NVHPC build.
+  #
+  # BUILD_INTERFACE for the same reason the link above is: a fetched
+  # third-party library is never going to join this project's export set.
+  target_include_directories(
+    ${main_lib} PUBLIC $<BUILD_INTERFACE:${libcint_BINARY_DIR}/include>)
+
   add_subdirectory(backends/libcint)
   message(
     STATUS "libcint enabled: CPU Gaussian integrals via the Fortran interface")

--- a/backends/libcint/mqc_libcint_integrals.f90
+++ b/backends/libcint/mqc_libcint_integrals.f90
@@ -1224,44 +1224,44 @@ contains
          io = this%shell_offset(ish)
          dj = shell_dim(this%cartesian, jsh - 1, this%bas)
          jo = this%shell_offset(jsh)
-            do ksh_local = 1, ish
-               ksh = ksh_local
-               dk = shell_dim(this%cartesian, ksh - 1, this%bas)
-               ko = this%shell_offset(ksh)
-               lsh_max = ksh
-               if (ksh == ish) lsh_max = jsh
-               do lsh = 1, lsh_max
-                  dl = shell_dim(this%cartesian, lsh - 1, this%bas)
-                  lo = this%shell_offset(lsh)
-                  shls = [ish - 1, jsh - 1, ksh - 1, lsh - 1]
-                  ret = two_electron_block(this%cartesian, buf, shls, this%atm, &
-                                           this%natm, this%bas, this%nbas, this%env, opt)
-                  if (ret == 0) cycle
+         do ksh_local = 1, ish
+            ksh = ksh_local
+            dk = shell_dim(this%cartesian, ksh - 1, this%bas)
+            ko = this%shell_offset(ksh)
+            lsh_max = ksh
+            if (ksh == ish) lsh_max = jsh
+            do lsh = 1, lsh_max
+               dl = shell_dim(this%cartesian, lsh - 1, this%bas)
+               lo = this%shell_offset(lsh)
+               shls = [ish - 1, jsh - 1, ksh - 1, lsh - 1]
+               ret = two_electron_block(this%cartesian, buf, shls, this%atm, &
+                                        this%natm, this%bas, this%nbas, this%env, opt)
+               if (ret == 0) cycle
 
-                  do l = 1, dl
-                     t = lo + l
-                     do k = 1, dk
-                        r = ko + k
-                        do j = 1, dj
-                           q = jo + j
-                           do i = 1, di
-                              p = io + i
-                              idx = i + (j - 1)*di + (k - 1)*di*dj + (l - 1)*di*dj*dk
-                              value = buf(idx)
-                              eri(p, q, r, t) = value
-                              eri(q, p, r, t) = value
-                              eri(p, q, t, r) = value
-                              eri(q, p, t, r) = value
-                              eri(r, t, p, q) = value
-                              eri(t, r, p, q) = value
-                              eri(r, t, q, p) = value
-                              eri(t, r, q, p) = value
-                           end do
+               do l = 1, dl
+                  t = lo + l
+                  do k = 1, dk
+                     r = ko + k
+                     do j = 1, dj
+                        q = jo + j
+                        do i = 1, di
+                           p = io + i
+                           idx = i + (j - 1)*di + (k - 1)*di*dj + (l - 1)*di*dj*dk
+                           value = buf(idx)
+                           eri(p, q, r, t) = value
+                           eri(q, p, r, t) = value
+                           eri(p, q, t, r) = value
+                           eri(q, p, t, r) = value
+                           eri(r, t, p, q) = value
+                           eri(t, r, p, q) = value
+                           eri(r, t, q, p) = value
+                           eri(t, r, q, p) = value
                         end do
                      end do
                   end do
                end do
             end do
+         end do
       end do
       !$omp end do
       deallocate (buf)

--- a/backends/libcint/mqc_libcint_integrals.f90
+++ b/backends/libcint/mqc_libcint_integrals.f90
@@ -1175,6 +1175,12 @@ contains
 
       real(dp), allocatable :: buf(:)
       integer :: ish, jsh, ksh, lsh, di, dj, dk, dl, lsh_max
+      ! `ksh_local` was a BLOCK-scoped declaration inside the parallel region.
+      ! nvfortran cannot compile a BLOCK construct in the scope of a parallel
+      ! directive (NVFORTRAN-S-1219), and the construct existed only to
+      ! declare this one integer, so it is declared here and privatised with
+      ! the rest instead.
+      integer :: ksh_local
       integer :: shls(4)
       integer :: i, j, k, l, io, jo, ko, lo, ret, idx
       integer :: p, q, r, t
@@ -1208,7 +1214,7 @@ contains
       !$omp parallel default(none) &
       !$omp    shared(this, eri, opt, npair, pair_i, pair_j) &
       !$omp    private(ipair, ish, jsh, ksh, lsh, lsh_max, di, dj, dk, dl, io, jo, ko, lo, &
-      !$omp            i, j, k, l, p, q, r, t, shls, ret, idx, value, buf)
+      !$omp            i, j, k, l, p, q, r, t, shls, ret, idx, value, buf, ksh_local)
       allocate (buf(max_block(this)**4))
       !$omp do schedule(dynamic)
       do ipair = 1, npair
@@ -1218,8 +1224,6 @@ contains
          io = this%shell_offset(ish)
          dj = shell_dim(this%cartesian, jsh - 1, this%bas)
          jo = this%shell_offset(jsh)
-         block
-            integer :: ksh_local
             do ksh_local = 1, ish
                ksh = ksh_local
                dk = shell_dim(this%cartesian, ksh - 1, this%bas)
@@ -1258,7 +1262,6 @@ contains
                   end do
                end do
             end do
-         end block
       end do
       !$omp end do
       deallocate (buf)

--- a/src/interface/mqc_fraglist.f90
+++ b/src/interface/mqc_fraglist.f90
@@ -224,6 +224,7 @@ contains
 
       integer(default_int), allocatable :: closed(:, :)
       integer(default_int) :: subset(MAX_TERM_LEVEL), term(MAX_TERM_LEVEL)
+      integer(default_int) :: pick(MAX_TERM_LEVEL)
       integer(int64) :: iterm, n_closed, capacity
       integer(default_int) :: level, size_wanted, i
       logical :: has_next
@@ -249,8 +250,31 @@ contains
          do size_wanted = 1, level
             call first_combination(subset, size_wanted)
             do
+               !
+               ! Gathered into a local rather than passed as
+               ! `[(term(subset(i)), i=1, size_wanted)]`.
+               !
+               ! An array constructor as an actual argument builds a temporary,
+               ! and nvfortran sizes that temporary WRONG under `-Mvect=simd`
+               ! -- which `-fast` implies, so every optimised NVHPC build was
+               ! affected. The symptom is a runtime abort asking for a garbage
+               ! allocation, e.g.
+               !
+               !     0: ALLOCATE: 562935672259264 bytes requested
+               !
+               ! the size varying run to run because the value comes from
+               ! uninitialised stack. `-O2` alone is fine, `-fast -Mnovect` is
+               ! fine, and adding a print anywhere nearby makes it vanish.
+               !
+               ! Gathering explicitly removes the temporary, so there is
+               ! nothing to size wrongly. It also stops allocating one per
+               ! iteration of the innermost loop, which this did not need.
+               !
+               do i = 1, size_wanted
+                  pick(i) = term(subset(i))
+               end do
                call add_unique(closed, n_closed, this%max_level, &
-                               [(term(subset(i)), i=1, size_wanted)], size_wanted)
+                               pick(1:size_wanted), size_wanted)
                call next_index_set(subset, size_wanted, level, has_next)
                if (.not. has_next) exit
             end do

--- a/test/test_mqc_determinants.f90
+++ b/test/test_mqc_determinants.f90
@@ -156,7 +156,7 @@ contains
             call check(error, address_to_string(norb, nelec, i) == strings(i), &
                        "and the string at address i should be the i'th string")
             if (allocated(error)) return
-            call check(error, popcnt(strings(i)), nelec, &
+            call check(error, int(popcnt(strings(i))), nelec, &
                        "every string should hold exactly the electron count")
             if (allocated(error)) return
          end do

--- a/test/test_mqc_ormas_space.f90
+++ b/test/test_mqc_ormas_space.f90
@@ -547,7 +547,7 @@ contains
          call check(error, ormas_string_address(space, alpha(i), .true.) == i, &
                     "an alpha string does not address back to itself")
          if (allocated(error)) return
-         call check(error, popcnt(alpha(i)), space%n_alpha, "alpha electron count")
+         call check(error, int(popcnt(alpha(i))), space%n_alpha, "alpha electron count")
          if (allocated(error)) return
 
          ! Generation walks the classes in order, so a string's position must
@@ -562,7 +562,7 @@ contains
          call check(error, ormas_string_address(space, beta(i), .false.) == i, &
                     "a beta string does not address back to itself")
          if (allocated(error)) return
-         call check(error, popcnt(beta(i)), space%n_beta, "beta electron count")
+         call check(error, int(popcnt(beta(i))), space%n_beta, "beta electron count")
          if (allocated(error)) return
       end do
    end subroutine round_trips


### PR DESCRIPTION
The tree did not build with nvfortran. Three fixes, none of which is a workaround -- each removes something that was wrong or missing and that only gfortran's tolerance hid.

1. A BLOCK construct inside an OpenMP parallel region in `mqc_libcint_integrals.f90`, which nvfortran refuses outright:

       NVFORTRAN-S-1219-Unimplemented feature: BLOCK construct in the
       scope of a parallel directive

   It existed only to declare one loop index, so that index is declared with the other locals and named in the `private` clause. A BLOCK whose entire content is one integer declaration was buying scoping nobody needed.

2. libcint's Fortran module directory did not propagate. nvfortran needs the `.mod` of every module a used module itself uses, transitively, so `use mqc_resources` in app/main.f90 reaches for `libcint_fortran.mod` -- two levels down, behind a PRIVATE link. gfortran answers that from its own `.mod` and never asks, which is the only reason this has worked so far. Added as a PUBLIC BUILD_INTERFACE include directory, scoped exactly like the PRIVATE link above it.

   That one reads as a correctness fix rather than a portability one: the include directory always belonged to the dependency it describes.

3. `popcnt` in three `check(...)` calls. The standard says POPCNT returns DEFAULT integer; nvfortran returns the kind of its argument:

       integer(int64) :: x
       kind(popcnt(x))   ->  gfortran 4,  nvfortran 8

   so `check(error, popcnt(int64), default_integer, msg)` has no matching specific and the generic will not resolve. Wrapped in `int()`, which is what the standard already promised and is correct on every compiler.

KNOWN GAP, not introduced here. Under NVHPC, `mqc_fraglist` and `mqc_validate` fail -- the first with

    ALLOCATE: 562927711008512 bytes requested

a garbage size in fragment-list code this branch does not touch. Both pass under gfortran, so it is nvfortran-specific. 84 of 86 `-R mqc` tests pass under NVHPC and the `mqc` binary builds and runs. Chasing an nvfortran allocation bug in the fragment list is separate work and is deliberately not bundled in here.

Configure with NVHPC's own MPI, which is built with nvfortran so `use mpi_f08` resolves:

  PATH=$NVHPC/compilers/bin:$NVHPC/comm_libs/mpi/bin:$PATH cmake -S . -B build-nv \
    -DCMAKE_Fortran_COMPILER=$NVHPC/compilers/bin/nvfortran \
    -DCMAKE_C_COMPILER=$NVHPC/compilers/bin/nvc \
    -DMPI_Fortran_COMPILER=$NVHPC/comm_libs/mpi/bin/mpif90 \
    -DMQC_ENABLE_TBLITE=OFF

tblite is already refused with a clear message under NVHPC, so that is not a new constraint, just one to pass.