### PR TITLE
ump2 and urimp2 to enable dh fukui 

### DIFF
--- a/backends/libcint/mqc_libcint_bridge.f90
+++ b/backends/libcint/mqc_libcint_bridge.f90
@@ -35,7 +35,8 @@ module mqc_libcint_bridge
    use mqc_libcint_hessian, only: rhf_hessian, hessian_to_matrix
    use mqc_libcint_mp2_gradient, only: libcint_mp2_gradient
    use mqc_libcint_ri_mp2_gradient, only: libcint_ri_mp2_gradient
-   use mqc_libcint_mp2, only: mp2_result_t, run_libcint_mp2, run_libcint_ri_mp2
+   use mqc_libcint_mp2, only: mp2_result_t, run_libcint_mp2, run_libcint_ri_mp2, &
+                              run_libcint_ump2, run_libcint_uri_mp2
    use mqc_libcint_cc, only: cc_result_t, run_libcint_ccsd
    use mqc_libcint_rcc, only: rcc_result_t, run_libcint_rccsd
    use mqc_libcint_bonding, only: run_quao_analysis, bonding_analysis_kind, &
@@ -659,19 +660,6 @@ contains
          ! themselves and return a plausible number. The Kohn-Sham half of the
          ! functional is unrestricted and correct, which is exactly what makes the
          ! total convincing.
-         if (unrestricted .and. xc%pt2_fraction /= 0.0_dp) then
-            call result%error%set(ERROR_VALIDATION, "'"//trim(settings%functional)// &
-                                  "' is a double hybrid and its perturbative term needs "// &
-                                  "an unrestricted MP2, which the CPU path does not have. "// &
-                                  "The Kohn-Sham part alone would be ~65 mHartree short, "// &
-                                  "so this is refused rather than reported. Run a "// &
-                                  "closed-shell system, or a functional without a "// &
-                                  "perturbative term.")
-            result%has_error = .true.
-            call xc%destroy()
-            call mol%destroy()
-            return
-         end if
          if (settings%verbose) then
             write (line, "(a,a,a,i0)") "  functional: ", trim(settings%functional), ", grid level ", settings%grid_level
             call logger%info(trim(line))
@@ -860,15 +848,63 @@ contains
             use mqc_libcint_fukui, only: fukui_result_t, fukui_indices, print_fukui_report
             type(fukui_result_t) :: fukui
             type(error_t) :: fukui_error
+            integer :: fukui_frozen
+            real(dp) :: fukui_pt2
+            type(libcint_molecule_t), target :: fukui_aux
+            type(libcint_molecule_t), pointer :: fukui_aux_arg
+            logical :: fukui_fitted
+
+            ! Zero unless this is a Kohn-Sham run with a perturbative term.
+            ! `xc` is only built when kohn_sham, so reading its fraction
+            ! unconditionally would read an uninitialised context on a
+            ! Hartree-Fock run.
+            fukui_pt2 = 0.0_dp
+            if (kohn_sham) fukui_pt2 = xc%pt2_fraction
+
+            ! Fitted exactly when the energy's own PT2 term is fitted. The
+            ! alternative -- Fukui always exact, the energy fitted when asked --
+            ! would print an IP beside a total energy that used a different
+            ! correlation treatment, and the difference between them would look
+            ! like a property of the molecule.
+            fukui_fitted = fukui_pt2 /= 0.0_dp .and. settings%aux_basis_named
+            if (fukui_fitted) then
+               call correlation_aux_basis(settings, fragment, symbols, fukui_aux, fukui_error)
+               if (fukui_error%has_error()) then
+                  call logger%warning("  the Fukui analysis could not build its "// &
+                                      "auxiliary basis: "//fukui_error%get_message())
+                  fukui_fitted = .false.
+                  call fukui_error%clear()
+               end if
+            end if
+            ! Absent rather than empty when unfitted. A disassociated pointer
+            ! passed to an optional dummy is not present, which is the same
+            ! idiom `xc_arg` uses a few hundred lines up.
+            fukui_aux_arg => null()
+            if (fukui_fitted) fukui_aux_arg => fukui_aux
 
             ! The functional by NAME, not this routine's `xc`: that context
             ! was built spin-unpolarised for the closed-shell neutral and the
             ! ions are doublets. fukui_indices builds its own polarised one.
+            ! A double hybrid needs the orbitals as well as the density: its
+            ! perturbative term is evaluated for all three states inside, so
+            ! that the neutral's comes from the same code path the ions' do.
+            ! `dh_frozen` is resolved the same way the energy's PT2 resolves
+            ! it, a few hundred lines below -- a Fukui run that froze a
+            ! different core than the energy would report an IP that did not
+            ! match the numbers beside it.
+            fukui_frozen = settings%n_frozen_core
+            if (fukui_frozen < 0) fukui_frozen = core_orbital_count(fragment%element_numbers)
+            if (.not. settings%freeze_core) fukui_frozen = 0
             call fukui_indices(mol, fragment%nelec, fragment%multiplicity, scf%density, &
                                scf%energy, settings%fukui_population, settings%max_iter, &
                                settings%energy_tol, settings%density_tol, fukui, &
                                fukui_error, functional=trim(settings%functional), &
-                               grid_level=settings%grid_level)
+                               grid_level=settings%grid_level, &
+                               pt2_fraction=fukui_pt2, &
+                               neutral_orbitals=scf%orbitals, &
+                               neutral_orbital_energies=scf%orbital_energies, &
+                               n_frozen=fukui_frozen, aux=fukui_aux_arg)
+            if (fukui_fitted) call fukui_aux%destroy()
             if (fukui_error%has_error()) then
                call logger%warning("  the Fukui analysis could not run: "// &
                                    fukui_error%get_message())
@@ -1362,6 +1398,11 @@ contains
                ! an `Energy` run and a `Gradient` run of one deck reporting
                ! different energies, and left the expensive `n^4` two-particle
                ! density in the one place fitting was supposed to remove it.
+               ! Four routines rather than two, because the reference decides
+               ! the correlation treatment as much as the auxiliary basis does.
+               ! `fragment%nelec/2` is not an occupied count for an open shell,
+               ! so the unrestricted calls take the SCF's own per-spin counts
+               ! rather than deriving one.
                if (settings%aux_basis_named) then
                   call correlation_aux_basis(settings, fragment, symbols, corr_aux, error)
                   if (error%has_error()) then
@@ -1371,14 +1412,28 @@ contains
                      call mol%destroy()
                      return
                   end if
