### PR TITLE
enable Fukui on DFT exceptn on dh

### DIFF
--- a/backends/libcint/mqc_libcint_bridge.f90
+++ b/backends/libcint/mqc_libcint_bridge.f90
@@ -861,10 +861,14 @@ contains
             type(fukui_result_t) :: fukui
             type(error_t) :: fukui_error
 
+            ! The functional by NAME, not this routine's `xc`: that context
+            ! was built spin-unpolarised for the closed-shell neutral and the
+            ! ions are doublets. fukui_indices builds its own polarised one.
             call fukui_indices(mol, fragment%nelec, fragment%multiplicity, scf%density, &
                                scf%energy, settings%fukui_population, settings%max_iter, &
                                settings%energy_tol, settings%density_tol, fukui, &
-                               fukui_error)
+                               fukui_error, functional=trim(settings%functional), &
+                               grid_level=settings%grid_level)
             if (fukui_error%has_error()) then
                call logger%warning("  the Fukui analysis could not run: "// &
                                    fukui_error%get_message())

--- a/backends/libcint/mqc_libcint_fukui.f90
+++ b/backends/libcint/mqc_libcint_fukui.f90
@@ -407,10 +407,9 @@ contains
             call logger%warning("  concluding anything from this table.")
          else
             call logger%warning("")
-            call logger%warning("  A larger basis, or a finer CHELPG grid, usually "// &
-                                "shrinks it. If it")
-            call logger%warning("  survives both, the atom simply carries little of "// &
-                                "this channel.")
+            call logger%warning("  A larger basis usually shrinks it. If it survives "// &
+                                "that, the atom")
+            call logger%warning("  simply carries little of this channel.")
          end if
          call logger%warning("")
       end if

--- a/backends/libcint/mqc_libcint_fukui.f90
+++ b/backends/libcint/mqc_libcint_fukui.f90
@@ -51,6 +51,15 @@ module mqc_libcint_fukui
       real(dp), allocatable :: f_plus(:)    !! Nucleophilic attack: where charge arrives
       real(dp), allocatable :: f_minus(:)   !! Electrophilic attack: where charge leaves
       real(dp), allocatable :: f_zero(:)    !! Radical attack, the average of the two
+         !! **A NEGATIVE ENTRY IN ANY OF THESE IS SPURIOUS.** The exact Fukui
+         !! function is a derivative of the density with respect to electron
+         !! count and cannot be negative -- no site gives up charge because the
+         !! molecule gained an electron. Negative condensed values come from
+         !! partitioning a continuous density onto atoms, where two states are
+         !! fitted independently and disagree by more than the one electron
+         !! that moved between them. Rank sites by these; do not quote the
+         !! numbers, and treat a small negative as "not reactive in this
+         !! channel" rather than as anything about repulsion.
       real(dp), allocatable :: dual(:)
          !! `f+ - f-`. Positive where a site prefers to accept and negative
          !! where it prefers to donate, so one column separates electrophilic
@@ -366,13 +375,44 @@ contains
       ! diffuse functions -- a function centred on one atom reaching over
       ! another gets charged to the wrong one.
       if (any_negative) then
-         call logger%warning("  some indices came out negative, which is the "// &
-                             "population analysis struggling rather than a site that "// &
-                             "repels charge")
+         call logger%warning("")
+         call logger%warning("  NEGATIVE INDICES ABOVE ARE SPURIOUS -- take them with a "// &
+                             "grain of salt.")
+         call logger%warning("")
+         call logger%warning("  f+ and f- are derivatives of a density with respect to "// &
+                             "electron count, so")
+         call logger%warning("  the exact quantities cannot be negative: no site "// &
+                             "releases charge when the")
+         call logger%warning("  molecule gains an electron. A negative value is an "// &
+                             "artefact of dividing a")
+         call logger%warning("  continuous density among atoms, not a chemical "// &
+                             "finding, and it appears")
+         call logger%warning("  where two states' charges are fitted independently and "// &
+                             "disagree by more")
+         call logger%warning("  than the electron being moved.")
+         call logger%warning("")
+         call logger%warning("  Read the RANKING, not the number: a site with a small "// &
+                             "negative index is")
+         call logger%warning("  unreactive in that channel, not anti-reactive. Do not "// &
+                             "quote the value,")
+         call logger%warning("  and do not build a further descriptor on it -- f0 and "// &
+                             "dual inherit the")
+         call logger%warning("  artefact from whichever index carried it.")
          if (trim(res%scheme) == "mulliken") then
