### PR TITLE
Put the two EFP2 cases back in the manifest

### DIFF
--- a/tools/cpu_validation/gen_cpu_validation.py
+++ b/tools/cpu_validation/gen_cpu_validation.py
@@ -7,7 +7,9 @@ Writes, under ``validation/``:
 * ``inputs/cpu_<molecule>_<basis>.json`` -- one metalquicha deck per case
 * ``validation_tests_cpu.json``          -- the manifest, with PySCF energies
 
-Nothing here is hand-maintained: edit ``MOLECULES`` or ``SWEEPS`` and rerun.
+Almost nothing here is hand-maintained: edit ``MOLECULES`` or ``SWEEPS`` and
+rerun. The exceptions are ``MANUAL_CASES`` and ``PRESERVED_TESTS``, for decks
+whose reference comes from GAMESS rather than PySCF.
 See README.md for how and why.
 
 The reference energies are PySCF RHF driven with the *same* basis JSON that
@@ -1800,6 +1802,40 @@ def pyscf_rhf(atoms, basis, aux="", multiplicity=1):
 # reference aborted it -- so nobody had regenerated to find out. Holding them
 # here keeps the generator the single source of the manifest, which is the
 # property everything else in this file assumes.
+# Manifest entries for decks this script cannot generate *and* does not write.
+#
+# HAND_MAINTAINED already spares these decks from the sweep, and the read-back
+# below re-emits any entry a previous manifest carried for them. Neither recovers
+# an entry once it has been lost: the sweep keeps the deck, and the read-back can
+# only return what is already there. The two EFP2 cases show what that costs --
+# they were dropped from the manifest between 279e9cf74 and 98877bcbb, the decks
+# stayed on disk, and the suite has not run them since. Coverage that looks
+# present and does not run.
+#
+# Declaring them here makes them reproducible from this script alone, the same
+# property MANUAL_CASES has, rather than from whatever the manifest happened to
+# hold. The reference is GAMESS: EFP2 is a sum of five terms against a fragment
+# potential, and PySCF has no EFP to generate one.
+#
+# The two differ only in the orientation of the dimer, and share an energy
+# because that is the assertion -- an EFP2 interaction must not depend on how the
+# fragments are placed.
+PRESERVED_TESTS = [
+    {
+        "name": "EFP2 water dimer 6-31G* (CPU)",
+        "input": "inputs/cpu/mqc/efp/water_dimer_efp.json",
+        "expected_energy": 0.0030795778,
+        "type": "unfragmented",
+    },
+    {
+        "name": "EFP2 water dimer 6-31G* arbitrarily oriented (CPU)",
+        "input": "inputs/cpu/mqc/efp/water_dimer_efp_turned.json",
+        "expected_energy": 0.0030795778,
+        "type": "unfragmented",
+    },
+]
+
+
 MANUAL_CASES = [
     {
         "stem": "cpu_h2o_3-21g_ormas_cisd",
@@ -2526,6 +2562,16 @@ def main():
         tests.append(entry)
         print(f"{case['name']}: transcribed reference "
               f"E={case['expected_energy']:.12f}", flush=True)
+
+    # The entries for hand-maintained decks this script neither generates nor
+    # writes. Emitted before the read-back further up would have had a chance to
+    # supply them, so a declared entry is what lands even if the old manifest
+    # still carried a stale copy.
+    for entry in PRESERVED_TESTS:
+        if entry["input"] not in {t["input"] for t in tests}:
+            tests.append(dict(entry))
+            print(f"{entry['name']}: transcribed reference "
+                  f"E={entry['expected_energy']:.10f}", flush=True)
 
     manifest = {"description": DESCRIPTION, "tolerance": TOLERANCE, "tests": tests}
     if args.dry_run:

--- a/validation/validation_tests_cpu.json
+++ b/validation/validation_tests_cpu.json
@@ -946,20 +946,6 @@
             "type": "unfragmented"
         },
         {
-            "name": "RHF with Fukui indices (chelpg) H2O 6-31g (CPU)",
-            "input": "inputs/cpu/mqc/fukui/cpu_water_6-31g_fukui_chelpg.json",
-            "expected_energy": -75.984779843967,
-            "type": "unfragmented",
-            "reference_note": "PySCF has no Fukui indices, so the checked energy is the ordinary RHF one. What this case covers is that the run completes: two SCFs on the ions and a sum rule that aborts rather than printing something wrong. The indices themselves are pinned in test/test_mqc_fukui.f90."
-        },
-        {
-            "name": "RHF with Fukui indices (mulliken) H2O 6-31g (CPU)",
-            "input": "inputs/cpu/mqc/fukui/cpu_water_6-31g_fukui_mulliken.json",
-            "expected_energy": -75.984779843967,
-            "type": "unfragmented",
-            "reference_note": "PySCF has no Fukui indices, so the checked energy is the ordinary RHF one. What this case covers is that the run completes: two SCFs on the ions and a sum rule that aborts rather than printing something wrong. The indices themselves are pinned in test/test_mqc_fukui.f90."
-        },
-        {
             "name": "RHF gradient H2O sto-3g (CPU)",
             "input": "inputs/cpu/mqc/gradient/cpu_water_sto-3g_grad.json",
             "expected_energy": -74.962005712275,
@@ -2077,6 +2063,20 @@
             "type": "unfragmented"
         },
         {
+            "name": "RHF with Fukui indices (chelpg) H2O 6-31g (CPU)",
+            "input": "inputs/cpu/mqc/fukui/cpu_water_6-31g_fukui_chelpg.json",
+            "expected_energy": -75.984779843967,
+            "type": "unfragmented",
+            "reference_note": "PySCF has no Fukui indices, so the checked energy is the ordinary RHF one. What this case covers is that the run completes: two SCFs on the ions and a sum rule that aborts rather than printing something wrong. The indices themselves are pinned in test/test_mqc_fukui.f90."
+        },
+        {
+            "name": "RHF with Fukui indices (mulliken) H2O 6-31g (CPU)",
+            "input": "inputs/cpu/mqc/fukui/cpu_water_6-31g_fukui_mulliken.json",
+            "expected_energy": -75.984779843967,
+            "type": "unfragmented",
+            "reference_note": "PySCF has no Fukui indices, so the checked energy is the ordinary RHF one. What this case covers is that the run completes: two SCFs on the ions and a sum rule that aborts rather than printing something wrong. The indices themselves are pinned in test/test_mqc_fukui.f90."
+        },
+        {
             "name": "FMO2 water trimer 6-31g (CPU)",
             "input": "inputs/cpu/mqc/fmo/fmo_water3.json",
             "expected_energy": -227.9705411684,
@@ -2113,6 +2113,18 @@
             "expected_energy": -109.019592219941,
             "type": "unfragmented",
             "tolerance": 1e-08
+        },
+        {
+            "name": "EFP2 water dimer 6-31G* (CPU)",
+            "input": "inputs/cpu/mqc/efp/water_dimer_efp.json",
+            "expected_energy": 0.0030795778,
+            "type": "unfragmented"
+        },
+        {
+            "name": "EFP2 water dimer 6-31G* arbitrarily oriented (CPU)",
+            "input": "inputs/cpu/mqc/efp/water_dimer_efp_turned.json",
+            "expected_energy": 0.0030795778,
+            "type": "unfragmented"
         }
     ]
 }