-                  call run_libcint_ri_mp2(mol, corr_aux, scf%orbitals, &
-                                          scf%orbital_energies, fragment%nelec/2, &
-                                          scf%energy, dh_mp2, error, n_frozen=dh_frozen)
+                  if (unrestricted) then
+                     call run_libcint_uri_mp2(mol, corr_aux, scf%orbitals, scf%orbitals_beta, &
+                                              scf%orbital_energies, scf%orbital_energies_beta, &
+                                              scf%n_occupied, scf%n_occupied_beta, &
+                                              scf%energy, dh_mp2, error, n_frozen=dh_frozen)
+                  else
+                     call run_libcint_ri_mp2(mol, corr_aux, scf%orbitals, &
+                                             scf%orbital_energies, fragment%nelec/2, &
+                                             scf%energy, dh_mp2, error, n_frozen=dh_frozen)
+                  end if
                   call corr_aux%destroy()
                else
-                  call run_libcint_mp2(mol, scf%orbitals, scf%orbital_energies, &
-                                       fragment%nelec/2, scf%energy, dh_mp2, error, &
-                                       n_frozen=dh_frozen)
+                  if (unrestricted) then
+                     call run_libcint_ump2(mol, scf%orbitals, scf%orbitals_beta, &
+                                           scf%orbital_energies, scf%orbital_energies_beta, &
+                                           scf%n_occupied, scf%n_occupied_beta, &
+                                           scf%energy, dh_mp2, error, n_frozen=dh_frozen)
+                  else
+                     call run_libcint_mp2(mol, scf%orbitals, scf%orbital_energies, &
+                                          fragment%nelec/2, scf%energy, dh_mp2, error, &
+                                          n_frozen=dh_frozen)
+                  end if
                end if
                if (error%has_error()) then
                   call result%error%set(ERROR_VALIDATION, "double hybrid: "// &

--- a/backends/libcint/mqc_libcint_fukui.f90
+++ b/backends/libcint/mqc_libcint_fukui.f90
@@ -32,6 +32,8 @@ module mqc_libcint_fukui
    use mqc_libcint_rhf, only: rhf_result_t, run_libcint_uhf
    use mqc_libcint_charges, only: mulliken_charges, chelpg_charges
    use mqc_libcint_xc, only: xc_context_t, xc_context_create, xc_available
+   use mqc_libcint_mp2, only: mp2_result_t, run_libcint_mp2, run_libcint_ri_mp2, &
+                              run_libcint_ump2, run_libcint_uri_mp2
    implicit none
    private
 
@@ -94,7 +96,8 @@ contains
 
    subroutine fukui_indices(mol, nelec, multiplicity, neutral_density, neutral_energy, &
                             scheme, max_iter, energy_tol, density_tol, res, error, &
-                            functional, grid_level)
+                            functional, grid_level, pt2_fraction, neutral_orbitals, &
+                            neutral_orbital_energies, aux, n_frozen)
       !! Run the ions and condense the difference onto atoms
       !!
       !! The neutral density is handed in rather than recomputed, since the
@@ -112,6 +115,24 @@ contains
       !!
       !! Absent or empty `functional` is Hartree-Fock, which is what this
       !! routine did before it could do anything else.
+      !!
+      !! DOUBLE HYBRIDS ARE COMPUTED HERE, ALL THREE OF THEM. `pt2_fraction`
+      !! non-zero means the functional carries a perturbative term, and this
+      !! routine evaluates it for the neutral as well as for the two ions --
+      !! even though the caller computes the neutral's separately for the
+      !! energy it reports.
+      !!
+      !! Recomputing it is the point rather than the cost. IP and EA are
+      !! differences of total energies, so the term has to be present in all
+      !! three or in none; taking the neutral's from the caller and the ions'
+      !! from here would make the three states depend on two code paths
+      !! agreeing about frozen cores and auxiliary bases. One restricted MP2 on
+      !! a closed shell is small beside the two unrestricted ones the ions
+      !! need, and it buys identical treatment by construction -- the same
+      !! argument that has the three states share one `libcint_molecule_t`.
+      !!
+      !! `aux` present fits the correlation, absent computes it exactly, which
+      !! is the choice the caller already made for its own PT2 term.
       type(libcint_molecule_t), intent(in) :: mol
       integer, intent(in) :: nelec
       integer, intent(in) :: multiplicity
@@ -124,13 +145,20 @@ contains
       type(error_t), intent(inout) :: error
       character(len=*), intent(in), optional :: functional
       integer, intent(in), optional :: grid_level
+      real(dp), intent(in), optional :: pt2_fraction
+      real(dp), intent(in), optional :: neutral_orbitals(:, :)
+      real(dp), intent(in), optional :: neutral_orbital_energies(:)
+      type(libcint_molecule_t), intent(in), optional :: aux
+      integer, intent(in), optional :: n_frozen
 
       type(rhf_result_t) :: anion, cation
       real(dp), allocatable :: overlap(:, :), total(:, :)
       integer :: natm
       type(xc_context_t), target :: xc_ions
       type(xc_context_t), pointer :: xc_arg
-      logical :: kohn_sham
+      logical :: kohn_sham, double_hybrid
+      real(dp) :: pt2, e_pt2_neutral, e_pt2_anion, e_pt2_cation
+      integer :: frozen
 
       if (error%has_error()) return
 
@@ -150,6 +178,14 @@ contains
 
       kohn_sham = .false.
       if (present(functional)) kohn_sham = len_trim(functional) > 0
+      pt2 = 0.0_dp
+      if (present(pt2_fraction)) pt2 = pt2_fraction
+      double_hybrid = kohn_sham .and. pt2 /= 0.0_dp
+      frozen = 0
+      if (present(n_frozen)) frozen = n_frozen
+      e_pt2_neutral = 0.0_dp
+      e_pt2_anion = 0.0_dp
+      e_pt2_cation = 0.0_dp
       res%functional = ""
       xc_arg => null()
 
@@ -167,20 +203,21 @@ contains
             call error%add_context("Fukui indices: the ions' functional")
             return
          end if
-         ! A double hybrid's perturbative term needs an unrestricted MP2, which
-         ! the CPU path does not have. Refused rather than run, because running
-         ! it would not fail: the Kohn-Sham half is correct and unrestricted, so
-         ! the ions would come back converged and short by the PT2 term. IP and
-         ! EA are differences of total energies, so a term missing from two of
-         ! the three states lands directly in every descriptor here.
-         if (xc_ions%pt2_fraction /= 0.0_dp) then
-            call error%set(ERROR_VALIDATION, "'"//trim(functional)//"' is a double "// &
-                           "hybrid, and the Fukui ions are open shell. Its perturbative "// &
-                           "term needs an unrestricted MP2 the CPU path does not have, "// &
-                           "so the ions would converge with the Kohn-Sham part alone and "// &
-                           "the IP and EA would be wrong by that term. Use a functional "// &
-                           "without a perturbative term.")
-            return
+         ! A double hybrid's perturbative term is evaluated below for all
+         ! three states. What cannot be done is evaluating it for some of them:
+         ! the Kohn-Sham half converges perfectly well on its own, so leaving
+         ! the term out of the ions would return descriptors that look fine and
+         ! are short by it. The orbitals the neutral's term needs are not
+         ! derivable from the density this routine was handed, so they are
+         ! required rather than assumed.
+         if (double_hybrid) then
+            if (.not. (present(neutral_orbitals) .and. present(neutral_orbital_energies))) then
+               call error%set(ERROR_VALIDATION, "'"//trim(functional)//"' is a double "// &
+                              "hybrid, so the Fukui analysis needs the neutral's orbitals "// &
+                              "to evaluate its perturbative term on the same footing as "// &
+                              "the ions. The caller passed a density only.")
+               return
+            end if
          end if
          xc_arg => xc_ions
          res%functional = trim(functional)