-            call logger%warning("  Mulliken is especially prone to this; chelpg is "// &
-                                "the default for that reason")
+            call logger%warning("")
+            call logger%warning("  Mulliken is especially prone to this, being basis-set "// &
+                                "dependent; chelpg")
+            call logger%warning("  is the default for that reason and is worth rerunning "// &
+                                "with before")
+            call logger%warning("  concluding anything from this table.")
+         else
+            call logger%warning("")
+            call logger%warning("  A larger basis, or a finer CHELPG grid, usually "// &
+                                "shrinks it. If it")
+            call logger%warning("  survives both, the atom simply carries little of "// &
+                                "this channel.")
          end if
+         call logger%warning("")
       end if
 
       ! The direct test rather than a guess from the basis-set name: if the

--- a/backends/libcint/mqc_libcint_fukui.f90
+++ b/backends/libcint/mqc_libcint_fukui.f90
@@ -31,6 +31,7 @@ module mqc_libcint_fukui
    use mqc_libcint_integrals, only: libcint_molecule_t
    use mqc_libcint_rhf, only: rhf_result_t, run_libcint_uhf
    use mqc_libcint_charges, only: mulliken_charges, chelpg_charges
+   use mqc_libcint_xc, only: xc_context_t, xc_context_create, xc_available
    implicit none
    private
 
@@ -73,16 +74,35 @@ module mqc_libcint_fukui
          !! diffuse functions moves its affinity from -0.19 to -0.04 hartree
          !! and never makes it positive, because H2O- does not exist.
       character(len=16) :: scheme = "chelpg"
+      character(len=:), allocatable :: functional
+         !! The functional the three states were computed with, empty for
+         !! Hartree-Fock. Recorded because an IP of 0.4 hartree means nothing
+         !! without it: the number is a difference of total energies and those
+         !! are not comparable across methods.
    end type fukui_result_t
 
 contains
 
    subroutine fukui_indices(mol, nelec, multiplicity, neutral_density, neutral_energy, &
-                            scheme, max_iter, energy_tol, density_tol, res, error)
+                            scheme, max_iter, energy_tol, density_tol, res, error, &
+                            functional, grid_level)
       !! Run the ions and condense the difference onto atoms
       !!
       !! The neutral density is handed in rather than recomputed, since the
       !! caller has just converged it.
+      !!
+      !! KOHN-SHAM IONS NEED THEIR OWN CONTEXT, which is why this takes a
+      !! functional NAME and not the caller's `xc_context_t`. libxc fixes the
+      !! spin channel when a functional is initialised, and the caller's
+      !! context was built for the closed-shell neutral, so it is
+      !! spin-unpolarised. Handing it to the unrestricted ions does not
+      !! misread it -- `xc_add_potential` refuses it outright -- but the
+      !! refusal would arrive as a failed analysis rather than as a design.
+      !! One polarised context is built here and shared by both doublets,
+      !! which see the same grid as each other by construction.
+      !!
+      !! Absent or empty `functional` is Hartree-Fock, which is what this
+      !! routine did before it could do anything else.
       type(libcint_molecule_t), intent(in) :: mol
       integer, intent(in) :: nelec
       integer, intent(in) :: multiplicity
@@ -93,10 +113,15 @@ contains
       real(dp), intent(in) :: energy_tol, density_tol
       type(fukui_result_t), intent(out) :: res
       type(error_t), intent(inout) :: error