### PR DESCRIPTION
They have not run since somewhere between 279e9cf74 and 98877bcbb. The decks stayed on disk and HAND_MAINTAINED kept them there, so nothing looked wrong -- `validation/inputs/cpu/mqc/efp/` has held two decks that the suite has not mentioned for weeks. Coverage that looks present and does not run.

Neither existing mechanism could bring them back. HAND_MAINTAINED spares the deck, not the entry. The read-back added with the Fukui cases re-emits whatever a previous manifest carried, which is the right guard against losing an entry and no help at all once one is lost -- there was nothing left to read. So the entries are declared here instead, which makes them reproducible from this script rather than from the manifest's own history, the same property MANUAL_CASES has.

The reference is GAMESS. EFP2 sums five terms against a fragment potential and PySCF has no EFP, so this script cannot generate one. Checked rather than trusted to git history before restoring it -- the dimer comes out at .003079577849 against the recovered 0.0030795778:

  electrostatics      .004959638170
  polarization       -.000218123463
  exchange repulsion -.001172850348
  dispersion         -.000570869705
  charge transfer     .000081783196

The turned deck gives the same total to every digit, which is what that case is for: an EFP2 interaction must not depend on how the fragments are placed.

Regenerating adds exactly these two and moves no other reference. Four other hand-maintained decks have no manifest entry either -- peptide46 and the three makefp ones -- and those are correct as they are: MAKEFP writes a fragment potential rather than returning an energy, so there is nothing to compare, and none of them has ever been in the manifest.