@@ -188,7 +225,20 @@ contains
 
       natm = mol%natm
       res%scheme = scheme
-      res%energy_neutral = neutral_energy
+      ! The neutral's perturbative term, on a closed shell and so restricted.
+      ! Computed before the ions so that a failure here -- a saturated basis,
+      ! an auxiliary set that will not fit -- is reported before two
+      ! unrestricted SCFs have been paid for.
+      if (double_hybrid) then
+         call state_pt2(mol, aux, neutral_orbitals, neutral_orbital_energies, &
+                        nelec/2, frozen, e_pt2_neutral, error)
+         if (error%has_error()) then
+            call error%add_context("Fukui indices: the neutral's PT2 term")
+            return
+         end if
+         e_pt2_neutral = pt2*e_pt2_neutral
+      end if
+      res%energy_neutral = neutral_energy + e_pt2_neutral
 
       call mol%overlap(overlap)
       call condense(mol, neutral_density, overlap, scheme, 0.0_dp, res%q_neutral, error)
@@ -212,7 +262,15 @@ contains
       total = anion%density + anion%density_beta
       call condense(mol, total, overlap, scheme, -1.0_dp, res%q_anion, error)
       if (error%has_error()) return
-      res%energy_anion = anion%energy
+      if (double_hybrid) then
+         call state_pt2_open(mol, aux, anion, frozen, e_pt2_anion, error)
+         if (error%has_error()) then
+            call error%add_context("Fukui indices: the anion's PT2 term")
+            return
+         end if
+         e_pt2_anion = pt2*e_pt2_anion
+      end if
+      res%energy_anion = anion%energy + e_pt2_anion
       deallocate (total)
 
       ! The cation.
@@ -231,7 +289,15 @@ contains
       total = cation%density + cation%density_beta
       call condense(mol, total, overlap, scheme, 1.0_dp, res%q_cation, error)
       if (error%has_error()) return
-      res%energy_cation = cation%energy
+      if (double_hybrid) then
+         call state_pt2_open(mol, aux, cation, frozen, e_pt2_cation, error)
+         if (error%has_error()) then
+            call error%add_context("Fukui indices: the cation's PT2 term")
+            return
+         end if
+         e_pt2_cation = pt2*e_pt2_cation
+      end if
+      res%energy_cation = cation%energy + e_pt2_cation
       deallocate (total, overlap)
 
       allocate (res%f_plus(natm), res%f_minus(natm), res%f_zero(natm), res%dual(natm))
@@ -251,6 +317,62 @@ contains
 
       call check_sum_rule(res, error)
    end subroutine fukui_indices
+
+   subroutine state_pt2(mol, aux, coeff, eps, n_occ, frozen, e_corr, error)
+      !! The UNSCALED MP2 correlation for the closed-shell neutral
+      !!
+      !! Unscaled, and the caller multiplies by the functional's fraction. Two
+      !! routines that each scale would be one place too many for a factor that
+      !! belongs to the functional rather than to the correlation treatment.
+      type(libcint_molecule_t), intent(in) :: mol
+      type(libcint_molecule_t), intent(in), optional :: aux
+      real(dp), intent(in) :: coeff(:, :), eps(:)
+      integer, intent(in) :: n_occ, frozen
+      real(dp), intent(out) :: e_corr
+      type(error_t), intent(inout) :: error
+
+      type(mp2_result_t) :: m
+      e_corr = 0.0_dp
+      if (present(aux)) then
+         call run_libcint_ri_mp2(mol, aux, coeff, eps, n_occ, 0.0_dp, m, error, &
+                                 n_frozen=frozen)
+      else
+         call run_libcint_mp2(mol, coeff, eps, n_occ, 0.0_dp, m, error, n_frozen=frozen)
+      end if
+      if (error%has_error()) return
+      e_corr = m%correlation
+   end subroutine state_pt2
+
+   subroutine state_pt2_open(mol, aux, scf, frozen, e_corr, error)
+      !! The same for one of the doublet ions
+      !!
+      !! Takes the whole SCF result rather than its pieces because the per-spin
+      !! occupied counts have to come from the same place the orbitals did.
+      !! Deriving them from a charge and a multiplicity is how an alpha count
+      !! ends up paired with a beta coefficient matrix.
+      type(libcint_molecule_t), intent(in) :: mol
+      type(libcint_molecule_t), intent(in), optional :: aux
+      type(rhf_result_t), intent(in) :: scf
+      integer, intent(in) :: frozen
+      real(dp), intent(out) :: e_corr
+      type(error_t), intent(inout) :: error
+
+      type(mp2_result_t) :: m
+      e_corr = 0.0_dp
+      if (present(aux)) then
+         call run_libcint_uri_mp2(mol, aux, scf%orbitals, scf%orbitals_beta, &
+                                  scf%orbital_energies, scf%orbital_energies_beta, &
+                                  scf%n_occupied, scf%n_occupied_beta, 0.0_dp, m, error, &
+                                  n_frozen=frozen)
+      else
+         call run_libcint_ump2(mol, scf%orbitals, scf%orbitals_beta, &
+                               scf%orbital_energies, scf%orbital_energies_beta, &
+                               scf%n_occupied, scf%n_occupied_beta, 0.0_dp, m, error, &
+                               n_frozen=frozen)
+      end if
+      if (error%has_error()) return
+      e_corr = m%correlation
+   end subroutine state_pt2_open
 
    subroutine condense(mol, density, overlap, scheme, total_charge, charges, error)
       !! Atomic charges for one of the three states

--- a/backends/libcint/mqc_libcint_mp2.f90
+++ b/backends/libcint/mqc_libcint_mp2.f90
@@ -41,6 +41,8 @@ module mqc_libcint_mp2
 
    public :: run_libcint_mp2
    public :: run_libcint_ri_mp2
+   public :: run_libcint_ump2
+   public :: run_libcint_uri_mp2
    public :: mp2_result_t
    ! Exported for coupled cluster, which needs every MO block rather than just
    ! (ia|jb). Lives here because this is where the two-half transform is, and a
@@ -266,6 +268,307 @@ contains
       result%n_occupied = n_o
       result%n_virtual = n_v
    end subroutine run_libcint_ri_mp2