+      character(len=*), intent(in), optional :: functional
+      integer, intent(in), optional :: grid_level
 
       type(rhf_result_t) :: anion, cation
       real(dp), allocatable :: overlap(:, :), total(:, :)
       integer :: natm
+      type(xc_context_t), target :: xc_ions
+      type(xc_context_t), pointer :: xc_arg
+      logical :: kohn_sham
 
       if (error%has_error()) return
 
@@ -114,6 +139,44 @@ contains
          return
       end if
 
+      kohn_sham = .false.
+      if (present(functional)) kohn_sham = len_trim(functional) > 0
+      res%functional = ""
+      xc_arg => null()
+
+      if (kohn_sham) then
+         if (.not. xc_available()) then
+            call error%set(ERROR_VALIDATION, "the Fukui ions were asked for with '"// &
+                           trim(functional)//"' but this build has no libxc.")
+            return
+         end if
+         ! Spin-polarised, because both ions are doublets. See the note on this
+         ! routine: this is the whole reason the functional arrives by name.
+         call xc_context_create(mol, trim(functional), xc_ions, error, &
+                                level=grid_level, polarized=.true.)
+         if (error%has_error()) then
+            call error%add_context("Fukui indices: the ions' functional")
+            return
+         end if
+         ! A double hybrid's perturbative term needs an unrestricted MP2, which
+         ! the CPU path does not have. Refused rather than run, because running
+         ! it would not fail: the Kohn-Sham half is correct and unrestricted, so
+         ! the ions would come back converged and short by the PT2 term. IP and
+         ! EA are differences of total energies, so a term missing from two of
+         ! the three states lands directly in every descriptor here.
+         if (xc_ions%pt2_fraction /= 0.0_dp) then
+            call error%set(ERROR_VALIDATION, "'"//trim(functional)//"' is a double "// &
+                           "hybrid, and the Fukui ions are open shell. Its perturbative "// &
+                           "term needs an unrestricted MP2 the CPU path does not have, "// &
+                           "so the ions would converge with the Kohn-Sham part alone and "// &
+                           "the IP and EA would be wrong by that term. Use a functional "// &
+                           "without a perturbative term.")
+            return
+         end if
+         xc_arg => xc_ions
+         res%functional = trim(functional)
+      end if
+
       natm = mol%natm
       res%scheme = scheme
       res%energy_neutral = neutral_energy
@@ -125,7 +188,7 @@ contains
       ! The anion. One more electron, and a doublet because the neutral was
       ! closed shell.
       call run_libcint_uhf(mol, nelec + 1, 2, max_iter, energy_tol, density_tol, &
-                           .false., anion, error)
+                           .false., anion, error, xc=xc_arg)
       if (error%has_error()) then
          call error%add_context("Fukui indices: the anion")
          return
@@ -145,7 +208,7 @@ contains
 
       ! The cation.
       call run_libcint_uhf(mol, nelec - 1, 2, max_iter, energy_tol, density_tol, &
-                           .false., cation, error)
+                           .false., cation, error, xc=xc_arg)
       if (error%has_error()) then
          call error%add_context("Fukui indices: the cation")
          return
@@ -246,6 +309,18 @@ contains
 
       natm = size(res%f_plus)
       call logger%info("")
+      ! The method belongs in the header for the same reason the scheme does:
+      ! IP, EA and hardness are differences of total energies, so they are not
+      ! comparable across methods and a table that does not say which one it
+      ! used invites exactly that comparison.
+      if (allocated(res%functional)) then
+         if (len_trim(res%functional) > 0) then
+            call logger%info("  Fukui ions: unrestricted Kohn-Sham, "// &
+                             trim(res%functional))
+         else
+            call logger%info("  Fukui ions: unrestricted Hartree-Fock")
+         end if
+      end if
       call logger%info("  ==== Fukui indices ("//trim(res%scheme)//") "// &
                        "=================================")
       call logger%info("")

