### PR TITLE
Stop billing the Fock build to the exchange-correlation quadrature

### DIFF
--- a/backends/libcint/mqc_libcint_rhf.f90
+++ b/backends/libcint/mqc_libcint_rhf.f90
@@ -533,12 +533,16 @@ contains
          ! The energy belongs to the Fock built from this density, so both come
          ! back together and before extrapolation. A DIIS-mixed Fock is a
          ! convergence device, not a state anything is the energy of.
+         ! Read the bucket BEFORE the build. `assemble_fock` closes the Fock
+         ! stage itself, so by the time it returns the time is already charged
+         ! and a read here would difference against itself -- which is what the
+         ! per-iteration Fock column was doing when it printed 0.00 s beside a
+         ! Kohn-Sham run that plainly took seconds.
+         t_fock_iter = clk%seconds_of(STAGE_FOCK)
          call assemble_fock(mol, h, density, coeff, n_occ, bmat, eri, bounds, xc, &
                             fock, e_elec, error, clk=clk, screening=screening, incr=incr, &
                             bmat_lr=bmat_lr)
          if (error%has_error()) return
-         t_fock_iter = clk%seconds_of(STAGE_FOCK)
-         call clk%lap(STAGE_FOCK)
          t_fock_iter = clk%seconds_of(STAGE_FOCK) - t_fock_iter
 
          ! FDS - SDF, projected into the orthogonal basis. It vanishes exactly
@@ -591,9 +595,11 @@ contains
       call move_alloc(density, result%density)
       call diis%destroy()
 
-      ! The final rebuild above is a Fock build like any other, so it lands in the
-      ! same bucket; `wall` closes over everything including it.
-      call clk%lap(STAGE_FOCK)
+      ! The final rebuild above is a Fock build like any other and lands in the
+      ! same bucket -- charged by `assemble_fock` itself, so no lap here. One
+      ! used to be, and once the routine started closing its own stage that
+      ! second lap only inflated the call count: 24 builds reported for a
+      ! 12-iteration SCF.
       call clk%finish()
       call scf_table_footer(verbose, result%converged, result%iterations)
       call energy_components(verbose, mol, result%density, result%electronic, &
@@ -1101,6 +1107,20 @@ contains
 
       ! Taken here, from the Fock matrix that is still a mean field.
       e_elec = electronic_energy(h, fock, density)
+
+      ! CLOSE THE FOCK BUCKET BEFORE THE QUADRATURE OPENS.
+      !
+      ! `lap` charges everything since the previous lap to the stage it names,
+      ! and the previous lap is in the caller, before this routine was entered.
+      ! So a single `lap(STAGE_XC)` after the quadrature charged the two-electron
+      ! build to the quadrature as well, and the caller's `lap(STAGE_FOCK)`
+      ! immediately afterwards found nothing left to charge.
+      !
+      ! The report said so plainly and was read as a result rather than as a
+      ! bug: 14 Fock builds at 0.00 s beside 81.57 s of "XC quadrature" on a
+      ! 518-function PBE0 run. A Kohn-Sham profile that shows no Fock time at
+      ! all is reporting on its own instrumentation.
+      if (present(clk)) call clk%lap(STAGE_FOCK)
 
       if (kohn_sham) then
          allocate (v_xc(size(h, 1), size(h, 2)))


### PR DESCRIPTION
A Kohn-Sham run reported no Fock time at all. On a 518-function PBE0 job:

    XC quadrature       81.57 s      14      5.8264 s
    Fock builds          0.00 s      14      0.0001 s

Fourteen two-electron builds in zero seconds, which is not a result about the code but about the instrumentation measuring it. Jorge spotted it and said so plainly: that cannot have taken 0 at 518 basis functions.

CAUSE. `clk%lap(name)` charges everything since the PREVIOUS lap to the stage it names. `assemble_fock` had exactly one lap -- `lap(STAGE_XC)`, after the quadrature -- and the previous lap was back in the caller, before the routine was entered. So the J and K build was charged to the quadrature along with the quadrature, and the caller's `lap(STAGE_FOCK)` immediately afterwards found nothing left to charge. The Fock stage now closes before the quadrature opens.

A SECOND BUG UNDERNEATH IT, which fixing the first exposed rather than fixed. The per-iteration Fock column read the bucket AFTER the build:

    call assemble_fock(...)
    t_fock_iter = clk%seconds_of(STAGE_FOCK)   ! already charged by now
    call clk%lap(STAGE_FOCK)
    t_fock_iter = clk%seconds_of(STAGE_FOCK) - t_fock_iter

which differences the bucket against itself. Correcting only the summary left that column still printing 0.00 s, which is what re-running rather than assuming caught. The read now happens before the call.

The caller's lap then had no time left to charge and only inflated the count -- 24 builds reported for a 12-iteration SCF -- so it is gone. `assemble_fock` charges its own stage.

WHAT THE NUMBERS ACTUALLY ARE. Formaldehyde-sized BODIPY, cc-pVDZ, PBE0:

    before   Fock  0.00 s / 24 calls      XC  38.29 s / 12
    after    Fock 21.33 s / 12 calls      XC  17.78 s / 12

The total is unchanged; it was only ever misattributed. Roughly half the SCF is the two-electron build, not the ~0% the report claimed, and any tuning aimed at the quadrature on the strength of that table was aimed at the wrong half.

NOT FIXED HERE: `assemble_fock_uhf` takes no clock, so an unrestricted Kohn-Sham run still shows no quadrature breakdown -- all of it lands in the Fock bucket via the caller's lap, which is the only accounting on that path. Separate change, and not one to make without a case to check it against.