+
+   !
+   ! THE UNRESTRICTED PAIR. Both routines below compute
+   !
+   !     E(2) = 1/4 sum_(ijab in a) |<ij||ab>|^2 / D
+   !          + 1/4 sum_(ijab in b) |<ij||ab>|^2 / D
+   !          +     sum_(ia in a, jb in b) (ia|jb)^2 / D
+   !
+   ! with D = e_i + e_j - e_a - e_b, and store the two like-spin terms together
+   ! in `same_spin` and the mixed one in `opposite_spin`, which is what those
+   ! fields already mean in the restricted result.
+   !
+   ! The like-spin terms are written as 1/2 sum (ia|jb)[(ia|jb) - (ib|ja)]/D
+   ! rather than 1/4 sum [(ia|jb) - (ib|ja)]^2/D. They are equal -- expanding
+   ! the square gives x^2 - 2xy + y^2, and relabelling a with b turns sum y^2/D
+   ! into sum x^2/D because D is symmetric in a and b -- and the first form is
+   ! half the arithmetic and the same shape as the restricted loop above it, so
+   ! the two can be read against each other.
+   !
+   ! THE CLOSED-SHELL LIMIT IS THE TEST that says the factors are right. With
+   ! alpha and beta identical the two like-spin terms sum to
+   ! sum x(x - y)/D, which is exactly `e_ss` in the restricted routines, and
+   ! the mixed term is `e_os`. check_ump2_matches_rmp2 asserts it.
+   !
+   ! Frozen orbitals are counted per spin, the same number from each. For a
+   ! doublet that leaves one more correlated beta hole than alpha, which is
+   ! what freezing a core rather than an electron count means.
+   !
+   subroutine run_libcint_ump2(mol, coeff_a, coeff_b, eps_a, eps_b, &
+                               n_occ_a, n_occ_b, scf_energy, result, error, n_frozen)
+      !! E(2) for an unrestricted reference, from the four-index transform
+      type(libcint_molecule_t), intent(in) :: mol
+      real(dp), intent(in) :: coeff_a(:, :), coeff_b(:, :)   !! (n_ao, n_mo) per spin
+      real(dp), intent(in) :: eps_a(:), eps_b(:)
+      integer, intent(in) :: n_occ_a, n_occ_b
+      real(dp), intent(in) :: scf_energy
+      type(mp2_result_t), intent(out) :: result
+      type(error_t), intent(inout) :: error
+      integer, intent(in), optional :: n_frozen
+
+      real(dp), allocatable :: ao_eri(:, :)
+      real(dp), allocatable :: ovov_aa(:, :, :, :), ovov_bb(:, :, :, :), ovov_ab(:, :, :, :)
+      real(dp), allocatable :: ca_o(:, :), ca_v(:, :), cb_o(:, :), cb_v(:, :)
+      integer :: n_ao, n_mo, frozen, n_oa, n_ob, n_va, n_vb
+      real(dp) :: e_aa, e_bb, e_ab
+      type(timing_report_t) :: clk
+
+      call ump2_dimensions(mol, coeff_a, coeff_b, eps_a, eps_b, n_occ_a, n_occ_b, &
+                           n_frozen, n_ao, n_mo, frozen, n_oa, n_ob, n_va, n_vb, error)
+      if (error%has_error()) return
+
+      ca_o = coeff_a(:, frozen + 1:n_occ_a)
+      ca_v = coeff_a(:, n_occ_a + 1:n_mo)
+      cb_o = coeff_b(:, frozen + 1:n_occ_b)
+      cb_v = coeff_b(:, n_occ_b + 1:n_mo)
+
+      call clk%start()
+      call mol%eris_packed(ao_eri)
+      call clk%lap("AO integrals")
+
+      ! Three blocks, not one. The like-spin pair needs its own coefficients on
+      ! both electrons; the mixed block needs alpha on one and beta on the
+      ! other and is NOT antisymmetrised -- two electrons of different spin are
+      ! already distinguishable, so there is no exchange term to subtract.
+      call transform_block(ao_eri, ca_o, ca_v, ca_o, ca_v, ovov_aa)
+      call transform_block(ao_eri, cb_o, cb_v, cb_o, cb_v, ovov_bb)
+      call transform_block(ao_eri, ca_o, ca_v, cb_o, cb_v, ovov_ab)
+      deallocate (ao_eri, ca_o, ca_v, cb_o, cb_v)
+      call clk%lap("AO->MO transform (3 blocks)")
+
+      e_aa = like_spin_energy(ovov_aa, eps_a, frozen, n_occ_a, n_oa, n_va)
+      e_bb = like_spin_energy(ovov_bb, eps_b, frozen, n_occ_b, n_ob, n_vb)
+      e_ab = mixed_spin_energy(ovov_ab, eps_a, eps_b, frozen, n_occ_a, n_occ_b, &
+                               n_oa, n_ob, n_va, n_vb)
+      deallocate (ovov_aa, ovov_bb, ovov_ab)
+      call clk%lap("energy denominators")
+      call clk%finish()
+      call clk%report("UMP2")
+
+      call fill_ump2_result(result, e_aa + e_bb, e_ab, scf_energy, frozen, &
+                            n_oa + n_ob, n_va + n_vb)
+   end subroutine run_libcint_ump2
+
+   subroutine run_libcint_uri_mp2(mol, aux, coeff_a, coeff_b, eps_a, eps_b, &
+                                  n_occ_a, n_occ_b, scf_energy, result, error, n_frozen)
+      !! E(2) for an unrestricted reference, from a fitted (ia|jb)
+      !!
+      !! One B tensor per spin, both fitted against the same auxiliary basis so
+      !! the mixed block is a gemm between them rather than anything new:
+      !!
+      !!     (ia|JB) = sum_P B(a)^P_ia B(b)^P_JB
+      !!
+      !! The like-spin blocks reuse the occupied-pair weighting of the
+      !! restricted routine -- exchanging i with j and a with b leaves the term
+      !! unchanged, so the lower triangle is enough. **The mixed block gets no
+      !! such weighting**: i is alpha and j is beta, so (i,j) and (j,i) are
+      !! different pairs of different spins and the full rectangle is the sum.
+      type(libcint_molecule_t), intent(in) :: mol
+      type(libcint_molecule_t), intent(in) :: aux
+      real(dp), intent(in) :: coeff_a(:, :), coeff_b(:, :)
+      real(dp), intent(in) :: eps_a(:), eps_b(:)
+      integer, intent(in) :: n_occ_a, n_occ_b
+      real(dp), intent(in) :: scf_energy
+      type(mp2_result_t), intent(out) :: result
+      type(error_t), intent(inout) :: error
+      integer, intent(in), optional :: n_frozen
+
+      real(dp), allocatable :: b_a(:, :, :), b_b(:, :, :), g(:, :)
+      real(dp), allocatable :: ca_o(:, :), ca_v(:, :), cb_o(:, :), cb_v(:, :)
+      integer :: n_ao, n_mo, frozen, n_oa, n_ob, n_va, n_vb
+      integer :: i, j, a, b
+      real(dp) :: e_aa, e_bb, e_ab, iajb, denom
+      type(timing_report_t) :: clk
+
+      call ump2_dimensions(mol, coeff_a, coeff_b, eps_a, eps_b, n_occ_a, n_occ_b, &
+                           n_frozen, n_ao, n_mo, frozen, n_oa, n_ob, n_va, n_vb, error)
+      if (error%has_error()) return
+
+      ca_o = coeff_a(:, frozen + 1:n_occ_a)
+      ca_v = coeff_a(:, n_occ_a + 1:n_mo)
+      cb_o = coeff_b(:, frozen + 1:n_occ_b)
+      cb_v = coeff_b(:, n_occ_b + 1:n_mo)
+
+      call clk%start()
+      call build_df_mo_tensor(mol, aux, ca_o, ca_v, b_a, error)
+      if (error%has_error()) return
+      call build_df_mo_tensor(mol, aux, cb_o, cb_v, b_b, error)
+      if (error%has_error()) return
+      deallocate (ca_o, ca_v, cb_o, cb_v)
+      call clk%lap("B tensors (3c/2c fit, both spins)")
+
+      e_aa = ri_like_spin_energy(b_a, eps_a, frozen, n_occ_a, n_oa, n_va)
+      e_bb = ri_like_spin_energy(b_b, eps_b, frozen, n_occ_b, n_ob, n_vb)
+
+      allocate (g(n_va, n_vb))
+      e_ab = 0.0_dp
+      do i = 1, n_oa
+         do j = 1, n_ob
+            call pic_gemm(b_a(:, :, i), b_b(:, :, j), g, transb="T")
+            do b = 1, n_vb
+               do a = 1, n_va
+                  iajb = g(a, b)
+                  denom = eps_a(frozen + i) + eps_b(frozen + j) &
+                          - eps_a(n_occ_a + a) - eps_b(n_occ_b + b)
+                  e_ab = e_ab + iajb*iajb/denom
+               end do
+            end do
+         end do
+      end do
+      deallocate (g, b_a, b_b)
+      call clk%lap("gemm + denominators")
+      call clk%finish()
+      call clk%report("URI-MP2")
+
+      call fill_ump2_result(result, e_aa + e_bb, e_ab, scf_energy, frozen, &
+                            n_oa + n_ob, n_va + n_vb)
+   end subroutine run_libcint_uri_mp2
+
+   subroutine ump2_dimensions(mol, coeff_a, coeff_b, eps_a, eps_b, n_occ_a, n_occ_b, &
+                              n_frozen, n_ao, n_mo, frozen, n_oa, n_ob, n_va, n_vb, error)
+      !! The shape checks both unrestricted routines need, in one place
+      !!
+      !! Checked per spin rather than once: a doublet has a different occupied
+      !! count in each, so "at least one occupied left after freezing" and "at
+      !! least one virtual" are two questions, and the beta channel is the one
+      !! that runs out first.
+      type(libcint_molecule_t), intent(in) :: mol
+      real(dp), intent(in) :: coeff_a(:, :), coeff_b(:, :)
+      real(dp), intent(in) :: eps_a(:), eps_b(:)
+      integer, intent(in) :: n_occ_a, n_occ_b
+      integer, intent(in), optional :: n_frozen
+      integer, intent(out) :: n_ao, n_mo, frozen, n_oa, n_ob, n_va, n_vb
+      type(error_t), intent(inout) :: error
+
+      n_ao = mol%nao
+      n_mo = size(coeff_a, 2)
+      frozen = 0
+      if (present(n_frozen)) frozen = n_frozen
+
+      if (size(coeff_b, 2) /= n_mo) then
+         call error%set(ERROR_VALIDATION, "UMP2: the alpha and beta coefficient "// &
+                        "matrices have different numbers of orbitals")
+         return
+      end if
+      if (size(eps_a) /= n_mo .or. size(eps_b) /= n_mo) then
+         call error%set(ERROR_VALIDATION, "UMP2: orbital energies do not match the "// &
+                        "coefficient matrices")
+         return
+      end if
+      if (frozen < 0 .or. frozen >= n_occ_a .or. frozen >= n_occ_b) then
+         call error%set(ERROR_VALIDATION, "UMP2: the frozen core must leave at least "// &
+                        "one occupied orbital in each spin to correlate")
+         return
+      end if
+
+      n_oa = n_occ_a - frozen
+      n_ob = n_occ_b - frozen
+      n_va = n_mo - n_occ_a
+      n_vb = n_mo - n_occ_b
+      if (n_va < 1 .or. n_vb < 1) then
+         call error%set(ERROR_VALIDATION, "UMP2: no virtual orbitals in one spin; "// &
+                        "the basis is saturated by the occupied space")
+         return
+      end if
+   end subroutine ump2_dimensions
+
+   subroutine fill_ump2_result(result, same, opposite, scf_energy, frozen, n_o, n_v)
+      !! One place that decides what the result fields mean for an open shell
+      type(mp2_result_t), intent(out) :: result
+      real(dp), intent(in) :: same, opposite, scf_energy
+      integer, intent(in) :: frozen, n_o, n_v
+      result%same_spin = same
+      result%opposite_spin = opposite
+      result%correlation = same + opposite
+      result%scf_energy = scf_energy
+      result%total = scf_energy + result%correlation
+      result%n_frozen = frozen
+      !! Summed over spins, so these count spin orbitals where the restricted
+      !! routines count spatial ones. There is no single number that means the
+      !! same thing in both cases and the totals are what a report shows.
+      result%n_occupied = n_o
+      result%n_virtual = n_v
+   end subroutine fill_ump2_result
+
+   pure function like_spin_energy(ovov, eps, frozen, n_occ, n_o, n_v) result(e)
+      !! 1/2 sum (ia|jb)[(ia|jb) - (ib|ja)] / D, one spin against itself
+      real(dp), intent(in) :: ovov(:, :, :, :)
+      real(dp), intent(in) :: eps(:)
+      integer, intent(in) :: frozen, n_occ, n_o, n_v
+      real(dp) :: e
+      integer :: i, j, a, b
+      real(dp) :: iajb, ibja, denom
+      e = 0.0_dp
+      do i = 1, n_o
+         do j = 1, n_o
+            do a = 1, n_v
+               do b = 1, n_v
+                  iajb = ovov(i, a, j, b)
+                  ibja = ovov(i, b, j, a)
+                  denom = eps(frozen + i) + eps(frozen + j) &
+                          - eps(n_occ + a) - eps(n_occ + b)
+                  e = e + 0.5_dp*iajb*(iajb - ibja)/denom
+               end do
+            end do
+         end do
+      end do
+   end function like_spin_energy
+
+   pure function mixed_spin_energy(ovov, eps_a, eps_b, frozen, n_occ_a, n_occ_b, &
+                                   n_oa, n_ob, n_va, n_vb) result(e)
+      !! sum (ia|JB)^2 / D, alpha on one electron and beta on the other
+      real(dp), intent(in) :: ovov(:, :, :, :)
+      real(dp), intent(in) :: eps_a(:), eps_b(:)
+      integer, intent(in) :: frozen, n_occ_a, n_occ_b, n_oa, n_ob, n_va, n_vb
+      real(dp) :: e
+      integer :: i, j, a, b
+      real(dp) :: iajb, denom
+      e = 0.0_dp
+      do i = 1, n_oa
+         do j = 1, n_ob
+            do a = 1, n_va
+               do b = 1, n_vb
+                  iajb = ovov(i, a, j, b)
+                  denom = eps_a(frozen + i) + eps_b(frozen + j) &
+                          - eps_a(n_occ_a + a) - eps_b(n_occ_b + b)
+                  e = e + iajb*iajb/denom
+               end do
+            end do
+         end do
+      end do
+   end function mixed_spin_energy
+
+   function ri_like_spin_energy(bia, eps, frozen, n_occ, n_o, n_v) result(e)
+      !! The like-spin term from a fitted B, lower occupied triangle only
+      real(dp), intent(in) :: bia(:, :, :)
+      real(dp), intent(in) :: eps(:)
+      integer, intent(in) :: frozen, n_occ, n_o, n_v
+      real(dp) :: e
+      real(dp), allocatable :: g(:, :)
+      integer :: i, j, a, b
+      real(dp) :: iajb, ibja, denom, weight
+      allocate (g(n_v, n_v))
+      e = 0.0_dp
+      do i = 1, n_o
+         do j = 1, i
+            call pic_gemm(bia(:, :, i), bia(:, :, j), g, transb="T")
+            weight = 2.0_dp
+            if (i == j) weight = 1.0_dp
+            do b = 1, n_v
+               do a = 1, n_v
+                  iajb = g(a, b)
+                  ibja = g(b, a)
+                  denom = eps(frozen + i) + eps(frozen + j) &
+                          - eps(n_occ + a) - eps(n_occ + b)
+                  e = e + 0.5_dp*weight*iajb*(iajb - ibja)/denom
+               end do
+            end do
+         end do
+      end do
+      deallocate (g)
+   end function ri_like_spin_energy
 
    subroutine transform_ovov(eri, coeff, frozen, n_occ, n_ao, n_mo, ovov)
       !! (pq|rs) over packed AO pairs -> (ia|jb)