--- a/mqc_docs/source/input_files.rst
+++ b/mqc_docs/source/input_files.rst
@@ -820,7 +820,7 @@ The driver stays ``"energy"``.
   .. code-block:: json
 
      "properties": {
-       "fukui": {"population": "chelpg"}
+       "fukui": {}
      }
 
   Condensed Fukui indices, by difference in the electron count: the molecule is
@@ -837,8 +837,15 @@ The driver stays ``"energy"``.
   the relaxation of every other orbital in response to the added charge -- which
   on a polar molecule is most of the answer.
 
-  ``population`` is required and chooses how the density difference is
-  condensed onto atoms:
+  Works with ``hf`` and with ``dft``. Under DFT the two ions are run as
+  unrestricted Kohn-Sham with the same functional as the neutral, so the three
+  energies are comparable and the ionisation potential and electron affinity
+  mean what they say. Double hybrids are refused: their perturbative term needs
+  an unrestricted MP2 the CPU path does not have, and running anyway would
+  return converged ions that are short by exactly that term.
+
+  ``population`` is optional and defaults to ``chelpg``. It chooses how the
+  density difference is condensed onto atoms:
 
   - ``chelpg`` -- charges fitted to the molecule's own electrostatic potential.
     The default choice, and the better behaved one.
@@ -846,9 +853,31 @@ The driver stays ``"energy"``.
     the literature used.** It divides the overlap between two atoms straight
     down the middle regardless of what the atoms are, so it is sensitive to the
     basis set in a way that has nothing to do with chemistry, and it produces
-    negative indices more readily. Negative values are reported rather than
-    hidden: they are the population analysis failing to divide the density
-    sensibly, not a site that repels electrons.
+    negative indices more readily. On formaldehyde it spreads ``f+`` as
+    0.27/0.28/0.23/0.23 over the four atoms, ranking nothing, where CHELPG puts
+    0.59 on the carbonyl carbon.
+
+  .. warning::
+
+     **Negative indices are spurious. Take them with a grain of salt.**
+
+     The exact Fukui function is a derivative of the density with respect to
+     electron count, so ``f+`` and ``f-`` cannot be negative: no site gives up
+     charge because the molecule gained an electron. A negative condensed value
+     is an artefact of dividing a continuous density among atoms -- the two
+     states are fitted independently, and they can disagree by more than the
+     one electron that moved between them.
+
+     They are printed rather than hidden, with a warning, because silently
+     clamping them would hide the fact that the partitioning struggled. Read
+     the *ranking* and not the number: a small negative index means the site is
+     unreactive in that channel, not that it repels charge. Do not quote the
+     value, and do not build anything further on it -- ``f0`` and the dual
+     descriptor inherit the artefact from whichever index carried it.
+
+     A larger basis or a finer CHELPG grid usually shrinks it. If it survives
+     both, that atom simply carries very little of that channel. If you saw it
+     under ``mulliken``, rerun with ``chelpg`` before concluding anything.
 
   Two limits. Only a closed-shell neutral is accepted, so that both ions are
   doublets; anything else is refused rather than having its multiplicities

--- a/mqc_docs/source/input_files.rst
+++ b/mqc_docs/source/input_files.rst
@@ -875,9 +875,26 @@ The driver stays ``"energy"``.
      value, and do not build anything further on it -- ``f0`` and the dual
      descriptor inherit the artefact from whichever index carried it.
 
