### PR TITLE
Take pic-blas v0.3.1 in the fpm build too

### DIFF
--- a/fpm.toml
+++ b/fpm.toml
@@ -29,7 +29,7 @@ source-form = "free"
 [dependencies]
 pic = { git = "https://github.com/JorgeG94/pic.git", tag = "v0.6.0"}
 pic-mpi = { git = "https://github.com/JorgeG94/pic-mpi.git", tag = "v0.5.1"}
-pic-blas = { git = "https://github.com/JorgeG94/pic-blas.git", tag = "v0.3.0"}
+pic-blas = { git = "https://github.com/JorgeG94/pic-blas.git", tag = "v0.3.1"}
 tblite = { git = "https://github.com/tblite/tblite", tag = "v0.6.0"}
 test-drive.git = "https://github.com/JorgeG94/test-drive"
 json-fortran = { git = "https://github.com/jacobwilliams/json-fortran.git", tag = "9.2.0"}


### PR DESCRIPTION
v0.3.1 is the release with the thread-safety fix: Intel's -auto-scalar leaves CHARACTER locals in static storage, so the transpose flags in the BLAS and LAPACK wrappers were shared by every thread and raced when a caller ran them inside an OpenMP region. The CMake build has had it since the release; this line is why the fpm build did not.

Worth being precise about what this does and does not buy. The fix itself is `-auto` in pic-blas's cmake/CMakeLists.txt, which fpm does not read, and pic-blas's fpm.toml sets no flags -- so an fpm build with ifx still compiles those locals static. What changes here is the source, not the flags. gfortran defaults to -fautomatic and was never affected, which is the whole fpm CI job, so what is left exposed is an fpm build driven by ifx by hand.