--- a/mqc_docs/source/input_files.rst
+++ b/mqc_docs/source/input_files.rst
@@ -837,12 +837,23 @@ The driver stays ``"energy"``.
   the relaxation of every other orbital in response to the added charge -- which
   on a polar molecule is most of the answer.
 
-  Works with ``hf`` and with ``dft``. Under DFT the two ions are run as
-  unrestricted Kohn-Sham with the same functional as the neutral, so the three
-  energies are comparable and the ionisation potential and electron affinity
-  mean what they say. Double hybrids are refused: their perturbative term needs
-  an unrestricted MP2 the CPU path does not have, and running anyway would
-  return converged ions that are short by exactly that term.
+  Works with ``hf`` and with ``dft``, **double hybrids included**. Under DFT
+  the two ions are run as unrestricted Kohn-Sham with the same functional as
+  the neutral, so the three energies are comparable and the ionisation
+  potential and electron affinity mean what they say.
+
+  For a double hybrid the perturbative term is evaluated for all three states,
+  the neutral's recomputed here rather than taken from the energy above it.
+  That is deliberate: IP and EA are differences of total energies, so the term
+  has to be present in all three or in none, and sourcing one of them
+  elsewhere would make the result depend on two code paths agreeing about
+  frozen cores and auxiliary bases. It costs one restricted MP2 beside the two
+  unrestricted ones the ions already need.
+
+  Naming an ``aux_basis`` fits that correlation, exactly as it does for the
+  energy's own perturbative term -- the two follow the same choice, so the IP
+  printed in the report and the total energy printed above it are never
+  computed different ways.
 
   ``population`` is optional and defaults to ``chelpg``. It chooses how the
   density difference is condensed onto atoms:

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -84,6 +84,9 @@ if(MQC_ENABLE_LIBCINT)
   # Fukui indices by difference in the electron count.
   addtest(mqc_fukui)
   target_link_libraries(test_mqc_fukui PRIVATE cint_fortran cint)