-     A larger basis or a finer CHELPG grid usually shrinks it. If it survives
-     both, that atom simply carries very little of that channel. If you saw it
-     under ``mulliken``, rerun with ``chelpg`` before concluding anything.
+     A larger basis usually shrinks it. If it survives that, the atom simply
+     carries very little of that channel. If you saw it under ``mulliken``,
+     rerun with ``chelpg`` before concluding anything. The CHELPG fitting grid
+     is not exposed as a deck setting, so it is not a knob available here.
+
+  **Use a finer integration grid than you would for the energy.** ``grid_level``
+  defaults to 3, which is right for a total energy but marginal here: the Fukui
+  descriptors are *differences* between three separately converged states, so
+  the quadrature error does not cancel the way it does within one SCF. On
+  formaldehyde in 6-31G, ``m06-l`` at level 3 gives an ionisation potential
+  2.7e-5 hartree away from the converged value; level 4 brings that to 4e-6 and
+  level 5 reaches it, with level 6 no different. **Level 4 or 5 is the
+  recommendation**, and it costs three grids rather than one because all three
+  states are integrated.
+
+  How much this matters depends on the functional rather than on its cost. The
+  LDA, GGA and hybrid functionals are already within about 1e-6 at level 3;
+  what moves are the meta-GGAs, which sample the kinetic-energy density and are
+  steeper on the grid -- ``m06-l`` is the most sensitive of the set -- and
+  ``wb97x``, whose range separation adds its own grid dependence.
 
   Two limits. Only a closed-shell neutral is accepted, so that both ions are
   doublets; anything else is refused rather than having its multiplicities

--- a/mqc_docs/source/json_output.rst
+++ b/mqc_docs/source/json_output.rst
@@ -93,6 +93,25 @@ what the caller is doing and which index to rank on depends on the reaction:
 because the output payload does not carry them -- a consumer that read the
 geometry already knows which atom is which.
 
+The ions are run with the deck's own method: Hartree-Fock for ``hf``, and
+unrestricted Kohn-Sham with the neutral's functional for ``dft``. The energies
+here are therefore differences of that method's total energies and are not
+comparable with a run that used another one -- nothing in this payload records
+which, because the deck that produced it does.
+
+.. warning::
+
+   **A negative ``f_plus`` or ``f_minus`` is spurious** -- the example above
+   has one. The exact Fukui function cannot be negative, so a negative
+   condensed value is an artefact of partitioning a continuous density onto
+   atoms, not a site that repels charge.
+
+   A consumer should rank on these, not quote them, and should treat a small
+   negative as "unreactive in that channel". ``f_zero`` and ``dual`` are
+   derived, so they inherit the artefact from whichever index carried it. A
+   script that sorts ascending on ``f_minus`` to find the least reactive site
+   will find the most artefactual one instead.
+
 **Check ``anion_bound`` before using ``f_plus``.** When it is false the anion
 came out above the neutral, nothing bound the added electron, and that column
 describes whatever orbital the basis had left over. Nothing about the values

--- a/src/io/mqc_json_config_reader.f90
+++ b/src/io/mqc_json_config_reader.f90
@@ -150,7 +150,7 @@ contains
 
       character(len=:), allocatable :: text
       integer :: n_mol, imol
-      logical :: found, settings
+      logical :: found, settings, found_fukui
       logical :: backend_named
 
       ! The two defaults that are not declared on the type itself.
@@ -197,8 +197,17 @@ contains
       call optional_string(json, "model.functional", config%functional)
 
       ! ---- properties ------------------------------------------------------