+  # Unrestricted MP2, whose closed-shell limit is the restricted one.
+  addtest(mqc_ump2)
+  target_link_libraries(test_mqc_ump2 PRIVATE cint_fortran cint)
   # Regrouping the kinetic energy onto atoms and atom pairs.
   addtest(mqc_ieda)
   target_link_libraries(test_mqc_ieda PRIVATE cint_fortran cint)

--- a/test/test_mqc_ump2.f90
+++ b/test/test_mqc_ump2.f90
@@ -1,0 +1,251 @@
+!! Unrestricted MP2: the closed-shell limit, and the two spin channels
+module test_mqc_ump2
+   !! **The closed-shell limit is the test that pins the spin factors.** An
+   !! unrestricted MP2 on a closed-shell reference has to reproduce the
+   !! restricted one exactly -- not approximately, since the alpha and beta
+   !! orbitals are the same orbitals and every integral is the same integral.
+   !! Getting the 1/4 on the like-spin terms wrong, or antisymmetrising the
+   !! mixed-spin block that must not be antisymmetrised, moves that number and
+   !! nothing else here would notice.
+   !!
+   !! It also separates the two implementations from each other: conventional
+   !! and fitted are checked against the same restricted reference, so a fault
+   !! in the B tensor shows up as a disagreement rather than as two routines
+   !! agreeing on the same mistake.
+   !!
+   !! The open-shell numbers are pinned rather than derived. There is no
+   !! identity that fixes E(2) for a doublet, so what is asserted about them is
+   !! sign, spin decomposition and reproducibility -- the value itself is
+   !! checked against PySCF outside this file.
+   use testdrive, only: new_unittest, unittest_type, error_type, check
+   use pic_types, only: dp
+   use mqc_error, only: error_t
+   use mqc_libcint_integrals, only: libcint_molecule_t, build_libcint_molecule
+   use mqc_libcint_rhf, only: rhf_result_t, run_libcint_rhf, run_libcint_uhf
+   use mqc_libcint_mp2, only: mp2_result_t, run_libcint_mp2, run_libcint_ump2, &
+                              run_libcint_ri_mp2, run_libcint_uri_mp2
+   implicit none
+   private
+
+   public :: collect_mqc_ump2_tests
+
+   integer, parameter :: WATER_Z(3) = [8, 1, 1]
+   character(len=2), parameter :: WATER_SYM(3) = ["O ", "H ", "H "]
+   !> Bohr, C2v, the same geometry the other backend tests use
+   real(dp), parameter :: WATER(3, 3) = reshape( &
+                          [0.0_dp, 0.0_dp, 0.0_dp, &
+                           0.0_dp, 1.4308_dp, 1.1078_dp, &
+                           0.0_dp, -1.4308_dp, 1.1078_dp], [3, 3])
+
+contains
+
+   subroutine collect_mqc_ump2_tests(testsuite)
+      type(unittest_type), allocatable, intent(out) :: testsuite(:)
+
+      testsuite = [ &
+                  new_unittest("ump2_reproduces_rmp2_on_a_closed_shell", closed_shell_limit), &
+                  new_unittest("cation_correlation_is_negative", cation_is_negative), &
+                  new_unittest("refuses_mismatched_orbital_counts", refuses_mismatch), &
+                  new_unittest("uri_mp2_reproduces_ri_mp2_on_a_closed_shell", ri_closed_shell_limit) &
+                  ]
+   end subroutine collect_mqc_ump2_tests
+
+   subroutine water_scf(nelec, mult, unrestricted, mol, scf, err, ok)
+      !! One converged reference on the shared geometry
+      integer, intent(in) :: nelec, mult
+      logical, intent(in) :: unrestricted
+      type(libcint_molecule_t), intent(out) :: mol
+      type(rhf_result_t), intent(out) :: scf
+      type(error_t), intent(inout) :: err
+      logical, intent(out) :: ok
+
+      ok = .false.
+      call build_libcint_molecule(WATER_Z, WATER_SYM, WATER, "sto-3g", mol, err)
+      if (err%has_error()) return
+      if (unrestricted) then
+         call run_libcint_uhf(mol, nelec, mult, 100, 1.0e-10_dp, 1.0e-8_dp, .false., scf, err)
+      else
+         call run_libcint_rhf(mol, nelec, 100, 1.0e-10_dp, 1.0e-8_dp, .false., scf, err)
+      end if
+      ok = .not. err%has_error()
+   end subroutine water_scf
+
+   subroutine closed_shell_limit(error)
+      !! UMP2 on a closed shell is RMP2, to machine precision
+      type(error_type), allocatable, intent(out) :: error
+
+      type(libcint_molecule_t) :: mol_r, mol_u
+      type(rhf_result_t) :: rhf, uhf
+      type(mp2_result_t) :: rmp2, ump2
+      type(error_t) :: err
+      logical :: ok
+
+      call water_scf(10, 1, .false., mol_r, rhf, err, ok)
+      call check(error, ok, "the restricted reference did not converge")
+      if (allocated(error)) return
+      call run_libcint_mp2(mol_r, rhf%orbitals, rhf%orbital_energies, 5, rhf%energy, &
+                           rmp2, err)
+      call check(error,.not. err%has_error(), "RMP2 failed")
+      if (allocated(error)) return
+
+      call water_scf(10, 1, .true., mol_u, uhf, err, ok)
+      call check(error, ok, "the unrestricted reference did not converge")
+      if (allocated(error)) return
+      call run_libcint_ump2(mol_u, uhf%orbitals, uhf%orbitals_beta, &
+                            uhf%orbital_energies, uhf%orbital_energies_beta, &
+                            5, 5, uhf%energy, ump2, err)
+      call check(error,.not. err%has_error(), "UMP2 failed")
+      if (allocated(error)) return
+
+      ! The correlation energy first, then each spin channel, so a failure says
+      ! which factor is wrong rather than only that something is.
+      call check(error, abs(ump2%correlation - rmp2%correlation) < 1.0e-10_dp, &
+                 "UMP2 correlation does not reproduce RMP2 on a closed shell")
+      if (allocated(error)) return
+      call check(error, abs(ump2%same_spin - rmp2%same_spin) < 1.0e-10_dp, &
+                 "the like-spin channels disagree: check the 1/2 on E(aa) and E(bb)")
+      if (allocated(error)) return
+      call check(error, abs(ump2%opposite_spin - rmp2%opposite_spin) < 1.0e-10_dp, &
+                 "the mixed-spin channels disagree: check that E(ab) is NOT antisymmetrised")
+
+      call mol_r%destroy(); call mol_u%destroy()
+   end subroutine closed_shell_limit
+
+   subroutine cation_is_negative(error)
+      !! A doublet correlates, and both channels contribute
+      type(error_type), allocatable, intent(out) :: error
+
+      type(libcint_molecule_t) :: mol
+      type(rhf_result_t) :: uhf
+      type(mp2_result_t) :: ump2
+      type(error_t) :: err
+      logical :: ok
+
+      call water_scf(9, 2, .true., mol, uhf, err, ok)
+      call check(error, ok, "the cation did not converge")
+      if (allocated(error)) return
+      call run_libcint_ump2(mol, uhf%orbitals, uhf%orbitals_beta, &
+                            uhf%orbital_energies, uhf%orbital_energies_beta, &
+                            5, 4, uhf%energy, ump2, err)
+      call check(error,.not. err%has_error(), "UMP2 on the cation failed")
+      if (allocated(error)) return
+
+      ! Every denominator is negative for a stable reference and every
+      ! numerator is a square or a sum of them, so both channels are negative.
+      ! A positive one means the reference was not a minimum, which is worth
+      ! catching here rather than in whatever consumes the number.
+      call check(error, ump2%correlation < 0.0_dp, "correlation energy is not negative")
+      if (allocated(error)) return
+      call check(error, ump2%opposite_spin < 0.0_dp, "the mixed-spin channel is not negative")
+      if (allocated(error)) return
+      call check(error, ump2%same_spin < 0.0_dp, "the like-spin channel is not negative")
+      if (allocated(error)) return
+      ! Opposite spin dominates in MP2, and by a wide margin -- roughly three to
+      ! one on a molecule like this. A run where they had swapped magnitude
+      ! would be a spin-factor error that the sign checks above would miss.
+      call check(error, abs(ump2%opposite_spin) > abs(ump2%same_spin), &
+                 "the like-spin channel outweighs the mixed one, which no MP2 does")
+
+      call mol%destroy()
+   end subroutine cation_is_negative
+
+   subroutine ri_closed_shell_limit(error)
+      !! The same limit for the fitted pair, which is a separate implementation
+      !!
+      !! Against RI-MP2 rather than against conventional MP2: the fitting error
+      !! is common to both sides here and cancels, so what is left is the spin
+      !! algebra. Checking the fitted unrestricted result against the exact
+      !! restricted one would fold in the RI error and need a tolerance loose
+      !! enough to hide a real mistake.
+      type(error_type), allocatable, intent(out) :: error
+
+      type(libcint_molecule_t) :: mol_r, mol_u, aux_r, aux_u
+      type(rhf_result_t) :: rhf, uhf
+      type(mp2_result_t) :: rmp2, ump2
+      type(error_t) :: err
+      logical :: ok
+
+      call water_scf(10, 1, .false., mol_r, rhf, err, ok)
+      call check(error, ok, "the restricted reference did not converge")
+      if (allocated(error)) return
+      call build_libcint_molecule(WATER_Z, WATER_SYM, WATER, "cc-pvdz-rifit", aux_r, err)
+      call check(error,.not. err%has_error(), "the auxiliary basis did not build")
+      if (allocated(error)) return
+      call run_libcint_ri_mp2(mol_r, aux_r, rhf%orbitals, rhf%orbital_energies, 5, &
+                              rhf%energy, rmp2, err)
+      call check(error,.not. err%has_error(), "RI-MP2 failed")
+      if (allocated(error)) return
+
+      call water_scf(10, 1, .true., mol_u, uhf, err, ok)
+      call check(error, ok, "the unrestricted reference did not converge")
+      if (allocated(error)) return
+      call build_libcint_molecule(WATER_Z, WATER_SYM, WATER, "cc-pvdz-rifit", aux_u, err)
+      call check(error,.not. err%has_error(), "the auxiliary basis did not build")
+      if (allocated(error)) return
+      call run_libcint_uri_mp2(mol_u, aux_u, uhf%orbitals, uhf%orbitals_beta, &
+                               uhf%orbital_energies, uhf%orbital_energies_beta, &
+                               5, 5, uhf%energy, ump2, err)
+      call check(error,.not. err%has_error(), "URI-MP2 failed")
+      if (allocated(error)) return
+
+      call check(error, abs(ump2%correlation - rmp2%correlation) < 1.0e-10_dp, &
+                 "URI-MP2 correlation does not reproduce RI-MP2 on a closed shell")
+      if (allocated(error)) return
+      call check(error, abs(ump2%same_spin - rmp2%same_spin) < 1.0e-10_dp, &
+                 "the like-spin channels disagree in the fitted pair")
+      if (allocated(error)) return
+      call check(error, abs(ump2%opposite_spin - rmp2%opposite_spin) < 1.0e-10_dp, &
+                 "the mixed-spin channels disagree in the fitted pair")
+
+      call mol_r%destroy(); call mol_u%destroy()
+      call aux_r%destroy(); call aux_u%destroy()
+   end subroutine ri_closed_shell_limit
+
+   subroutine refuses_mismatch(error)
+      !! Alpha and beta must span the same orbital space
+      type(error_type), allocatable, intent(out) :: error
+
+      type(libcint_molecule_t) :: mol
+      type(rhf_result_t) :: uhf
+      type(mp2_result_t) :: ump2
+      type(error_t) :: err
+      logical :: ok
+
+      call water_scf(10, 1, .true., mol, uhf, err, ok)
+      call check(error, ok, "the reference did not converge")
+      if (allocated(error)) return
+
+      ! Beta truncated by one column. Silently correlating a smaller virtual
+      ! space than alpha would return a plausible number.
+      call run_libcint_ump2(mol, uhf%orbitals, uhf%orbitals_beta(:, 1:size(uhf%orbitals_beta, 2) - 1), &
+                            uhf%orbital_energies, uhf%orbital_energies_beta, &
+                            5, 5, uhf%energy, ump2, err)
+      call check(error, err%has_error(), "a truncated beta space was accepted")
+      call err%clear()
+      call mol%destroy()
+   end subroutine refuses_mismatch
+
+end module test_mqc_ump2
+
+program tester
+   use, intrinsic :: iso_fortran_env, only: error_unit
+   use testdrive, only: run_testsuite, new_testsuite, testsuite_type
+   use test_mqc_ump2, only: collect_mqc_ump2_tests
+   implicit none
+   integer :: stat, is
+   type(testsuite_type), allocatable :: testsuites(:)
+   character(len=*), parameter :: fmt = '("#", *(1x, a))'
+
+   stat = 0
+   testsuites = [new_testsuite("mqc_ump2", collect_mqc_ump2_tests)]
+
+   do is = 1, size(testsuites)
+      write (error_unit, fmt) "Testing:", testsuites(is)%name
+      call run_testsuite(testsuites(is)%collect, error_unit, stat)
+   end do
+
+   if (stat > 0) then
+      write (error_unit, "(i0, 1x, a)") stat, "test(s) failed!"
+      error stop
+   end if
+end program tester


### PR DESCRIPTION
Unrestricted MP2, and the double-hybrid Fukui it unlocks

UMP2 AND URI-MP2. Two spin channels rather than one:

    E(2) = 1/4 sum_(aa) |<ij||ab>|^2/D + 1/4 sum_(bb) ... + sum_(ab) (ia|jb)^2/D

The like-spin terms are written as 1/2 sum (ia|jb)[(ia|jb) - (ib|ja)]/D, which
is the same quantity -- relabelling a with b turns sum (ib|ja)^2/D into
sum (ia|jb)^2/D because D is symmetric in them -- and half the arithmetic. The
mixed block is NOT antisymmetrised: two electrons of different spin are already
distinguishable, so there is no exchange term to subtract. Getting that wrong
is the failure this pair is most likely to have, and it is what the tests
target.

The conventional route transforms three (ov|ov) blocks instead of one. The
fitted route builds one B tensor per spin against the same auxiliary basis, so
the mixed block is a gemm between them. Like-spin blocks reuse the restricted
routine's occupied-pair weighting; the mixed block does not get it, because i
is alpha and j is beta and (i,j) is not (j,i).

THE CLOSED-SHELL LIMIT IS THE TEST. An unrestricted MP2 on a closed shell must
reproduce the restricted one exactly, and the new suite asserts it for both
implementations -- correlation and each spin channel separately, so a failure
says which factor is wrong. The fitted pair is checked against RI-MP2 rather
than against conventional MP2, so the fitting error cancels instead of forcing
a tolerance loose enough to hide a mistake.