-      call optional_string(json, "properties.fukui.population", &
-                           config%fukui_population)
+      ! The `fukui` OBJECT is what asks for the analysis; `population` only
+      ! says which charges. Default it here rather than downstream, so that the
+      ! scheme the run used is a value in the config -- and therefore in the
+      ! report and the JSON -- rather than a default buried in whichever
+      ! routine happened to look last.
+      call json%info("properties.fukui", found=found_fukui)
+      if (found_fukui) then
+         config%fukui_population = "chelpg"
+         call optional_string(json, "properties.fukui.population", &
+                              config%fukui_population)
+      end if
       call optional_string(json, "properties.bonding_analysis.type", &
                            config%bonding_analysis)
       call optional_real(json, "properties.bonding_analysis.energy_threshold", &

--- a/src/io/mqc_json_schema.f90
+++ b/src/io/mqc_json_schema.f90
@@ -236,13 +236,17 @@ contains
    function fukui_keys() result(keys)
       !! Settings for the Fukui index analysis
       !!
-      !! `population` is required rather than defaulted, because the object
-      !! being present is what asks for the analysis and because the scheme
-      !! changes the numbers: a choice that large should be written down in the
-      !! deck rather than inherited silently.
+      !! `population` defaults to CHELPG. It was required rather than
+      !! defaulted, on the argument that a choice which changes the numbers
+      !! should be written down rather than inherited -- but the two schemes
+      !! are not equal candidates. CHELPG fits the electrostatic potential and
+      !! is what a condensed Fukui index is normally reported from; Mulliken is
+      !! basis-set dependent to the point of changing which site ranks first.
+      !! Defaulting to the better one and naming the other is more useful than
+      !! refusing to choose, and the scheme is echoed in the report and the
+      !! JSON either way, so nothing is inherited silently.
       type(key_set_t) :: keys
       call allow(keys, "population")
-      call require(keys, "population")
    end function fukui_keys
 
    function bonding_analysis_keys() result(keys)

--- a/src/methods/mqc_method_dft.F90
+++ b/src/methods/mqc_method_dft.F90
@@ -181,6 +181,12 @@ contains
       settings%angular_points = this%options%angular_points
       settings%grid_level = this%options%grid_level
       settings%pcm = this%options%pcm
+      ! Where the molecule reacts. Absent here until now, so a DFT deck asking
+      ! for `properties.fukui` got a normal DFT run and no analysis, with no
+      ! error to say why: the bridge gates on this being allocated.
+      if (allocated(this%options%properties%fukui_population)) then
+         settings%fukui_population = this%options%properties%fukui_population
+      end if
       settings%bonding_analysis = this%options%properties%bonding_analysis
       settings%bonding_threshold = this%options%properties%bonding_threshold
       ! Set unconditionally, and deliberately not guarded on the backend. cuEST

--- a/tools/cpu_validation/gen_cpu_validation.py
+++ b/tools/cpu_validation/gen_cpu_validation.py
@@ -307,6 +307,14 @@ HAND_MAINTAINED = {
     # exercised the path end to end.
     "cpu/mqc/fukui/cpu_water_6-31g_fukui_chelpg.json",
     "cpu/mqc/fukui/cpu_water_6-31g_fukui_mulliken.json",
+    # The same analysis on Kohn-Sham ions. Here for a reason the other two do
+    # not cover: the ions are doublets, so they need a spin-POLARISED
+    # functional, while the closed-shell neutral's context is unpolarised.
+    # Handing the wrong one across is refused rather than misread, which turns
+    # into a skipped analysis and a run that still exits zero -- so a deck that
+    # completes with a Fukui table is the assertion. It also omits
+    # `population`, which pins the CHELPG default.
+    "cpu/mqc/fukui/cpu_water_6-31g_pbe_fukui.json",
     # FMO2/FMO3 and EE-MBE. This script generates single-determinant references
     # from PySCF, which has no FMO, so it cannot produce these and would sweep the
     # decks away while leaving their manifest entries pointing at nothing. The two

--- a/validation/inputs/cpu/mqc/fukui/cpu_water_6-31g_pbe_fukui.json
+++ b/validation/inputs/cpu/mqc/fukui/cpu_water_6-31g_pbe_fukui.json
@@ -21,7 +21,7 @@
             "tolerance": 1e-10
         },
         "dft": {
-            "grid_level": 3
+            "grid_level": 4
         }
     },
     "system": {

--- a/validation/inputs/cpu/mqc/fukui/cpu_water_6-31g_pbe_fukui.json
+++ b/validation/inputs/cpu/mqc/fukui/cpu_water_6-31g_pbe_fukui.json
@@ -1,0 +1,36 @@
+{
+    "schema": {
+        "name": "mqc-frag",
+        "version": "1.0"
+    },
+    "molecules": [
+        {
+            "xyz": "../../../sample_inputs/w1.xyz",
+            "molecular_charge": 0,
+            "molecular_multiplicity": 1
+        }
+    ],
+    "model": {
+        "method": "dft",
+        "basis": "6-31g",
+        "functional": "pbe"
+    },
+    "keywords": {
+        "scf": {
+            "maxiter": 100,
+            "tolerance": 1e-10
+        },
+        "dft": {
+            "grid_level": 3
+        }
+    },
+    "system": {
+        "logger": {
+            "level": "Verbose"
+        }
+    },
+    "driver": "Energy",
+    "properties": {
+        "fukui": {}
+    }
+}

--- a/validation/validation_tests_cpu.json
+++ b/validation/validation_tests_cpu.json
@@ -2077,6 +2077,14 @@
             "reference_note": "PySCF has no Fukui indices, so the checked energy is the ordinary RHF one. What this case covers is that the run completes: two SCFs on the ions and a sum rule that aborts rather than printing something wrong. The indices themselves are pinned in test/test_mqc_fukui.f90."
         },
         {
+            "name": "KS PBE with Fukui indices (chelpg default) H2O 6-31g grid 4 (CPU)",
+            "input": "inputs/cpu/mqc/fukui/cpu_water_6-31g_pbe_fukui.json",
+            "expected_energy": -76.298635406403,
+            "tolerance": 1e-07,
+            "type": "unfragmented",
+            "reference_note": "PySCF has no Fukui indices, so the checked energy is the ordinary Kohn-Sham one. What this case covers is that the run completes with a Fukui table: the two ions are doublets and need a spin-POLARISED functional while the neutral's context is unpolarised, and handing the wrong one across is refused rather than misread -- which would surface as a skipped analysis and a run that still exits zero. It also omits `population`, so it pins the CHELPG default. Grid level 4 rather than 3, because the Fukui descriptors are differences between three separately converged states and the quadrature error does not cancel the way it does within one SCF. The tolerance is 1e-7 rather than the manifest's 1e-9: both codes build a level-4 grid from the same tables but prune it differently, which is 3.1e-8 on this molecule and has nothing to do with the analysis being tested."
+        },
+        {
             "name": "FMO2 water trimer 6-31g (CPU)",
             "input": "inputs/cpu/mqc/fmo/fmo_water3.json",
             "expected_energy": -227.9705411684,


### PR DESCRIPTION
Recommend a finer grid for Fukui, and register the deck it needed

THE GRID. `grid_level` defaults to 3, which is right for a total energy and
marginal for these descriptors: they are differences between three separately
converged states, so the quadrature error does not cancel the way it does
within one SCF. Measured on formaldehyde/6-31G rather than asserted --
`m06-l`'s ionisation potential is 2.7e-5 hartree off at level 3, 4e-6 at level
4, converged at 5, and unchanged at 6. Level 4 or 5 is the recommendation, and
it costs three grids rather than one.

Which functionals care is not the same as which are expensive. LDA, GGA and the
hybrids are already within ~1e-6 at level 3; what moves are the meta-GGAs,
which sample the kinetic energy density, and wb97x, whose range separation adds
its own grid dependence. All nine non-double-hybrids were checked against PySCF
delta-SCF: every one agrees to 1e-6 or better, m06-l worst at 2.7e-5 for the
reason above. The three double hybrids refuse, as intended.

A CORRECTION. The negative-index warning suggested trying a finer CHELPG grid.
That grid's spacing is an argument to chelpg_charges and is not exposed in any
deck, so it was advice nobody could act on. Removed from the warning and from
the docs; a larger basis is the remedy that remains.

THE DECK. The validation case added with the previous commit was listed in
gen_cpu_validation's HAND_MAINTAINED set but had no manifest entry, so it would
not have run at all. Entry added, at grid level 4 to match the recommendation.

Its tolerance is 1e-7 rather than the manifest's 1e-9, and that is a real
difference rather than a loosened one: both codes build a level-4 grid from the
same tables but prune it differently, worth 3.1e-8 on this molecule. Nine
existing entries already carry a per-case tolerance for comparable reasons. The
reference is PySCF through the generator's own pyscf_rks, so it reads exponents
from basis_sets/ as every other entry does -- using PySCF's internal 6-31G
instead shifts it by ~1e-8, which the manifest's own description warns about
and which I had been doing while spot-checking.

93 tests pass; the deck reproduces its entry to 3.1e-8.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>