Against PySCF on a UHF water cation in STO-3G: correlation to 9.4e-10, and the
spin decomposition matches its own e_corr_ss and e_corr_os to 1e-10.

DOUBLE HYBRIDS. The energy path no longer refuses an open shell. The GRADIENT
path still does, and that refusal is untouched: it needs a relaxed density and
a spin-resolved response, neither of which this adds.

Fukui evaluates the perturbative term for all three states, recomputing the
neutral's rather than taking it from the caller. The caller computes it after
the analysis runs, so it is not available to take -- but even if it were,
sourcing one of three states from another code path makes the descriptors
depend on two places agreeing about frozen cores and auxiliary bases. One
restricted MP2 beside the ions' two unrestricted ones buys identical treatment
by construction.

Fitted exactly when the energy's own term is fitted. The first version of this
accepted an `aux` argument that the bridge never passed, so the fitted and
exact decks returned identical numbers -- which is what exposed it, since a
fitted correlation that agrees to all six printed digits has not been fitted.

VALIDATED, formaldehyde/6-31G, delta-SCF against PySCF with frozen=2:

    b2plyp   IP 0.390746  EA -0.086156   -- both exact to 6 dp
    b2gp-plyp, mpw2plyp   run; RI path differs from exact by 2-3e-6, the
    fitting error, which is what says it is actually fitting.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>