### PR TITLE
pcm

### DIFF
--- a/backends/cuest/backend/mqc_cuest_integrals.f90
+++ b/backends/cuest/backend/mqc_cuest_integrals.f90
@@ -1018,6 +1018,18 @@ contains
          call error%set(ERROR_VALIDATION, "keywords.pcm.angular_points must be positive")
          return
       end if
+      ! The model is cuEST's own: the plan takes a cavity and a dielectric and
+      ! solves its fixed formulation. "cpcm" -- the default -- is the only value
+      ! accepted here; "iefpcm" exists for the CPU backend, which solves either,
+      ! and substituting one model's charges for the other's would change the
+      ! energy without saying so.
+      if (trim(pcm%method) /= "cpcm") then
+         call error%set(ERROR_VALIDATION, "keywords.pcm.method = '"//trim(pcm%method)// &
+                        "' is not available on the cuEST backend, whose continuum "// &
+                        "solver is fixed. Run this model on the CPU backend, or drop "// &
+                        "the method keyword.")
+         return
+      end if
 
       natm = size(atomic_numbers)
       allocate (angular_per_atom(natm), radii(natm), zetas(natm), charges(natm))

--- a/backends/libcint/CMakeLists.txt
+++ b/backends/libcint/CMakeLists.txt
@@ -34,6 +34,7 @@ target_sources(
           mqc_libcint_cphf.F90
           mqc_libcint_dma.f90
           mqc_libcint_esp.f90
+          mqc_libcint_pcm.f90
           mqc_libcint_charges.f90
           mqc_libcint_fukui.f90
           mqc_libcint_fmo.f90

--- a/backends/libcint/mqc_libcint_bridge.f90
+++ b/backends/libcint/mqc_libcint_bridge.f90
@@ -31,6 +31,7 @@ module mqc_libcint_bridge
    use mqc_libcint_atomic_guess, only: build_atomic_guess, parse_guess_name, &
                                        guess_display_name
    use mqc_libcint_xc, only: xc_context_t, xc_context_create, xc_available
+   use mqc_libcint_pcm, only: pcm_context_t
    use mqc_libcint_gradient, only: libcint_scf_gradient
    use mqc_libcint_hessian, only: rhf_hessian, hessian_to_matrix
    use mqc_libcint_mp2_gradient, only: libcint_mp2_gradient
@@ -477,6 +478,7 @@ contains
       type(libcint_molecule_t), target :: aux
       type(libcint_molecule_t), pointer :: aux_arg
       type(rhf_result_t) :: scf
+      type(pcm_context_t) :: pcm_ctx
       type(error_t) :: error
       character(len=MAX_ELEMENT_SYMBOL_LEN), allocatable :: symbols(:)
       integer :: iatom, diis_size, guess_kind
@@ -546,19 +548,53 @@ contains
       unrestricted = (fragment%multiplicity /= 1) .or. (mod(fragment%nelec, 2) /= 0) &
                      .or. settings%unrestricted
 
-      ! Continuum solvation belongs to cuEST on this side: the CPU path has no
-      ! cavity, no surface charges and no attenuated one-electron integrals over
-      ! them. Refused rather than ignored, because ignoring it returns a
-      ! gas-phase energy for a deck that asked for solvent -- of the right
-      ! magnitude, converged, and with nothing in the output to say the solvent
-      ! was dropped.
+      ! Continuum solvation on this backend is an *energy*: the surface
+      ! charges enter every SCF iteration and the total. What does not exist is
+      ! their derivative -- the cavity moves with the nuclei and the charges
+      ! respond -- so an analytic gradient would come back converged, plausible
+      ! and missing the solvent's pull on every atom. And anything that runs
+      ! further calculations on top of the solvated reference -- correlation,
+      ! the Fukui ions -- needs its own decision about the continuum, which
+      ! none of them has yet. Each combination is refused by name rather than
+      ! run in a quietly mixed phase.
       if (settings%pcm%enabled) then
-         call result%error%set(ERROR_VALIDATION, "continuum solvation (keywords.pcm) is "// &
-                               "implemented on the cuEST backend only; the CPU path has "// &
-                               "no cavity. Refused rather than run in the gas phase, "// &
-                               "which is what ignoring it would silently give you.")
-         result%has_error = .true.
-         return
+         if (do_gradient) then
+            call result%error%set(ERROR_VALIDATION, "the PCM nuclear gradient is not "// &
+                                  "implemented on the CPU backend -- the energy is, but "// &
+                                  "its cavity and charge-response derivative terms are "// &
+                                  "not built. Run the energy here, or the gradient on "// &
+                                  "the cuEST backend, which has them.")
+            result%has_error = .true.
+            return
+         end if
+         if (settings%run_mp2 .or. settings%run_cc) then
+            call result%error%set(ERROR_VALIDATION, "correlation on top of a solvated "// &
+                                  "reference is not implemented on the CPU backend: the "// &
+                                  "orbitals would carry the continuum while the "// &
+                                  "correlation treatment ignored it, and which scheme "// &
+                                  "that amounts to should be chosen, not implied. Run "// &
+                                  "the SCF with keywords.pcm, or the correlation "// &
+                                  "without it.")
+            result%has_error = .true.
+            return
+         end if
+         if (allocated(settings%fukui_population)) then
+            call result%error%set(ERROR_VALIDATION, "the Fukui analysis runs two more "// &
+                                  "SCFs for the ions, and those would run in the gas "// &
+                                  "phase against a solvated neutral -- an IP computed "// &
+                                  "across two different physics. Not wired up; run the "// &
+                                  "analysis without keywords.pcm.")
+            result%has_error = .true.
+            return
+         end if
+         if (settings%bonding_energy) then
+            call result%error%set(ERROR_VALIDATION, "the bonding energy decomposition "// &
+                                  "rebuilds its atom energies from gas-phase operators "// &
+                                  "and would drop the dielectric term without saying "// &
+                                  "so. Not wired up; run it without keywords.pcm.")
+            result%has_error = .true.
+            return
+         end if
       end if
 
       if (unrestricted .and. settings%density_fitting) then
@@ -670,6 +706,21 @@ contains
             write (line, "(a,a,a,i0)") "  functional: ", trim(settings%functional), ", grid level ", settings%grid_level
             call logger%info(trim(line))
          end if
+         ! A double hybrid's perturbative term is an MP2 on top of the
+         ! reference, and correlation over a solvated reference is refused
+         ! above by name. This is the same refusal for the case where the deck
+         ! spells MP2 as part of the functional.
+         if (settings%pcm%enabled .and. xc%pt2_fraction /= 0.0_dp) then
+            call result%error%set(ERROR_VALIDATION, "a double hybrid under continuum "// &
+                                  "solvation is correlation on a solvated reference, "// &
+                                  "which is not implemented on the CPU backend -- see "// &
+                                  "the MP2 refusal. Use a hybrid or GGA functional "// &
+                                  "with keywords.pcm.")
+            result%has_error = .true.
+            if (kohn_sham) call xc%destroy()
+            call mol%destroy()
+            return
+         end if
       end if
 
       ! ---- which initial guess? ---------------------------------------------
@@ -733,6 +784,29 @@ contains
       ! and after a fallback it is the only place the substitution is visible.
       call logger%verbose("initial guess: "//guess_display_name(guess_kind))
 
+      ! ---- the continuum, once per geometry ---------------------------------
+      !
+      ! Built here because this is the first point where the molecule exists;
+      ! the SCF then solves the surface charges against each iteration's
+      ! density. The banner mirrors the cuEST driver's, so a run reads the same
+      ! on either backend.
+      if (settings%pcm%enabled) then
+         call pcm_ctx%build(mol, fragment%element_numbers, settings%pcm, error)
+         if (error%has_error()) then
+            call result%error%set(ERROR_VALIDATION, error%get_message())
+            result%has_error = .true.
+            call mol%destroy()
+            return
+         end if
+         write (line, "(a,f10.4,a,i0,a,f6.3,a,a)") "    continuum: eps = ", &
+            settings%pcm%dielectric, "   angular points ", settings%pcm%angular_points, &
+            "   radii x ", settings%pcm%radii_scale, "   model ", trim(settings%pcm%method)
+         call logger%info(trim(line))
+         write (line, "(a,i0,a,i0,a)") "    continuum: ", pcm_ctx%surface%n_points, &
+            " surface points kept, ", pcm_ctx%surface%n_discarded, " buried"
+         call logger%info(trim(line))
+      end if
+
       ! Density fitting is asked for, not inferred. aux_basis_set carries a
       ! default, so treating its presence as the request would mean every
       ! calculation quietly fitted -- and the difference is 5e-5 Hartree, large
@@ -773,14 +847,15 @@ contains
          call run_libcint_rhf(mol, fragment%nelec, settings%max_iter, settings%energy_tol, &
                               settings%density_tol, settings%verbose, scf, error, &
                               aux=aux, diis_vectors=diis_size, guess=guess_kind, &
-                              guess_density=guess_total, xc=xc)
+                              guess_density=guess_total, xc=xc, pcm=pcm_ctx)
          ! Kept alive: the gradient below has to be told the same auxiliary
          ! basis this SCF fitted with. Released once past it.
       else if (unrestricted) then
          call run_libcint_uhf(mol, fragment%nelec, fragment%multiplicity, settings%max_iter, &
                               settings%energy_tol, settings%density_tol, settings%verbose, &
                               scf, error, diis_vectors=diis_size, guess=guess_kind, &
-                              guess_density_alpha=guess_a, guess_density_beta=guess_b, xc=xc)
+                              guess_density_alpha=guess_a, guess_density_beta=guess_b, xc=xc, &
+                              pcm=pcm_ctx)
       else
          ! Store the integrals when they fit, rather than rebuilding every
          ! quartet at every iteration.
@@ -807,7 +882,7 @@ contains
          call run_libcint_rhf(mol, fragment%nelec, settings%max_iter, settings%energy_tol, &
                               settings%density_tol, settings%verbose, scf, error, &
                               diis_vectors=diis_size, guess=guess_kind, &
-                              guess_density=guess_total, xc=xc, &
+                              guess_density=guess_total, xc=xc, pcm=pcm_ctx, &
                               in_core=eri_fits_in_core(mol%nao) .and. .not. xc%range_separated)
       end if
       if (error%has_error()) then
@@ -838,6 +913,11 @@ contains
 
       result%energy%scf = scf%energy
       result%has_energy = .true.
+      if (settings%pcm%enabled) then
+         write (line, "(a,f18.10,a,f9.4)") "    continuum: E_diel = ", scf%pcm_energy, &
+            "   total surface charge ", scf%pcm_charge
+         call logger%info(trim(line))
+      end if
 
       ! ---- analyses asked for alongside the energy ---------------------------
       !
@@ -1079,9 +1159,13 @@ contains
       ! have to be redistributed onto the heavy atoms the caps replaced, and
       ! that is checked for the finite-difference path and not for this one.
       ! Falling back leaves a fragmented Hessian exactly as it was.
+      ! A solvated SCF also falls through: these second derivatives are the
+      ! gas-phase operator's, and the finite-difference fallback is *correct*
+      ! for the continuum -- each displaced energy rebuilds its own cavity.
       if (do_hessian .and. .not. unrestricted .and. .not. kohn_sham &
           .and. .not. settings%density_fitting .and. .not. settings%run_mp2 &
-          .and. .not. settings%run_cc .and. fragment%n_caps == 0) then
+          .and. .not. settings%run_cc .and. .not. settings%pcm%enabled &
+          .and. fragment%n_caps == 0) then
          block
             real(dp), allocatable :: hess4(:, :, :, :)
             type(timer_type) :: hess_clock

--- a/backends/libcint/mqc_libcint_pcm.f90
+++ b/backends/libcint/mqc_libcint_pcm.f90
@@ -1,0 +1,865 @@
+!! A polarizable continuum for the CPU backend
+module mqc_libcint_pcm
+   !! The cavity, the surface charges, and the one-electron operator they add.
+   !!
+   !! This is the smooth switching/Gaussian (SWIG) discretization of Lange and
+   !! Herbert [J. Chem. Phys. 133, 244111 (2010)], solved either as C-PCM or as
+   !! IEF-PCM, and it follows PySCF's `pyscf.solvent.pcm` term for term -- the
+   !! same Lebedev points per sphere, the same switching function, the same
+   !! per-point Gaussian exponents from the fitted xi of Table II in
+   !! [J. Chem. Phys. 122, 194110 (2005)], the same S and D matrices. That is a
+   !! deliberate choice of reference: every piece of this file can be diffed
+   !! against a working Python implementation, and the validation suite does so.
+   !!
+   !! **What each surface point is.** Not a point charge but a normalized
+   !! spherical Gaussian of exponent `zeta**2`, which is what keeps every matrix
+   !! element finite as points approach each other and the cavity smooth as
+   !! points cross the switching region. Its electrostatic potential at distance
+   !! d is `erf(zeta*d)/d` -- exactly the attenuated `1/r` that libcint's
+   !! `int1e_grids` produces when `env(PTR_RANGE_OMEGA)` holds `zeta`. So the
+   !! solute-surface integrals need no fake basis functions: the points are
+   !! grouped by their zeta (there are few distinct values -- one per cavity
+   !! radius per Lebedev weight orbit) and each group is one batched grids call
+   !! per shell pair, attenuated by its own omega.
+   !!
+   !! **The charge solve is direct.** K is formed once per geometry -- it depends
+   !! on the cavity and the dielectric, neither of which moves during an SCF --
+   !! and LU-factored; each iteration is two triangular solves. So
+   !! `keywords.pcm.tolerance` and `max_iter`, which bound cuEST's conjugate
+   !! gradient solve, have nothing to bound here: the direct solve meets any
+   !! tolerance they could ask for.
+   !!
+   !! The energy is `E_diel = q . v / 2` and the Fock matrix takes the *full*
+   !! potential of the charges, because the charges are determined variationally
+   !! and the half does not appear in the derivative -- the same split the cuEST
+   !! path documents in `system_pcm_device`.
+   use pic_types, only: dp
+   use, intrinsic :: iso_c_binding, only: c_int, c_ptr, c_loc, c_null_ptr
+   use pic_blas_interfaces, only: pic_gemm, pic_gemv
+   use pic_lapack_interfaces, only: pic_getrf, pic_getrs
+   use mqc_error, only: error_t, ERROR_VALIDATION
+   use mqc_physical_constants, only: PI
+   use mqc_lebedev, only: lebedev_grid
+   use mqc_pcm_radii, only: cavity_radius
+   use mqc_method_config, only: pcm_config_t
+   use mqc_calculation_defaults, only: DEFAULT_PCM_ZETA
+   use mqc_libcint_integrals, only: libcint_molecule_t, shell_dim
+   use libcint_fortran, only: LIBCINT_PTR_RANGE_OMEGA
+   use pic_io, only: to_char
+   implicit none
+   private
+
+   public :: pcm_context_t
+   public :: pcm_surface_t
+   public :: build_pcm_surface
+   public :: PCM_MODEL_CPCM
+   public :: PCM_MODEL_IEFPCM
+
+   integer, parameter :: PCM_MODEL_CPCM = 1
+      !! Conductor-like: K = S, scaled by (eps-1)/eps
+   integer, parameter :: PCM_MODEL_IEFPCM = 2
+      !! Integral equation formalism: the D-matrix terms, scaled by (eps-1)/(eps+1)
+
+   !> `PTR_GRIDS` from libcint's `cint.h`. Not exported by the Fortran
+   !> interface, and 0-based like every other `PTR_*`, so it is used as `+ 1`.
+   integer, parameter :: LIBCINT_PTR_GRIDS = 12
+
+   !> The Lebedev orders the SWIG exponents are fitted for, and the fitted
+   !> values. Table II of [J. Chem. Phys. 122, 194110 (2005)], copied from
+   !> PySCF's `pcm.XI` so the two discretizations are the same numbers.
+   !> `mqc_lebedev` also carries orders 74, 230 and 266, which the paper does
+   !> not tabulate; those are refused rather than interpolated.
+   integer, parameter :: N_XI_ORDERS = 29
+   integer, parameter :: XI_ORDERS(N_XI_ORDERS) = [ &
+                         6, 14, 26, 38, 50, 86, 110, 146, 170, 194, 302, 350, 434, 590, &
+                         770, 974, 1202, 1454, 1730, 2030, 2354, 2702, 3074, 3470, 3890, &
+                         4334, 4802, 5294, 5810]
+   real(dp), parameter :: XI_VALUES(N_XI_ORDERS) = [ &
+                          4.84566077868_dp, 4.86458714334_dp, 4.85478226219_dp, 4.90105812685_dp, &
+                          4.89250673295_dp, 4.89741372580_dp, 4.90101060987_dp, 4.89825187392_dp, &
+                          4.90685517725_dp, 4.90337644248_dp, 4.90498088169_dp, 4.86879474832_dp, &
+                          4.90567349080_dp, 4.90624071359_dp, 4.90656435779_dp, 4.90685167998_dp, &
+                          4.90704098216_dp, 4.90721023869_dp, 4.90733270691_dp, 4.90744499142_dp, &
+                          4.90753082825_dp, 4.90760972766_dp, 4.90767282394_dp, 4.90773141371_dp, &
+                          4.90777965981_dp, 4.90782469526_dp, 4.90749125553_dp, 4.90762073452_dp, &
+                          4.90792902522_dp]
+
+   !> A point whose quadrature weight times switching value falls below this is
+   !> buried inside a neighbouring sphere and dropped, as PySCF drops it.
+   real(dp), parameter :: BURIED_CUTOFF = 1.0e-16_dp
+
+   type :: pcm_surface_t
+      !! The discretized cavity: one smooth Gaussian per surviving Lebedev point
+      integer :: n_points = 0
+      integer :: n_discarded = 0            !! Buried points that were dropped
+      integer, allocatable :: parent(:)     !! Owning atom, 1-based
+      real(dp), allocatable :: coords(:, :)  !! (3, n), Bohr
+      real(dp), allocatable :: normals(:, :)  !! (3, n), outward unit normals
+      real(dp), allocatable :: zeta(:)      !! Gaussian exponent is zeta**2
+      real(dp), allocatable :: weights(:)   !! Lebedev weight times 4 pi
+      real(dp), allocatable :: switch_f(:)  !! SWIG switching value, in (0, 1]
+      real(dp), allocatable :: area(:)      !! weight * R**2 * switch, Bohr**2
+      real(dp), allocatable :: r_parent(:)  !! Cavity radius of the owning atom
+   end type pcm_surface_t
+
+   type :: pcm_group_t
+      !! Surface points sharing one zeta, batched into one grids call
+      !!
+      !! `env` is the molecule's env with this group's point coordinates
+      !! appended and `PTR_RANGE_OMEGA` set to the group's zeta, prebuilt once
+      !! because nothing in it moves during the SCF.
+      real(dp) :: zeta = 0.0_dp
+      integer, allocatable :: idx(:)        !! Global point indices
+      real(dp), allocatable :: env(:)
+   end type pcm_group_t
+
+   type :: pcm_context_t
+      !! Everything the SCF iteration needs from the continuum
+      logical :: enabled = .false.
+      integer :: model = PCM_MODEL_CPCM
+      real(dp) :: dielectric = 0.0_dp
+      real(dp) :: f_eps = 0.0_dp            !! The dielectric scale factor of the model
+      type(pcm_surface_t) :: surface
+      real(dp), allocatable :: kmat(:, :)   !! K, LU-factored in place
+      integer, allocatable :: ipiv(:)
+      real(dp), allocatable :: rmat(:, :)   !! R, IEF-PCM only; C-PCM's R is -f_eps * I
+      real(dp), allocatable :: v_nuc(:)     !! Nuclear potential at the points
+      integer :: n_groups = 0
+      type(pcm_group_t), allocatable :: groups(:)
+      ! What the last solve did, for reporting beside the SCF table.
+      real(dp) :: e_diel = 0.0_dp
+      real(dp) :: q_total = 0.0_dp          !! Total apparent surface charge
+   contains
+      procedure :: build => pcm_build
+      procedure :: init_model => pcm_init_model
+      procedure :: build_operators => pcm_build_operators
+      procedure :: solve => pcm_solve
+      procedure :: operator_matrix => pcm_operator_matrix
+      procedure :: destroy => pcm_destroy
+   end type pcm_context_t
+
+   interface
+      function cint1e_grids_sph(buf, dims, shls, atm, natm, bas, nbas, env, opt, &
+                                cache) result(ret) bind(C, name="int1e_grids_sph")
+         import :: c_int, c_ptr
+         implicit none
+         type(c_ptr), value, intent(in) :: buf, dims, shls, atm
+         integer(c_int), value, intent(in) :: natm
+         type(c_ptr), value, intent(in) :: bas
+         integer(c_int), value, intent(in) :: nbas
+         type(c_ptr), value, intent(in) :: env, opt, cache
+         integer(c_int) :: ret
+      end function cint1e_grids_sph
+
+      function cint1e_grids_cart(buf, dims, shls, atm, natm, bas, nbas, env, opt, &
+                                 cache) result(ret) bind(C, name="int1e_grids_cart")
+         import :: c_int, c_ptr
+         implicit none
+         type(c_ptr), value, intent(in) :: buf, dims, shls, atm
+         integer(c_int), value, intent(in) :: natm
+         type(c_ptr), value, intent(in) :: bas
+         integer(c_int), value, intent(in) :: nbas
+         type(c_ptr), value, intent(in) :: env, opt, cache
+         integer(c_int) :: ret
+      end function cint1e_grids_cart
+   end interface
+
+contains
+
+   function switch_h(x) result(h)
+      !! The elementary switching function, eq. 3.19 of the SWIG paper
+      !!
+      !! A quintic that rises smoothly from 0 to 1 across [0, 1] with two
+      !! vanishing derivatives at each end. (The paper prints the polynomial
+      !! with a typo; this is the corrected form PySCF uses.)
+      real(dp), intent(in) :: x
+      real(dp) :: h
+
+      if (x <= 0.0_dp) then
+         h = 0.0_dp
+      else if (x >= 1.0_dp) then
+         h = 1.0_dp
+      else
+         h = x**3*(10.0_dp - 15.0_dp*x + 6.0_dp*x**2)
+      end if
+   end function switch_h
+
+   subroutine build_pcm_surface(atomic_numbers, coords, angular_points, radii_scale, &
+                                surface, error)
+      !! Tessellate the cavity: Lebedev points per atom, switched and pruned
+      !!
+      !! Free of the molecule type on purpose: the cavity depends on nuclei and
+      !! radii, not on the basis, and the unit tests exercise it against
+      !! analytic spheres with no basis in sight.
+      integer, intent(in) :: atomic_numbers(:)
+      real(dp), intent(in) :: coords(:, :)      !! (3, natm), Bohr
+      integer, intent(in) :: angular_points     !! Lebedev points per sphere
+      real(dp), intent(in) :: radii_scale       !! Scaling from van der Waals radii
+      type(pcm_surface_t), intent(out) :: surface
+      type(error_t), intent(inout) :: error
+
+      real(dp), allocatable :: unit_points(:, :), unit_weights(:)
+      real(dp), allocatable :: radii(:), r_switch(:), r_inner(:)
+      real(dp), allocatable :: pt(:, :), nrm(:, :), zet(:), wgt(:), swf(:)
+      integer, allocatable :: own(:)
+      real(dp) :: point(3)
+      real(dp) :: xi, ratio, alpha, w, f, d, dist
+      integer :: natm, iatom, jatom, ipt, n_kept, xi_index, i
+
+      if (error%has_error()) return
+
+      natm = size(atomic_numbers)
+      if (size(coords, 1) /= 3 .or. size(coords, 2) /= natm) then
+         call error%set(ERROR_VALIDATION, "PCM surface: coordinates must be (3, natm)")
+         return
+      end if
+
+      ! The exponent table is fitted per Lebedev order, so an order it does not
+      ! cover has no exponents to use -- refused rather than interpolated, since
+      ! a wrong exponent smooths the cavity by the wrong amount and changes the
+      ! solvation energy without failing.
+      xi_index = 0
+      do i = 1, size(XI_ORDERS)
+         if (XI_ORDERS(i) == angular_points) then
+            xi_index = i
+            exit
+         end if
+      end do
+      if (xi_index == 0) then
+         call error%set(ERROR_VALIDATION, "keywords.pcm.angular_points = "// &
+                        to_char(angular_points)//" has no fitted SWIG exponent. The "// &
+                        "continuum's Gaussian widths are tabulated per Lebedev order "// &
+                        "[J. Chem. Phys. 122, 194110 (2005), Table II]; use one of "// &
+                        "6, 14, 26, 38, 50, 86, 110, 146, 170, 194, 302, 350, 434, 590 "// &
+                        "or denser.")
+         return
+      end if
+      xi = XI_VALUES(xi_index)
+
+      call lebedev_grid(angular_points, unit_points, unit_weights, error)
+      if (error%has_error()) return
+
+      ! The switching region of each sphere, eq. 3.11-3.13 of the SWIG paper:
+      ! a shell of width R_sw just inside the cavity radius, sized so that the
+      ! region a point sweeps as it fades matches the point spacing.
+      allocate (radii(natm), r_switch(natm), r_inner(natm))
+      do iatom = 1, natm
+         call cavity_radius(atomic_numbers(iatom), radii_scale, radii(iatom), error)
+         if (error%has_error()) return
+         r_switch(iatom) = radii(iatom)*sqrt(14.0_dp/real(angular_points, dp))
+         ratio = radii(iatom)/r_switch(iatom)
+         alpha = 0.5_dp + ratio - sqrt(ratio**2 - 1.0_dp/28.0_dp)
+         r_inner(iatom) = radii(iatom) - alpha*r_switch(iatom)
+      end do
+
+      allocate (pt(3, natm*angular_points), nrm(3, natm*angular_points))
+      allocate (zet(natm*angular_points), wgt(natm*angular_points))
+      allocate (swf(natm*angular_points), own(natm*angular_points))
+
+      n_kept = 0
+      surface%n_discarded = 0
+      do iatom = 1, natm
+         do ipt = 1, angular_points
+            point = radii(iatom)*unit_points(:, ipt) + coords(:, iatom)
+            w = 4.0_dp*PI*unit_weights(ipt)
+
+            ! The product of every other sphere's elementary switch. One factor
+            ! at zero -- the point is inside that sphere's inner radius -- kills
+            ! the product, which is what "buried" means here.
+            f = 1.0_dp
+            do jatom = 1, natm
+               if (jatom == iatom) cycle
+               dist = norm2(point - coords(:, jatom))
+               d = (dist - r_inner(jatom))/r_switch(jatom)
+               f = f*switch_h(d)
+               if (f <= 0.0_dp) exit
+            end do
+
+            if (w*f <= BURIED_CUTOFF) then
+               surface%n_discarded = surface%n_discarded + 1
+               cycle
+            end if
+
+            n_kept = n_kept + 1
+            pt(:, n_kept) = point
+            nrm(:, n_kept) = unit_points(:, ipt)
+            wgt(n_kept) = w
+            swf(n_kept) = f
+            own(n_kept) = iatom
+            zet(n_kept) = xi/(radii(iatom)*sqrt(w))
+         end do
+      end do
+
+      if (n_kept == 0) then
+         call error%set(ERROR_VALIDATION, "PCM surface: every point was buried, "// &
+                        "which no molecular cavity produces -- check the geometry's units")
+         return
+      end if
+
+      surface%n_points = n_kept
+      surface%parent = own(1:n_kept)
+      surface%coords = pt(:, 1:n_kept)
+      surface%normals = nrm(:, 1:n_kept)
+      surface%zeta = zet(1:n_kept)
+      surface%weights = wgt(1:n_kept)
+      surface%switch_f = swf(1:n_kept)
+      allocate (surface%area(n_kept), surface%r_parent(n_kept))
+      do ipt = 1, n_kept
+         surface%r_parent(ipt) = radii(own(ipt))
+         surface%area(ipt) = wgt(ipt)*radii(own(ipt))**2*swf(ipt)
+      end do
+   end subroutine build_pcm_surface
+
+   subroutine pcm_init_model(this, method, dielectric, error)
+      !! Settle which continuum model this is and its dielectric scale factor
+      class(pcm_context_t), intent(inout) :: this
+      character(len=*), intent(in) :: method
+      real(dp), intent(in) :: dielectric
+      type(error_t), intent(inout) :: error
+
+      if (error%has_error()) return
+
+      ! A dielectric is required rather than defaulted: every solvent has a
+      ! different one, and a default would silently pick a solvent. Same
+      ! refusal the cuEST plan makes.
+      if (dielectric <= 1.0_dp) then
+         call error%set(ERROR_VALIDATION, "the polarizable continuum needs a solvent "// &
+                        "dielectric greater than one; set keywords.pcm.dielectric. "// &
+                        "There is no solvent-name table on this path, so nothing can "// &
+                        "be assumed from a name.")
+         return
+      end if
+      this%dielectric = dielectric
+
+      select case (trim(adjustl(method)))
+      case ("cpcm", "c-pcm", "CPCM", "C-PCM")
+         this%model = PCM_MODEL_CPCM
+         this%f_eps = (dielectric - 1.0_dp)/dielectric
+      case ("iefpcm", "ief-pcm", "IEFPCM", "IEF-PCM")
+         this%model = PCM_MODEL_IEFPCM
+         this%f_eps = (dielectric - 1.0_dp)/(dielectric + 1.0_dp)
+      case default
+         call error%set(ERROR_VALIDATION, "keywords.pcm.method = '"//trim(method)// &
+                        "' is not a continuum model here. The CPU path solves "// &
+                        "'cpcm' (conductor-like) or 'iefpcm' (integral equation "// &
+                        "formalism); they are different models with different "// &
+                        "energies, so neither substitutes for the other.")
+         return
+      end select
+   end subroutine pcm_init_model
+
+   subroutine pcm_build_operators(this, error)
+      !! Form K from the surface, factor it, and keep R where the model has one
+      !!
+      !! The matrices are eqs. 3.35-3.43 of the SWIG paper as PySCF writes
+      !! them: S carries `erf(zeta_ij r)/r` off the diagonal and
+      !! `zeta sqrt(2/pi)/F` on it; D is its normal derivative with the
+      !! Gaussian correction term and `-zeta sqrt(2/pi)/(2R)` on the diagonal.
+      !!
+      !!     C-PCM:   K = S                          R = -f_eps
+      !!     IEF-PCM: K = S - f_eps/(2 pi) D A S     R = -f_eps (1 - D A/(2 pi))
+      !!
+      !! Once per geometry, hence dense LAPACK rather than anything iterative:
+      !! the LU is paid once and every SCF iteration is two triangular solves.
+      class(pcm_context_t), intent(inout) :: this
+      type(error_t), intent(inout) :: error
+
+      real(dp), allocatable :: smat(:, :), dmat(:, :)
+      real(dp) :: dr(3)
+      real(dp) :: r, nr, zi, zj, zij, xr
+      integer :: n, i, j, info
+
+      if (error%has_error()) return
+      n = this%surface%n_points
+
+      allocate (smat(n, n))
+      if (this%model == PCM_MODEL_IEFPCM) allocate (dmat(n, n))
+
+      !$omp parallel do default(none) schedule(static) &
+      !$omp    shared(this, smat, dmat, n) private(i, j, dr, r, nr, zi, zj, zij, xr)
+      do j = 1, n
+         zj = this%surface%zeta(j)
+         do i = 1, n
+            if (i == j) then
+               smat(j, j) = zj*sqrt(2.0_dp/PI)/this%surface%switch_f(j)
+               if (allocated(dmat)) then
+                  dmat(j, j) = -zj*sqrt(2.0_dp/PI)/(2.0_dp*this%surface%r_parent(j))
+               end if
+            else
+               zi = this%surface%zeta(i)
+               dr = this%surface%coords(:, i) - this%surface%coords(:, j)
+               r = norm2(dr)
+               zij = zi*zj/sqrt(zi**2 + zj**2)
+               xr = zij*r
+               smat(i, j) = erf(xr)/r
+               if (allocated(dmat)) then
+                  nr = dot_product(dr, this%surface%normals(:, j))
+                  dmat(i, j) = smat(i, j)*nr/r**2 &
+                               - 2.0_dp*xr/sqrt(PI)*exp(-xr**2)*nr/r**3
+               end if
+            end if
+         end do
+      end do
+      !$omp end parallel do
+
+      if (this%model == PCM_MODEL_IEFPCM) then
+         ! D becomes D*A in place -- a column scaling, since A weights the
+         ! charge each point stands for -- and then feeds both K and R.
+         do j = 1, n
+            dmat(:, j) = dmat(:, j)*this%surface%area(j)
+         end do
+         allocate (this%kmat(n, n))
+         this%kmat = smat
+         call pic_gemm(dmat, smat, this%kmat, alpha=-this%f_eps/(2.0_dp*PI), beta=1.0_dp)
+         deallocate (smat)
+         ! R = -f_eps (I - DA/(2 pi)), kept dense: IEF-PCM's right-hand side
+         ! mixes the potentials, so the solve needs the whole matrix.
+         call move_alloc(dmat, this%rmat)
+         this%rmat = this%rmat*(this%f_eps/(2.0_dp*PI))
+         do j = 1, n
+            this%rmat(j, j) = this%rmat(j, j) - this%f_eps
+         end do
+      else
+         call move_alloc(smat, this%kmat)
+      end if
+
+      allocate (this%ipiv(n))
+      call pic_getrf(this%kmat, this%ipiv, info)
+      if (info /= 0) then
+         call error%set(ERROR_VALIDATION, "the PCM K matrix is singular (dgetrf info = "// &
+                        to_char(info)//"), which a physical cavity does not produce -- "// &
+                        "two surface points may coincide; check the geometry")
+         return
+      end if
+   end subroutine pcm_build_operators
+
+   subroutine pcm_solve(this, v_grids, q_sym, error)
+      !! Apparent surface charges for one solute potential
+      !!
+      !! `K q = R v`, and for the nonsymmetric K of IEF-PCM also the transposed
+      !! system, averaging the two as PySCF does -- the symmetrized charge is
+      !! what makes `E = q . v / 2` a variational functional of the density.
+      !! C-PCM's K is symmetric and R is a scalar, so there one solve is both.
+      class(pcm_context_t), intent(inout) :: this
+      real(dp), intent(in) :: v_grids(:)
+      real(dp), allocatable, intent(out) :: q_sym(:)
+      type(error_t), intent(inout) :: error
+
+      real(dp), allocatable :: rhs(:, :), adj(:, :), qt(:)
+      integer :: n, info
+
+      if (error%has_error()) return
+      n = this%surface%n_points
+
+      allocate (rhs(n, 1))
+      if (this%model == PCM_MODEL_IEFPCM) then
+         rhs(:, 1) = 0.0_dp
+         call pic_gemv(this%rmat, v_grids, rhs(:, 1))
+      else
+         rhs(:, 1) = -this%f_eps*v_grids
+      end if
+      call pic_getrs(this%kmat, this%ipiv, rhs, info=info)
+      if (info /= 0) then
+         call error%set(ERROR_VALIDATION, "PCM charge solve failed (dgetrs info = "// &
+                        to_char(info)//")")
+         return
+      end if
+
+      if (this%model == PCM_MODEL_IEFPCM) then
+         allocate (adj(n, 1), qt(n))
+         adj(:, 1) = v_grids
+         call pic_getrs(this%kmat, this%ipiv, adj, trans="T", info=info)
+         if (info /= 0) then
+            call error%set(ERROR_VALIDATION, "PCM adjoint charge solve failed "// &
+                           "(dgetrs info = "//to_char(info)//")")
+            return
+         end if
+         qt = 0.0_dp
+         call pic_gemv(this%rmat, adj(:, 1), qt, trans_a="T")
+         q_sym = 0.5_dp*(rhs(:, 1) + qt)
+      else
+         q_sym = rhs(:, 1)
+      end if
+   end subroutine pcm_solve
+
+   subroutine pcm_build(this, mol, atomic_numbers, config, error)
+      !! Cavity, operators, nuclear potential and integral batches, once per geometry
+      class(pcm_context_t), intent(inout) :: this
+      type(libcint_molecule_t), intent(in) :: mol
+      integer, intent(in) :: atomic_numbers(:)
+      type(pcm_config_t), intent(in) :: config
+      type(error_t), intent(inout) :: error
+
+      integer :: ipt, iatom
+      real(dp) :: d
+
+      if (error%has_error()) return
+
+      ! `zeta` tunes the exponent convention cuEST's plan takes, and this path
+      ! does not have that freedom: its exponents are the fitted xi values the
+      ! discretization was parameterized with, one per Lebedev order. A deck
+      ! that moves the knob would silently get the same surface, which is the
+      ! kind of ignored keyword this codebase refuses.
+      if (abs(config%zeta - DEFAULT_PCM_ZETA) > 0.0_dp) then
+         call error%set(ERROR_VALIDATION, "keywords.pcm.zeta tunes the Gaussian "// &
+                        "switching exponents of the cuEST plan. The CPU continuum "// &
+                        "uses the fitted SWIG exponents for its Lebedev order "// &
+                        "[J. Chem. Phys. 122, 194110 (2005)] and has no free "// &
+                        "prefactor; remove the keyword or run the cuEST backend.")
+         return
+      end if
+
+      call this%init_model(config%method, config%dielectric, error)
+      if (error%has_error()) return
+
+      call build_pcm_surface(atomic_numbers, mol%coords, config%angular_points, &
+                             config%radii_scale, this%surface, error)
+      if (error%has_error()) return
+
+      call pcm_build_operators(this, error)
+      if (error%has_error()) return
+
+      ! The nuclear potential each smooth point charge feels. A normalized
+      ! Gaussian of exponent zeta**2 against a point nucleus integrates to
+      ! erf(zeta*d)/d exactly; ghosts carry zero charge in `mol%charges` and so
+      ! contribute nothing, though their spheres still shape the cavity above.
+      allocate (this%v_nuc(this%surface%n_points))
+      this%v_nuc = 0.0_dp
+      do ipt = 1, this%surface%n_points
+         do iatom = 1, mol%natm
+            d = norm2(this%surface%coords(:, ipt) - mol%coords(:, iatom))
+            this%v_nuc(ipt) = this%v_nuc(ipt) &
+                              + mol%charges(iatom)*erf(this%surface%zeta(ipt)*d)/d
+         end do
+      end do
+
+      call build_zeta_groups(this, mol, error)
+      if (error%has_error()) return
+
+      this%enabled = .true.
+   end subroutine pcm_build
+
+   subroutine build_zeta_groups(this, mol, error)
+      !! Batch the surface points by zeta for the attenuated grids integrals
+      !!
+      !! `int1e_grids` takes one `PTR_RANGE_OMEGA` per call, so points sharing
+      !! an exponent -- same cavity radius, same Lebedev weight orbit -- go in
+      !! one call. A 302-point sphere has about a dozen distinct weights, so a
+      !! molecule yields tens of groups, not thousands of single-point calls.
+      class(pcm_context_t), intent(inout) :: this
+      type(libcint_molecule_t), intent(in) :: mol
+      type(error_t), intent(inout) :: error
+
+      real(dp), allocatable :: unique_zeta(:)
+      integer, allocatable :: group_of(:), counts(:)
+      integer :: n, ipt, ig, n_unique, grid_offset, m
+      real(dp) :: z
+
+      if (error%has_error()) return
+      n = this%surface%n_points
+
+      allocate (unique_zeta(n), group_of(n))
+      n_unique = 0
+      do ipt = 1, n
+         z = this%surface%zeta(ipt)
+         group_of(ipt) = 0
+         do ig = 1, n_unique
+            if (abs(unique_zeta(ig) - z) <= 1.0e-12_dp*z) then
+               group_of(ipt) = ig
+               exit
+            end if
+         end do
+         if (group_of(ipt) == 0) then
+            n_unique = n_unique + 1
+            unique_zeta(n_unique) = z
+            group_of(ipt) = n_unique
+         end if
+      end do
+
+      this%n_groups = n_unique
+      allocate (this%groups(n_unique), counts(n_unique))
+      counts = 0
+      do ipt = 1, n
+         counts(group_of(ipt)) = counts(group_of(ipt)) + 1
+      end do
+
+      grid_offset = size(mol%env)
+      do ig = 1, n_unique
+         this%groups(ig)%zeta = unique_zeta(ig)
+         allocate (this%groups(ig)%idx(counts(ig)))
+         allocate (this%groups(ig)%env(grid_offset + 3*counts(ig)))
+         this%groups(ig)%env(1:grid_offset) = mol%env
+         this%groups(ig)%env(LIBCINT_PTR_RANGE_OMEGA + 1) = unique_zeta(ig)
+         this%groups(ig)%env(LIBCINT_PTR_GRIDS + 1) = real(grid_offset, dp)
+      end do
+
+      counts = 0
+      do ipt = 1, n
+         ig = group_of(ipt)
+         counts(ig) = counts(ig) + 1
+         m = counts(ig)
+         this%groups(ig)%idx(m) = ipt
+         this%groups(ig)%env(grid_offset + 3*(m - 1) + 1:grid_offset + 3*m) = &
+            this%surface%coords(:, ipt)
+      end do
+   end subroutine build_zeta_groups
+
+   subroutine surface_potential(groups, n_groups, mol, n_points, density, values, error)
+      !! `values(k) = sum_uv D_uv <u| erf(zeta_k |r - r_k|)/|r - r_k| |v>`
+      !!
+      !! The electronic part of the solute potential on the surface, contracted
+      !! inside the integral loop -- the tensor this avoids storing is
+      !! `(n_ao, n_ao, n_points)`, the same reasoning as `esp_contract`, whose
+      !! loop this is with the group batching and the omega attenuation added.
+      type(pcm_group_t), intent(in), target :: groups(:)
+      integer, intent(in) :: n_groups
+      type(libcint_molecule_t), intent(in), target :: mol
+      integer, intent(in) :: n_points
+      real(dp), intent(in) :: density(:, :)
+      real(dp), intent(out) :: values(:)
+      type(error_t), intent(inout) :: error
+
+      real(dp), allocatable, target :: buf(:)
+      real(dp), allocatable :: local(:)
+      integer, allocatable :: pair_i(:), pair_j(:)
+      integer, target :: shls(4)
+      integer :: block_max, max_group, n_pair, p, ish, jsh, di, dj, io, jo
+      integer :: ig, ng, i, j, g, ret
+      real(dp) :: dij, wt
+
+      if (error%has_error()) return
+
+      values(1:n_points) = 0.0_dp
+      block_max = 1
+      do ish = 1, mol%nbas
+         block_max = max(block_max, shell_dim(mol%cartesian, ish - 1, mol%bas))
+      end do
+      max_group = 0
+      do ig = 1, n_groups
+         max_group = max(max_group, size(groups(ig)%idx))
+      end do
+
+      n_pair = mol%nbas*(mol%nbas + 1)/2
+      allocate (pair_i(n_pair), pair_j(n_pair))
+      p = 0
+      do ish = 1, mol%nbas
+         do jsh = 1, ish
+            p = p + 1
+            pair_i(p) = ish
+            pair_j(p) = jsh
+         end do
+      end do
+
+      !$omp parallel default(none) &
+      !$omp    shared(groups, n_groups, mol, density, values, n_points, &
+      !$omp           block_max, max_group, n_pair, pair_i, pair_j) &
+      !$omp    private(p, ish, jsh, di, dj, io, jo, ig, ng, i, j, g, ret, &
+      !$omp            shls, buf, local, dij, wt)
+      allocate (buf(block_max*block_max*max_group), local(n_points))
+      local = 0.0_dp
+      !$omp do schedule(dynamic)
+      do p = 1, n_pair
+         ish = pair_i(p)
+         jsh = pair_j(p)
+         di = shell_dim(mol%cartesian, ish - 1, mol%bas)
+         io = mol%shell_offset(ish)
+         dj = shell_dim(mol%cartesian, jsh - 1, mol%bas)
+         jo = mol%shell_offset(jsh)
+         ! An off-diagonal block stands for itself and its transpose, counted
+         ! once and doubled, exactly as `esp_contract` counts them.
+         wt = 2.0_dp
+         if (ish == jsh) wt = 1.0_dp
+
+         do ig = 1, n_groups
+            ng = size(groups(ig)%idx)
+            shls = [ish - 1, jsh - 1, 0, ng]
+            if (mol%cartesian) then
+               ret = cint1e_grids_cart(c_loc(buf), c_null_ptr, c_loc(shls), &
+                                       c_loc(mol%atm), mol%natm, c_loc(mol%bas), &
+                                       mol%nbas, c_loc(groups(ig)%env), c_null_ptr, &
+                                       c_null_ptr)
+            else
+               ret = cint1e_grids_sph(c_loc(buf), c_null_ptr, c_loc(shls), &
+                                      c_loc(mol%atm), mol%natm, c_loc(mol%bas), &
+                                      mol%nbas, c_loc(groups(ig)%env), c_null_ptr, &
+                                      c_null_ptr)
+            end if
+            if (ret == 0) cycle
+            do j = 1, dj
+               do i = 1, di
+                  dij = wt*density(io + i, jo + j)
+                  if (dij == 0.0_dp) cycle
+                  do g = 1, ng
+                     local(groups(ig)%idx(g)) = local(groups(ig)%idx(g)) &
+                                                + dij*buf(g + (i - 1)*ng + (j - 1)*ng*di)
+                  end do
+               end do
+            end do
+         end do
+      end do
+      !$omp end do
+      !$omp critical(mqc_pcm_potential_accumulate)
+      values(1:n_points) = values(1:n_points) + local
+      !$omp end critical(mqc_pcm_potential_accumulate)
+      deallocate (buf, local)
+      !$omp end parallel
+   end subroutine surface_potential
+
+   subroutine surface_fock(groups, n_groups, mol, q, vmat, error)
+      !! `vmat(u,v) = -sum_k q_k <u| erf(zeta_k |r - r_k|)/|r - r_k| |v>`
+      !!
+      !! The one-electron operator the surface charges add to the Fock matrix.
+      !! The minus sign is the electron's charge against the apparent charges'
+      !! potential. Same loop as `surface_potential` contracted the other way;
+      !! a shell pair owns its block of `vmat` outright, so the threads share
+      !! nothing but the read-only tables.
+      type(pcm_group_t), intent(in), target :: groups(:)
+      integer, intent(in) :: n_groups
+      type(libcint_molecule_t), intent(in), target :: mol
+      real(dp), intent(in) :: q(:)
+      real(dp), intent(out) :: vmat(:, :)
+      type(error_t), intent(inout) :: error
+
+      real(dp), allocatable, target :: buf(:)
+      real(dp), allocatable :: blk(:, :)
+      integer, allocatable :: pair_i(:), pair_j(:)
+      integer, target :: shls(4)
+      integer :: block_max, max_group, n_pair, p, ish, jsh, di, dj, io, jo
+      integer :: ig, ng, i, j, g, ret
+
+      if (error%has_error()) return
+
+      vmat = 0.0_dp
+      block_max = 1
+      do ish = 1, mol%nbas
+         block_max = max(block_max, shell_dim(mol%cartesian, ish - 1, mol%bas))
+      end do
+      max_group = 0
+      do ig = 1, n_groups
+         max_group = max(max_group, size(groups(ig)%idx))
+      end do
+
+      n_pair = mol%nbas*(mol%nbas + 1)/2
+      allocate (pair_i(n_pair), pair_j(n_pair))
+      p = 0
+      do ish = 1, mol%nbas
+         do jsh = 1, ish
+            p = p + 1
+            pair_i(p) = ish
+            pair_j(p) = jsh
+         end do
+      end do
+
+      !$omp parallel default(none) &
+      !$omp    shared(groups, n_groups, mol, q, vmat, block_max, max_group, &
+      !$omp           n_pair, pair_i, pair_j) &
+      !$omp    private(p, ish, jsh, di, dj, io, jo, ig, ng, i, j, g, ret, &
+      !$omp            shls, buf, blk)
+      allocate (buf(block_max*block_max*max_group), blk(block_max, block_max))
+      !$omp do schedule(dynamic)
+      do p = 1, n_pair
+         ish = pair_i(p)
+         jsh = pair_j(p)
+         di = shell_dim(mol%cartesian, ish - 1, mol%bas)
+         io = mol%shell_offset(ish)
+         dj = shell_dim(mol%cartesian, jsh - 1, mol%bas)
+         jo = mol%shell_offset(jsh)
+
+         blk(1:di, 1:dj) = 0.0_dp
+         do ig = 1, n_groups
+            ng = size(groups(ig)%idx)
+            shls = [ish - 1, jsh - 1, 0, ng]
+            if (mol%cartesian) then
+               ret = cint1e_grids_cart(c_loc(buf), c_null_ptr, c_loc(shls), &
+                                       c_loc(mol%atm), mol%natm, c_loc(mol%bas), &
+                                       mol%nbas, c_loc(groups(ig)%env), c_null_ptr, &
+                                       c_null_ptr)
+            else
+               ret = cint1e_grids_sph(c_loc(buf), c_null_ptr, c_loc(shls), &
+                                      c_loc(mol%atm), mol%natm, c_loc(mol%bas), &
+                                      mol%nbas, c_loc(groups(ig)%env), c_null_ptr, &
+                                      c_null_ptr)
+            end if
+            if (ret == 0) cycle
+            do j = 1, dj
+               do i = 1, di
+                  do g = 1, ng
+                     blk(i, j) = blk(i, j) &
+                                 + q(groups(ig)%idx(g))*buf(g + (i - 1)*ng + (j - 1)*ng*di)
+                  end do
+               end do
+            end do
+         end do
+
+         ! A pair owns both its block and the transposed one, so this write is
+         ! race-free across the pair loop. On the diagonal they coincide.
+         do j = 1, dj
+            do i = 1, di
+               vmat(io + i, jo + j) = -blk(i, j)
+            end do
+         end do
+         if (ish /= jsh) then
+            do j = 1, dj
+               do i = 1, di
+                  vmat(jo + j, io + i) = -blk(i, j)
+               end do
+            end do
+         end if
+      end do
+      !$omp end do
+      deallocate (buf, blk)
+      !$omp end parallel
+   end subroutine surface_fock
+
+   subroutine pcm_operator_matrix(this, mol, density, vmat, energy, error)
+      !! One SCF iteration's continuum: charges from this density, then their operator
+      !!
+      !! The caller adds `vmat` -- the full potential -- to its Fock matrix and
+      !! `energy` -- which already carries the half -- to its electronic energy,
+      !! the same contract `system_pcm_device` keeps on the GPU path.
+      class(pcm_context_t), intent(inout) :: this
+      type(libcint_molecule_t), intent(in) :: mol
+      real(dp), intent(in) :: density(:, :)   !! Total density (alpha plus beta)
+      real(dp), intent(out) :: vmat(:, :)
+      real(dp), intent(out) :: energy
+      type(error_t), intent(inout) :: error
+
+      real(dp), allocatable :: v_grids(:), q_sym(:)
+
+      energy = 0.0_dp
+      if (error%has_error()) return
+
+      allocate (v_grids(this%surface%n_points))
+      call surface_potential(this%groups, this%n_groups, mol, this%surface%n_points, &
+                             density, v_grids, error)
+      if (error%has_error()) return
+      ! Nuclei push the potential up, electrons pull it down.
+      v_grids = this%v_nuc - v_grids
+
+      call this%solve(v_grids, q_sym, error)
+      if (error%has_error()) return
+
+      this%e_diel = 0.5_dp*dot_product(q_sym, v_grids)
+      this%q_total = sum(q_sym)
+      energy = this%e_diel
+
+      call surface_fock(this%groups, this%n_groups, mol, q_sym, vmat, error)
+   end subroutine pcm_operator_matrix
+
+   subroutine pcm_destroy(this)
+      !! Release everything; the context is reusable after another `build`
+      class(pcm_context_t), intent(inout) :: this
+
+      this%enabled = .false.
+      this%n_groups = 0
+      this%e_diel = 0.0_dp
+      this%q_total = 0.0_dp
+      if (allocated(this%kmat)) deallocate (this%kmat)
+      if (allocated(this%ipiv)) deallocate (this%ipiv)
+      if (allocated(this%rmat)) deallocate (this%rmat)
+      if (allocated(this%v_nuc)) deallocate (this%v_nuc)
+      if (allocated(this%groups)) deallocate (this%groups)
+      this%surface = pcm_surface_t()
+   end subroutine pcm_destroy
+
+end module mqc_libcint_pcm

--- a/backends/libcint/mqc_libcint_rhf.f90
+++ b/backends/libcint/mqc_libcint_rhf.f90
@@ -631,6 +631,11 @@ contains
          result%electronic = result%electronic + e_pcm
          result%pcm_energy = e_pcm
          result%pcm_charge = pcm%q_total
+         ! Lapped like the iterations' operators, so the stage counts one per
+         ! Fock build rather than one fewer. The final rebuild is a solvated
+         ! build like any other -- it has to be, or the energy reported would
+         ! be the gas-phase one.
+         call clk%lap(STAGE_PCM)
       end if
       result%nuclear_repulsion = mol%nuclear_repulsion()
       result%energy = result%electronic + result%nuclear_repulsion

--- a/backends/libcint/mqc_libcint_rhf.f90
+++ b/backends/libcint/mqc_libcint_rhf.f90
@@ -26,6 +26,7 @@ module mqc_libcint_rhf
                                  direct_stats_t
    use mqc_libcint_integrals, only: libcint_molecule_t, build_df_tensor
    use mqc_libcint_xc, only: xc_context_t, xc_add_potential, xc_add_potential_uks
+   use mqc_libcint_pcm, only: pcm_context_t
    implicit none
    private
 
@@ -131,6 +132,11 @@ module mqc_libcint_rhf
       real(dp), allocatable :: density_beta(:, :)
       integer :: n_occupied_beta = 0
       real(dp) :: spin_squared = 0.0_dp        !! <S^2>, unrestricted only
+      ! Continuum solvation. Zero when the SCF ran in the gas phase; when a
+      ! context was passed, `energy` and `electronic` above already include
+      ! `pcm_energy` -- this is the breakdown, not an addend.
+      real(dp) :: pcm_energy = 0.0_dp          !! Dielectric energy, halved already
+      real(dp) :: pcm_charge = 0.0_dp          !! Total apparent surface charge
    end type rhf_result_t
 
    !> Iterations between full rebuilds of the accumulated G.
@@ -156,6 +162,7 @@ module mqc_libcint_rhf
    character(len=*), parameter :: STAGE_DIAG = "diagonalisation"
    character(len=*), parameter :: STAGE_DIIS = "DIIS"
    character(len=*), parameter :: STAGE_XC = "XC quadrature"
+   character(len=*), parameter :: STAGE_PCM = "continuum operator"
 
 contains
 
@@ -312,7 +319,7 @@ contains
 
    subroutine run_libcint_rhf(mol, nelec, max_iter, energy_tol, density_tol, &
                               verbose, result, error, aux, diis_vectors, in_core, &
-                              guess, guess_density, xc, h_extra)
+                              guess, guess_density, xc, h_extra, pcm)
       !! Drive a closed-shell SCF to convergence
       type(libcint_molecule_t), intent(in) :: mol
       integer, intent(in) :: nelec
@@ -382,6 +389,12 @@ contains
          !! and not the energy: the dipole is unambiguous, one derivative
          !! better conditioned, and needs no bookkeeping about what the total
          !! is supposed to contain.
+      type(pcm_context_t), intent(inout), optional :: pcm
+         !! Continuum solvation. Present and built means every iteration solves
+         !! the surface charges against its density and folds their operator
+         !! into the Fock matrix; `result%energy` then includes the dielectric
+         !! energy. Present-but-disabled is the same as absent, so a caller can
+         !! pass its context unconditionally.
 
       integer :: diis_size, guess_kind
       logical :: use_in_core
@@ -393,6 +406,9 @@ contains
       real(dp), allocatable :: x(:, :), fock(:, :), density(:, :), density_old(:, :)
       real(dp), allocatable :: coeff(:, :), eigenvalues(:)
       real(dp), allocatable :: err(:, :), fock_flat(:)
+      real(dp), allocatable :: v_pcm(:, :)
+      logical :: use_pcm
+      real(dp) :: e_pcm
       type(diis_state_t) :: diis
       logical :: extrapolated
       real(dp) :: e_elec, e_old, de, drms
@@ -414,6 +430,8 @@ contains
       if (present(in_core)) use_in_core = in_core
       guess_kind = SCF_GUESS_GWH
       if (present(guess)) guess_kind = guess
+      use_pcm = .false.
+      if (present(pcm)) use_pcm = pcm%enabled
 
       n_ao = mol%nao
       n_occ = nelec/2
@@ -481,6 +499,7 @@ contains
 
       allocate (fock(n_ao, n_ao), density(n_ao, n_ao), density_old(n_ao, n_ao))
       allocate (err(n_mo, n_mo), fock_flat(n_ao*n_ao))
+      if (use_pcm) allocate (v_pcm(n_ao, n_ao))
 
       ! The error vector lives in the orthogonal basis, where it is n_mo
       ! square rather than n_ao -- that is the same shape the cuEST path uses
@@ -543,6 +562,25 @@ contains
                             fock, e_elec, error, clk=clk, screening=screening, incr=incr, &
                             bmat_lr=bmat_lr)
          if (error%has_error()) return
+         ! The continuum, after the gas-phase pieces and before the commutator:
+         ! its operator belongs to the Fock matrix DIIS extrapolates and the
+         ! eigenproblem diagonalises, or the converged orbitals would not feel
+         ! the solvent. The energy carries its own half already.
+         !
+         ! Charged to its OWN stage, not folded into the Fock bucket. `lap`
+         ! adds to a stage's seconds and increments its call count, and
+         ! `assemble_fock` already closes STAGE_FOCK itself -- so lapping it
+         ! again here would report two Fock builds per iteration, which is the
+         ! reporting bug the Fock/quadrature split was fixed for. A separate row
+         ! also says what the continuum actually costs, which turns out to be
+         ! almost nothing beside the quadrature.
+         if (use_pcm) then
+            call pcm%operator_matrix(mol, density, v_pcm, e_pcm, error)
+            if (error%has_error()) return
+            fock = fock + v_pcm
+            e_elec = e_elec + e_pcm
+            call clk%lap(STAGE_PCM)
+         end if
          t_fock_iter = clk%seconds_of(STAGE_FOCK) - t_fock_iter
 
          ! FDS - SDF, projected into the orthogonal basis. It vanishes exactly
@@ -587,6 +625,13 @@ contains
       call assemble_fock(mol, h, density, coeff, n_occ, bmat, eri, bounds, xc, &
                          fock, result%electronic, error, clk=clk, bmat_lr=bmat_lr)
       if (error%has_error()) return
+      if (use_pcm) then
+         call pcm%operator_matrix(mol, density, v_pcm, e_pcm, error)
+         if (error%has_error()) return
+         result%electronic = result%electronic + e_pcm
+         result%pcm_energy = e_pcm
+         result%pcm_charge = pcm%q_total
+      end if
       result%nuclear_repulsion = mol%nuclear_repulsion()
       result%energy = result%electronic + result%nuclear_repulsion
       result%n_occupied = n_occ
@@ -610,7 +655,7 @@ contains
 
    subroutine run_libcint_uhf(mol, nelec, multiplicity, max_iter, energy_tol, density_tol, &
                               verbose, result, error, diis_vectors, in_core, diis_start, &
-                              guess, guess_density_alpha, guess_density_beta, xc)
+                              guess, guess_density_alpha, guess_density_beta, xc, pcm)
       !! Drive an unrestricted SCF to convergence
       !!
       !! Two Fock matrices sharing one Coulomb field: F_sigma = H + J(D_a + D_b)
@@ -655,6 +700,11 @@ contains
          !! ordering right. SAD hands over half the spherically averaged total
          !! twice, and relies on the occupations to break the symmetry -- the
          !! same position the core guess is in, but from a far better density.
+      type(pcm_context_t), intent(inout), optional :: pcm
+         !! Continuum solvation, exactly as on the restricted path. The surface
+         !! charges see the total density and their operator lands in both spin
+         !! Fock matrices, because the potential of a classical charge does not
+         !! know spin.
 
       integer :: diis_size, start_cycle, guess_kind
       logical :: use_in_core
@@ -666,6 +716,9 @@ contains
       real(dp), allocatable :: d_a(:, :), d_b(:, :), d_a_old(:, :), d_b_old(:, :)
       real(dp), allocatable :: coeff_a(:, :), coeff_b(:, :), eig_a(:), eig_b(:)
       real(dp), allocatable :: err_a(:, :), err_b(:, :), fock_flat(:), err_flat(:)
+      real(dp), allocatable :: v_pcm(:, :)
+      logical :: use_pcm
+      real(dp) :: e_pcm
       type(diis_state_t) :: diis
       logical :: extrapolated
       real(dp) :: e_elec, e_old, de, drms
@@ -682,6 +735,8 @@ contains
       if (present(in_core)) use_in_core = in_core
       guess_kind = SCF_GUESS_GWH
       if (present(guess)) guess_kind = guess
+      use_pcm = .false.
+      if (present(pcm)) use_pcm = pcm%enabled
 
       ! 2S+1 = n_alpha - n_beta + 1, so the unpaired count is multiplicity - 1.
       ! Both have to come out whole and non-negative, and a deck can ask for a
@@ -742,6 +797,7 @@ contains
       allocate (d_a(n_ao, n_ao), d_b(n_ao, n_ao), d_a_old(n_ao, n_ao), d_b_old(n_ao, n_ao))
       allocate (err_a(n_mo, n_mo), err_b(n_mo, n_mo))
       allocate (fock_flat(2*nsq), err_flat(2*msq))
+      if (use_pcm) allocate (v_pcm(n_ao, n_ao))
 
       ! One subspace over both spins, so an extrapolation step moves them
       ! together. The vectors are the two Fock matrices laid end to end and the
@@ -803,6 +859,15 @@ contains
          call assemble_fock_uhf(mol, h, d_a, d_b, eri, bounds, xc, fock_a, fock_b, &
                                 e_elec, error)
          if (error%has_error()) return
+         ! The continuum sees one density -- the total -- and both spins feel
+         ! one potential, as they would from any classical charge.
+         if (use_pcm) then
+            call pcm%operator_matrix(mol, d_a + d_b, v_pcm, e_pcm, error)
+            if (error%has_error()) return
+            fock_a = fock_a + v_pcm
+            fock_b = fock_b + v_pcm
+            e_elec = e_elec + e_pcm
+         end if
          t_fock_iter = clk%seconds_of(STAGE_FOCK)
          call clk%lap(STAGE_FOCK)
          t_fock_iter = clk%seconds_of(STAGE_FOCK) - t_fock_iter
@@ -852,6 +917,13 @@ contains
       call assemble_fock_uhf(mol, h, d_a, d_b, eri, bounds, xc, fock_a, fock_b, &
                              result%electronic, error)
       if (error%has_error()) return
+      if (use_pcm) then
+         call pcm%operator_matrix(mol, d_a + d_b, v_pcm, e_pcm, error)
+         if (error%has_error()) return
+         result%electronic = result%electronic + e_pcm
+         result%pcm_energy = e_pcm
+         result%pcm_charge = pcm%q_total
+      end if
       result%nuclear_repulsion = mol%nuclear_repulsion()
       result%energy = result%electronic + result%nuclear_repulsion
       result%n_occupied = n_alpha

--- a/mqc_docs/source/continuum_solvation.rst
+++ b/mqc_docs/source/continuum_solvation.rst
@@ -1,0 +1,233 @@
+Continuum solvation (PCM)
+=========================
+
+A molecule in solution sits in a polarizable medium: its charge distribution
+polarizes the solvent, and the polarization acts back on the molecule. A
+polarizable continuum model (PCM) replaces the solvent with a dielectric
+continuum outside a molecule-shaped cavity, puts apparent charges on the cavity
+surface, solves for them self-consistently with the SCF density, and adds their
+potential to the Fock matrix and their interaction energy -- with its
+variational factor of one half -- to the total.
+
+The keyword reference lives with the other keywords in :doc:`input_files`
+(``keywords.pcm``). This page is what the model is, which backend does what,
+why the cavity convention matters more than anything else in it, and how each
+implementation was validated.
+
+Why you would use it
+--------------------
+
+The sharpest case is an ion that does not exist in the gas phase. A 51-atom
+dianion (C\ :sub:`19`\ H\ :sub:`16`\ N\ :sub:`8`\ O\ :sub:`8`, charge -2) at
+PBE0/cc-pVDZ is electronically *unbound* in vacuum: six of its 126 occupied
+orbitals come out with positive orbital energy and the HOMO sits at +0.045
+Hartree. That is not a convergence problem to push through -- adding diffuse
+functions lowers the energy by another 99 kcal/mol, which is the signature of
+electrons escaping toward the continuum limit, not of a basis converging. Every
+gas-phase property of that wave function is an artifact of the basis being too
+small to let the electrons leave.
+
+With a water cavity (IEF-PCM, :math:`\varepsilon` = 78.3553) the same molecule
+is entirely ordinary:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Quantity
+     - Gas phase
+     - IEF-PCM water
+   * - HOMO (Hartree)
+     - +0.045
+     - -0.203
+   * - Occupied orbitals above zero
+     - 6
+     - 0
+   * - HOMO-LUMO gap (eV)
+     - 0.4
+     - 3.39
+   * - Solvation energy (kcal/mol)
+     - --
+     - about -200
+
+A deck for it, on the CPU backend:
+
+.. code-block:: json
+
+   {
+     "molecules": [
+       { "xyz": "mol.xyz", "molecular_charge": -2, "molecular_multiplicity": 1 }
+     ],
+     "model": { "method": "dft", "functional": "pbe0", "basis": "cc-pvdz" },
+     "keywords": {
+       "scf": { "maxiter": 60, "tolerance": 1e-08 },
+       "dft": { "grid_level": 3 },
+       "pcm": { "method": "iefpcm", "dielectric": 78.3553, "angular_points": 302 }
+     },
+     "driver": "Energy"
+   }
+
+The same gas-phase SCF oscillates for as long as it is allowed to run; the
+solvated one converges in 13 iterations, and the continuum adds almost nothing
+to the iteration cost -- the surface-charge equations are factorized once per
+geometry and each iteration solves them directly.
+
+Two backends, two implementations
+---------------------------------
+
+**CPU (libcint) backend.** Implements the smooth switching/Gaussian (SWIG)
+discretization of Lange and Herbert [J. Chem. Phys. 133, 244111 (2010)],
+following PySCF's ``pyscf.solvent.pcm`` term for term: Lebedev points per
+atomic sphere, the quintic switching function with buried points discarded,
+per-point Gaussian charges with the fitted exponents of
+[J. Chem. Phys. 122, 194110 (2005)], and the same S and D matrices. Two models
+are solved, chosen by ``keywords.pcm.method``:
+
+- ``cpcm`` -- conductor-like; the charge equation is scaled by
+  :math:`(\varepsilon-1)/\varepsilon`.
+- ``iefpcm`` -- the integral equation formalism, whose D-matrix terms make it
+  exact for ideal cavities; internal scale :math:`(\varepsilon-1)/(\varepsilon+1)`.
+
+Restricted and unrestricted, Hartree-Fock and any non-double-hybrid
+functional, with or without density fitting. **Energies only** -- see the
+refusals below.
+
+**cuEST (GPU) backend.** The cavity and the charge solve belong to the cuEST
+library (an iSWIG surface with a preconditioned conjugate-gradient solve); mqc
+supplies the radii, the dielectric and the exponents. One fixed model -- a deck
+asking for ``iefpcm`` there is refused rather than quietly given the other
+model's charges. The GPU path has the PCM nuclear gradient; the CPU path does
+not.
+
+Both backends build their cavity from the same radii table
+(``mqc_pcm_radii``: Bondi, filled in from Mantina, scaled by
+``radii_scale`` = 1.2), so a deck moved between them describes the same cavity.
+
+The cavity decides the answer
+-----------------------------
+
+The solvation energy scales roughly as :math:`1/R` in the cavity radii, so the
+radii are worth more than everything else in the model combined -- and codes
+disagree about them *by default*. mqc uses Bondi's van der Waals radii
+(hydrogen 1.20 Angstrom) scaled by 1.2. PySCF and gpu4pyscf default to a
+"modified Bondi" table whose only change is hydrogen at **1.1** Angstrom, times
+the same 1.2.
+
+That one radius is not a detail. On the dianion above (16 hydrogens), mqc
+against gpu4pyscf's *default* cavity differs by about 5 mHartree in total
+energy and 0.04 eV in the gap -- numbers that look exactly like a bug in
+whichever code is being checked. It is not a bug; it is two defensible
+hydrogen radii. To make PySCF or gpu4pyscf build **mqc's** cavity:
+
+.. code-block:: python
+
+   from pyscf.data import radii
+   cm.radii_table = 1.2 * radii.VDW    # Bondi, H = 1.20 A -- matches mqc
+   cm.lebedev_order = 29               # 302 points, matches angular_points: 302
+
+With the cavity matched, the two implementations agree to the ninth decimal
+place (below). Without it, no amount of grid tightening will close the gap.
+
+Validation
+----------
+
+**CPU backend, against PySCF** (same model, same dielectric, same cavity radii,
+same Lebedev order; basis exponents read from ``basis_sets/`` on both sides,
+because PySCF's internal tables carry more digits than BSE writes and that
+alone is 2.5e-8 on water):
+
+.. list-table::
+   :header-rows: 1
+
+   * - Case
+     - Model
+     - Agreement (Hartree)
+   * - Water, RHF/STO-3G
+     - C-PCM
+     - 3e-12
+   * - Hydroxide anion, RHF/6-31G
+     - IEF-PCM
+     - 5e-12
+   * - Water, PBE0/cc-pVDZ
+     - IEF-PCM
+     - 3e-8 (grid quadrature, not PCM)
+   * - H\ :sub:`2`\ O\ :sup:`+`, UHF/6-31G
+     - IEF-PCM
+     - 9e-9
+   * - The 51-atom dianion, PBE0/cc-pVDZ
+     - IEF-PCM
+     - 1.2e-9 vs gpu4pyscf, matched cavity
+
+The first two run in the CPU validation suite
+(``validation/validation_tests_cpu.json``, at the manifest's global 1e-9). The
+physics that needs no external reference is pinned in
+``test/test_mqc_pcm.f90``: an isolated sphere's tessellation integrates to
+exactly :math:`4\pi R^2`, buried points are accounted for one by one, and a
+central charge in a spherical cavity reproduces Born's closed-form energy --
+where IEF-PCM must land on the *true* :math:`(\varepsilon-1)/\varepsilon` Born
+energy despite its internal :math:`(\varepsilon-1)/(\varepsilon+1)` factor,
+which is the D-matrix terms doing their job and the first thing to break if
+they are misscaled.
+
+**cuEST backend, against PySCF's C-PCM**, on water in water at PBE0/def2-SVP
+and :math:`\varepsilon` = 78.39, at the defaults:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Quantity
+     - metalquicha (cuEST)
+     - PySCF C-PCM
+   * - dielectric energy
+     - -10.2104 mHartree
+     - -10.3625 mHartree
+   * - solvation energy
+     - -5.804 kcal/mol
+     - -5.904 kcal/mol
+   * - solvated dipole
+     - 2.21754 D
+     - 2.2162 D
+
+The dipole is the sharp one: agreeing to 0.0013 D means the potential reaching
+the Fock matrix is right, not merely that an energy came out plausible. The
+residual 1.5% on the dielectric energy is the difference between two
+independently discretised cavities and is not expected to close -- cuEST's
+surface construction is its own, where the CPU backend's is PySCF's by design,
+which is why the CPU numbers above agree to twelve digits and these agree to
+three.
+
+Two limits of the cuEST path were checked as well, and both are worth knowing
+because they need no external reference. At :math:`\varepsilon` = 1.0001 the
+dielectric energy falls to -7e-7 Hartree and the total returns to the
+gas-phase energy, agreeing with PySCF's to 5.5 microhartree -- the continuum
+contributes nothing when it should contribute nothing. And the surface
+resolution matters more than it looks: at 110 angular points the dielectric
+energy was 21% short, which is why ``angular_points`` defaults to 302.
+
+What is refused, and why
+------------------------
+
+These are deliberate refusals, not oversights. Each would otherwise return a
+converged, plausible number computed in a quietly mixed phase, with nothing in
+the output to say so.
+
+- **The PCM nuclear gradient (CPU backend).** The energy's derivative carries
+  the cavity moving with the nuclei and the charges responding, and neither
+  term is built. An analytic gradient without them would be missing the
+  solvent's pull on every atom. Run the energy on the CPU, or the gradient on
+  cuEST, which has it.
+- **Correlation on a solvated reference** -- MP2, coupled cluster, and the
+  double hybrids, whose perturbative term is an MP2 by another spelling. The
+  orbitals would carry the continuum while the correlation treatment ignored
+  it; whether that is the PTE scheme or an inconsistency should be a decision,
+  not an accident.
+- **Fukui indices.** The analysis runs two further SCFs on the ions, and those
+  would run in the gas phase against a solvated neutral -- an ionisation
+  potential computed across two different physics.
+- **The bonding energy decomposition**, which rebuilds atom energies from
+  gas-phase operators and would drop the dielectric term without saying so.
+- **The analytic Hessian** quietly stands down rather than refusing: a solvated
+  run falls through to the finite-difference path, which is *correct* for the
+  continuum -- each displaced energy rebuilds its own cavity.
+
+The xTB path's CPCM (``keywords.xtb``) is tblite's own model with its own
+cavity and shares nothing with ``keywords.pcm``; see :doc:`input_files`.

--- a/mqc_docs/source/index.rst
+++ b/mqc_docs/source/index.rst
@@ -29,6 +29,7 @@ The API docs for the code itself can be found here: https://jorgeg94.github.io/m
    geometry_optimization
    fmo
    counterpoise
+   continuum_solvation
    charges_and_bond_orders
    bonding_analysis
    makefp

--- a/mqc_docs/source/input_files.rst
+++ b/mqc_docs/source/input_files.rst
@@ -354,80 +354,66 @@ Laplacian -- on libxc's own say-so rather than a guess about which ones are safe
 Continuum Solvation
 ^^^^^^^^^^^^^^^^^^^
 
-A polarizable continuum, on the **cuEST (GPU) backend only**:
+A polarizable continuum, on both ab initio backends. See
+:doc:`continuum_solvation` for what the model is, the worked example, and the
+cavity conventions that decide whether a comparison against another code can
+succeed. This section is the keyword reference.
 
 .. code-block:: json
 
    "keywords": {
      "pcm": {
-       "dielectric": 78.39,
+       "method": "cpcm",
+       "dielectric": 78.3553,
        "angular_points": 302,
-       "radii_scale": 1.2,
-       "zeta": 2.0,
-       "tolerance": 1e-8,
-       "max_iter": 100
+       "radii_scale": 1.2
      }
    }
 
 Naming the block is what turns solvation on -- there is no separate flag, because
 a deck that states a dielectric wants solvent and two switches could disagree.
 
+- ``method``: which continuum model the surface charges solve. ``"cpcm"``
+  (conductor-like, the default) or ``"iefpcm"`` (the integral equation
+  formalism) on the CPU backend. They are different models with different
+  energies -- on the hydroxide anion in water they differ by 5.1e-5 Hartree --
+  so the choice is named rather than implied. The cuEST backend's solver is
+  fixed and accepts only the default; asking it for ``"iefpcm"`` is refused
+  rather than substituted.
 - ``dielectric``: the solvent's dielectric constant. **Required.** There is no
   solvent-name table on this path: tblite has one for its own CPCM, and a second
   table here that disagreed with it would make the same word mean two things.
 - ``angular_points``: Lebedev points per atom on the cavity surface. 302 by
   default, and not a knob to economise on: 110 was the default until it was
   measured, and it gave a dielectric energy 21% short of the converged one. The
-  surface integrand has cusps where the atomic spheres intersect.
+  surface integrand has cusps where the atomic spheres intersect. On the CPU
+  backend the order must also carry a fitted SWIG exponent -- 6, 14, 26, 38,
+  50, 86, 110, 146, 170, 194, 302, 350, 434, 590 or denser; the odd orders
+  74, 230 and 266 exist in the grid tables but are refused, because the
+  exponent table [J. Chem. Phys. 122, 194110 (2005)] does not cover them.
 - ``radii_scale``: multiplies the van der Waals radii in ``mqc_pcm_radii``, which
-  are Bondi's filled in from Mantina's. 1.2 is the usual convention.
-- ``zeta``: the Gaussian switching prefactor for the smooth cavity surface, used
-  as :math:`\zeta_i = \zeta \sqrt{n_{ang}} / R_i`. Its default is calibrated
-  against the reference below rather than derived -- cuEST's own convention for
-  these exponents is not documented -- so treat it as an empirical constant of
-  this interface.
-- ``tolerance``, ``max_iter``: the surface-charge solve. A final solve that did
-  not converge is refused rather than reported, because the SCF's own convergence
-  test cannot see the cavity.
+  are Bondi's filled in from Mantina's. 1.2 is the usual convention. **The radii
+  are the cavity and the cavity is most of the answer** -- see
+  :doc:`continuum_solvation` before comparing against another code's defaults.
+- ``zeta``: **cuEST only** -- the Gaussian switching prefactor for its smooth
+  cavity surface, used as :math:`\zeta_i = \zeta \sqrt{n_{ang}} / R_i`, an
+  empirical constant of that interface. The CPU backend refuses a deck that
+  sets it: its exponents are the fitted per-point SWIG values and have no free
+  prefactor, so the keyword would be silently ignored -- which is exactly what
+  this program does not do.
+- ``tolerance``, ``max_iter``: bounds on cuEST's iterative (conjugate gradient)
+  surface-charge solve; a final solve that did not converge is refused rather
+  than reported. The CPU backend factorizes the charge equations once and
+  solves directly, which meets any tolerance these could ask for -- the keys
+  are accepted and moot there.
 
 This is **not** ``keywords.xtb.solvation_model: cpcm``. That configures tblite's
 continuum, which builds its own cavity with its own defaults, and the two are
 separate models rather than one keyword with two backends.
 
-**Validated against PySCF's C-PCM**, on water in water at PBE0/def2-SVP and
-:math:`\varepsilon` = 78.39, at the defaults above:
+What each backend supports, refuses, and how each was validated is on
+:doc:`continuum_solvation`.
 
-.. list-table::
-   :header-rows: 1
-
-   * -
-     - metalquicha
-     - PySCF C-PCM
-   * - dielectric energy
-     - -10.2104 mHartree
-     - -10.3625 mHartree
-   * - solvation energy
-     - -5.804 kcal/mol
-     - -5.904 kcal/mol
-   * - solvated dipole
-     - 2.21754 D
-     - 2.2162 D
-
-The dipole is the sharp one: agreeing to 0.0013 D means the potential reaching the
-Fock matrix is right, not merely that an energy came out plausible. The residual
-1.5% on the dielectric energy is the difference between two independently
-discretised cavities and is not expected to close.
-
-Two limits were checked as well, and both are worth knowing because they need no
-external reference. At :math:`\varepsilon` = 1.0001 the dielectric energy falls
-to -7e-7 Hartree and the total returns to the gas-phase energy, which agrees with
-PySCF's to 5.5 microhartree -- so the continuum contributes nothing when it should
-contribute nothing. And the surface resolution matters more than it looks: at 110
-angular points the dielectric energy was 21% short.
-
-``zeta`` remains the one parameter whose convention is not confirmed against
-cuEST's own definition, and its default was set by matching the reference above
-rather than derived. It is a keyword so it can be checked.
 
 DFT Options
 ^^^^^^^^^^^

--- a/src/core/mqc_fingerprint.f90
+++ b/src/core/mqc_fingerprint.f90
@@ -188,6 +188,18 @@ contains
             call h%int(config%dft%radial_points)
             call h%int(config%dft%angular_points)
          end if
+         ! The continuum. A solvated fragment is a different number from a
+         ! gas-phase one -- by hundreds of kcal/mol for an ion -- and without
+         ! these a checkpoint written in the gas phase would satisfy a deck
+         ! that asked for solvent.
+         if (config%pcm%enabled) then
+            call h%text("pcm")
+            call h%text(trim(config%pcm%method))
+            call h%real(config%pcm%dielectric)
+            call h%int(config%pcm%angular_points)
+            call h%real(config%pcm%radii_scale)
+            call h%real(config%pcm%zeta)
+         end if
       end select
    end subroutine add_method
 

--- a/src/io/mqc_config_adapter.f90
+++ b/src/io/mqc_config_adapter.f90
@@ -250,6 +250,7 @@ contains
       end if
 
       driver_config%method_config%pcm%enabled = mqc_config%pcm_enabled
+      driver_config%method_config%pcm%method = mqc_config%pcm_method
       driver_config%method_config%pcm%dielectric = mqc_config%pcm_dielectric
       driver_config%method_config%pcm%angular_points = mqc_config%pcm_angular_points
       driver_config%method_config%pcm%radii_scale = mqc_config%pcm_radii_scale

--- a/src/io/mqc_config_types.f90
+++ b/src/io/mqc_config_types.f90
@@ -270,6 +270,8 @@ module mqc_config_types
          !! told apart: absent leaves `backend` alone, false pins it to the CPU.
 
       logical :: pcm_enabled = .false.
+      character(len=16) :: pcm_method = "cpcm"
+         !! Continuum model: "cpcm" or "iefpcm". See `pcm_config_t`.
       real(dp) :: pcm_dielectric = -1.0_dp
          !! Solvent dielectric constant. Required: there is no solvent-name
          !! table on this path, because inventing one that disagreed with

--- a/src/io/mqc_json_config_reader.f90
+++ b/src/io/mqc_json_config_reader.f90
@@ -328,6 +328,16 @@ contains
       if (error%has_error()) return
       call json%info("keywords.pcm", found=found)
       config%pcm_enabled = found
+      block
+         ! Read into a deferred-length local, since the config field is fixed
+         ! width and `optional_string` takes an allocatable.
+         character(len=:), allocatable :: pcm_method_text
+         logical :: pcm_method_named
+         call json%get("keywords.pcm.method", pcm_method_text, pcm_method_named)
+         if (pcm_method_named .and. allocated(pcm_method_text)) then
+            config%pcm_method = pcm_method_text
+         end if
+      end block
       call optional_real(json, "keywords.pcm.dielectric", config%pcm_dielectric)
       call optional_int(json, "keywords.pcm.angular_points", config%pcm_angular_points)
       call optional_real(json, "keywords.pcm.radii_scale", config%pcm_radii_scale)

--- a/src/io/mqc_json_schema.f90
+++ b/src/io/mqc_json_schema.f90
@@ -350,6 +350,7 @@ contains
       !! Separate from `xtb`, which configures tblite's own CPCM. Two continuum
       !! implementations with different cavities should not share one keyword.
       type(key_set_t) :: keys
+      call allow(keys, "method")
       call allow(keys, "dielectric")
       call allow(keys, "angular_points")
       call allow(keys, "radii_scale")

--- a/src/methods/mqc_method_config.f90
+++ b/src/methods/mqc_method_config.f90
@@ -144,10 +144,20 @@ module mqc_method_config
    type :: pcm_config_t
       !! A polarizable continuum: the cavity, the solvent, and the charge solve
       !!
-      !! Backend-neutral in shape, but only the cuEST path implements it. tblite's
-      !! CPCM is configured through `xtb_config_t` and builds its own cavity; the
-      !! two are separate models and share no settings.
+      !! Backend-neutral in shape. The cuEST path hands the cavity and the charge
+      !! solve to the library; the CPU path builds both itself in
+      !! `mqc_libcint_pcm`. tblite's CPCM is configured through `xtb_config_t`
+      !! and builds its own cavity; the two are separate models and share no
+      !! settings.
       logical :: enabled = .false.
+      character(len=16) :: method = "cpcm"
+         !! Which continuum model the surface charges solve: "cpcm"
+         !! (conductor-like, scale factor (eps-1)/eps) or "iefpcm" (the integral
+         !! equation formalism, scale (eps-1)/(eps+1) with the D-matrix terms).
+         !! The two are different models with different energies -- water differs
+         !! by ~1% of the solvation energy -- so the choice is named, not
+         !! defaulted per backend. Only the CPU path reads it; cuEST's solver is
+         !! fixed and refuses "iefpcm" rather than substituting.
       real(dp) :: dielectric = -1.0_dp
          !! Solvent dielectric. No solvent-name table on this path, on purpose:
          !! see `mqc_config_types`.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -193,6 +193,10 @@ if(MQC_ENABLE_LIBCINT)
   # dipole rank being the first.
   addtest(mqc_libcint_esp)
   target_link_libraries(test_mqc_libcint_esp PRIVATE ${MQC_INTEGRALS_LIBS})
+  # The continuum: cavity geometry, the Born ion in closed form, and one
+  # solvated SCF pinned against PySCF.
+  addtest(mqc_pcm)
+  target_link_libraries(test_mqc_pcm PRIVATE ${MQC_INTEGRALS_LIBS})
   # SAPT0's molecules: ghosts in the dimer basis. Everything checkable before a
   # term is computed -- that ghosts keep their basis and lose their charge, and
   # that a monomer's AO ordering is the dimer's, which Tr(D S) catches.

--- a/test/test_mqc_pcm.f90
+++ b/test/test_mqc_pcm.f90
@@ -1,0 +1,292 @@
+!! The CPU continuum: cavity, charges, and the solvated SCF
+module test_mqc_pcm
+   !! What can be asserted without a reference implementation is the physics:
+   !! an isolated sphere's tessellation must integrate to its own surface area,
+   !! points buried between overlapping spheres must vanish, and a central
+   !! charge in a spherical cavity is Born's problem with a closed-form energy.
+   !! C-PCM approaches it as -f q^2/2R with f = (eps-1)/eps; IEF-PCM's D-matrix
+   !! terms make it exact for a sphere, so it must land on the *same* Born
+   !! energy despite carrying f = (eps-1)/(eps+1) inside.
+   !!
+   !! The one pinned number is a solvated water SCF, validated against PySCF's
+   !! `pyscf.solvent.pcm` (C-PCM, identical cavity radii and Lebedev order):
+   !! PySCF gives -74.9684556809 on this geometry and this implementation
+   !! -74.9684557057, 2.5e-8 apart. The pin catches drift, not correctness;
+   !! the Born tests carry the correctness.
+   use testdrive, only: new_unittest, unittest_type, error_type, check
+   use pic_types, only: dp
+   use mqc_error, only: error_t
+   use mqc_physical_constants, only: PI
+   use mqc_pcm_radii, only: cavity_radius
+   use mqc_method_config, only: pcm_config_t
+   use mqc_libcint_integrals, only: libcint_molecule_t, build_libcint_molecule
+   use mqc_libcint_rhf, only: rhf_result_t, run_libcint_rhf
+   use mqc_libcint_pcm, only: pcm_context_t, build_pcm_surface
+   implicit none
+   private
+
+   public :: collect_mqc_pcm_tests
+
+   real(dp), parameter :: EPS_WATER = 78.3553_dp
+
+   integer, parameter :: WATER_Z(3) = [8, 1, 1]
+   character(len=2), parameter :: WATER_SYM(3) = ["O ", "H ", "H "]
+   !> Bohr, C2v
+   real(dp), parameter :: WATER(3, 3) = reshape( &
+                          [0.0_dp, 0.0_dp, 0.0_dp, &
+                           0.0_dp, 1.4308_dp, 1.1078_dp, &
+                           0.0_dp, -1.4308_dp, 1.1078_dp], [3, 3])
+
+contains
+
+   subroutine collect_mqc_pcm_tests(testsuite)
+      type(unittest_type), allocatable, intent(out) :: testsuite(:)
+
+      testsuite = [ &
+                  new_unittest("one_sphere_area_is_exact", one_sphere_area_is_exact), &
+                  new_unittest("overlapping_spheres_bury_points", overlapping_spheres_bury_points), &
+                  new_unittest("born_ion_cpcm", born_ion_cpcm), &
+                  new_unittest("born_ion_iefpcm_is_exact", born_ion_iefpcm_is_exact), &
+                  new_unittest("solvated_water_has_not_drifted", solvated_water_has_not_drifted), &
+                  new_unittest("refuses_an_unknown_model", refuses_an_unknown_model), &
+                  new_unittest("refuses_a_gas_dielectric", refuses_a_gas_dielectric), &
+                  new_unittest("refuses_an_untabulated_order", refuses_an_untabulated_order) &
+                  ]
+   end subroutine collect_mqc_pcm_tests
+
+   subroutine born_energy(method, e_diel, q_total, err)
+      !! A unit positive charge at the centre of one oxygen-sized cavity
+      character(len=*), intent(in) :: method
+      real(dp), intent(out) :: e_diel, q_total
+      type(error_t), intent(inout) :: err
+
+      type(pcm_context_t) :: ctx
+      real(dp), allocatable :: v(:), q(:)
+      real(dp) :: d
+      integer :: k
+
+      call build_pcm_surface([8], reshape([0.0_dp, 0.0_dp, 0.0_dp], [3, 1]), &
+                             302, 1.2_dp, ctx%surface, err)
+      if (err%has_error()) return
+      call ctx%init_model(method, EPS_WATER, err)
+      if (err%has_error()) return
+      call ctx%build_operators(err)
+      if (err%has_error()) return
+
+      ! The potential of the central charge at each smooth surface point --
+      ! erf-attenuated exactly as the SCF's nuclear term is, though at these
+      ! exponents the erf is 1 to machine precision.
+      allocate (v(ctx%surface%n_points))
+      do k = 1, ctx%surface%n_points
+         d = norm2(ctx%surface%coords(:, k))
+         v(k) = erf(ctx%surface%zeta(k)*d)/d
+      end do
+
+      call ctx%solve(v, q, err)
+      if (err%has_error()) return
+      e_diel = 0.5_dp*dot_product(q, v)
+      q_total = sum(q)
+   end subroutine born_energy
+
+   subroutine one_sphere_area_is_exact(error)
+      !! An isolated sphere keeps every point and integrates to 4 pi R^2
+      !!
+      !! The Lebedev weights sum to one and nothing is switched off, so the
+      !! area sum is exact to roundoff -- this is the identity that catches a
+      !! misplaced 4 pi, a radius applied twice, or a weight normalization
+      !! change in the grid tables.
+      type(error_type), allocatable, intent(out) :: error
+
+      type(pcm_context_t) :: ctx
+      type(error_t) :: err
+      real(dp) :: radius
+
+      call build_pcm_surface([8], reshape([0.0_dp, 0.0_dp, 0.0_dp], [3, 1]), &
+                             110, 1.2_dp, ctx%surface, err)
+      call check(error,.not. err%has_error(), more="surface build failed")
+      if (allocated(error)) return
+
+      call check(error, ctx%surface%n_points, 110, more="an isolated sphere buried points")
+      if (allocated(error)) return
+
+      call cavity_radius(8, 1.2_dp, radius, err)
+      call check(error, sum(ctx%surface%area), 4.0_dp*PI*radius**2, &
+                 thr=1.0e-10_dp, more="the tessellated area is not the sphere's")
+   end subroutine one_sphere_area_is_exact
+
+   subroutine overlapping_spheres_bury_points(error)
+      !! Two oxygens a bond apart lose the points between them
+      type(error_type), allocatable, intent(out) :: error
+
+      type(pcm_context_t) :: ctx
+      type(error_t) :: err
+      real(dp) :: radius
+
+      call build_pcm_surface([8, 8], reshape( &
+                             [0.0_dp, 0.0_dp, 0.0_dp, &
+                              0.0_dp, 0.0_dp, 2.3_dp], [3, 2]), &
+                             110, 1.2_dp, ctx%surface, err)
+      call check(error,.not. err%has_error(), more="surface build failed")
+      if (allocated(error)) return
+
+      call check(error, ctx%surface%n_points < 220, &
+                 more="no point was buried between overlapping spheres")
+      if (allocated(error)) return
+      call check(error, ctx%surface%n_discarded, 220 - ctx%surface%n_points, &
+                 more="kept plus discarded is not the full count")
+      if (allocated(error)) return
+
+      call cavity_radius(8, 1.2_dp, radius, err)
+      call check(error, sum(ctx%surface%area) < 2.0_dp*4.0_dp*PI*radius**2, &
+                 more="the fused surface is not smaller than two full spheres")
+   end subroutine overlapping_spheres_bury_points
+
+   subroutine born_ion_cpcm(error)
+      !! C-PCM reproduces its own Born expression, -f q^2/(2R), f = (eps-1)/eps
+      !!
+      !! For a conductor-like model on a sphere the discretization is the only
+      !! error, and with 302 points it is parts in 1e6. The apparent charge
+      !! must integrate to -f by Gauss's law.
+      type(error_type), allocatable, intent(out) :: error
+
+      type(error_t) :: err
+      real(dp) :: e_diel, q_total, radius, f, e_ref
+
+      call born_energy("cpcm", e_diel, q_total, err)
+      call check(error,.not. err%has_error(), more="the Born solve failed")
+      if (allocated(error)) return
+
+      call cavity_radius(8, 1.2_dp, radius, err)
+      f = (EPS_WATER - 1.0_dp)/EPS_WATER
+      e_ref = -0.5_dp*f/radius
+      call check(error, e_diel, e_ref, thr=1.0e-5_dp*abs(e_ref), &
+                 more="C-PCM misses the Born energy of its own model")
+      if (allocated(error)) return
+      call check(error, q_total, -f, thr=1.0e-4_dp, &
+                 more="the apparent charge violates Gauss's law")
+   end subroutine born_ion_cpcm
+
+   subroutine born_ion_iefpcm_is_exact(error)
+      !! IEF-PCM lands on the *true* Born energy, -q^2 (eps-1)/(2 R eps)
+      !!
+      !! Its internal scale factor is (eps-1)/(eps+1), so getting the physical
+      !! (eps-1)/eps out is what exercises the D A S terms -- drop or misscale
+      !! them and this is off by roughly 1/(2 eps), far outside the tolerance.
+      type(error_type), allocatable, intent(out) :: error
+
+      type(error_t) :: err
+      real(dp) :: e_diel, q_total, radius, e_ref
+
+      call born_energy("iefpcm", e_diel, q_total, err)
+      call check(error,.not. err%has_error(), more="the Born solve failed")
+      if (allocated(error)) return
+
+      call cavity_radius(8, 1.2_dp, radius, err)
+      e_ref = -0.5_dp*(EPS_WATER - 1.0_dp)/EPS_WATER/radius
+      call check(error, e_diel, e_ref, thr=1.0e-4_dp*abs(e_ref), &
+                 more="IEF-PCM misses the exact Born energy for a sphere")
+   end subroutine born_ion_iefpcm_is_exact
+
+   subroutine solvated_water_has_not_drifted(error)
+      !! The full path: cavity, charges, SCF -- pinned to the PySCF-validated run
+      !!
+      !! Water RHF/STO-3G, C-PCM, eps 78.3553, 302 points. The pin holds this
+      !! implementation's own converged value; the tolerance is far looser than
+      !! the 2.5e-8 gap to PySCF, so drifting past it means something moved.
+      type(error_type), allocatable, intent(out) :: error
+
+      type(libcint_molecule_t) :: mol
+      type(pcm_context_t) :: ctx
+      type(pcm_config_t) :: config
+      type(rhf_result_t) :: scf
+      type(error_t) :: err
+
+      call build_libcint_molecule(WATER_Z, WATER_SYM, WATER, "sto-3g", mol, err)
+      call check(error,.not. err%has_error(), more="molecule build failed")
+      if (allocated(error)) return
+
+      config%enabled = .true.
+      config%method = "cpcm"
+      config%dielectric = EPS_WATER
+      config%angular_points = 302
+      call ctx%build(mol, WATER_Z, config, err)
+      call check(error,.not. err%has_error(), more="context build failed")
+      if (allocated(error)) then
+         call mol%destroy()
+         return
+      end if
+
+      call run_libcint_rhf(mol, 10, 100, 1.0e-10_dp, 1.0e-8_dp, .false., scf, err, &
+                           pcm=ctx)
+      call mol%destroy()
+      call check(error,.not. err%has_error(), more="the solvated SCF failed")
+      if (allocated(error)) return
+      call check(error, scf%converged, more="the solvated SCF did not converge")
+      if (allocated(error)) return
+
+      call check(error, scf%energy, -74.96845570_dp, thr=1.0e-6_dp, &
+                 more="the solvated total energy has drifted")
+      if (allocated(error)) return
+      call check(error, scf%pcm_energy, -0.00571472_dp, thr=1.0e-6_dp, &
+                 more="the dielectric energy has drifted")
+   end subroutine solvated_water_has_not_drifted
+
+   subroutine refuses_an_unknown_model(error)
+      !! "cosmo" is a real model this path does not solve; it must not be mapped
+      type(error_type), allocatable, intent(out) :: error
+
+      type(pcm_context_t) :: ctx
+      type(error_t) :: err
+
+      call ctx%init_model("cosmo", EPS_WATER, err)
+      call check(error, err%has_error(), more="an unknown model was accepted")
+   end subroutine refuses_an_unknown_model
+
+   subroutine refuses_a_gas_dielectric(error)
+      !! eps = 1 is the gas phase pretending to be a solvent
+      type(error_type), allocatable, intent(out) :: error
+
+      type(pcm_context_t) :: ctx
+      type(error_t) :: err
+
+      call ctx%init_model("cpcm", 1.0_dp, err)
+      call check(error, err%has_error(), more="a dielectric of one was accepted")
+   end subroutine refuses_a_gas_dielectric
+
+   subroutine refuses_an_untabulated_order(error)
+      !! Lebedev order 74 exists in mqc_lebedev but has no fitted SWIG exponent
+      type(error_type), allocatable, intent(out) :: error
+
+      type(pcm_context_t) :: ctx
+      type(error_t) :: err
+
+      call build_pcm_surface([8], reshape([0.0_dp, 0.0_dp, 0.0_dp], [3, 1]), &
+                             74, 1.2_dp, ctx%surface, err)
+      call check(error, err%has_error(), more="an order with no fitted exponent "// &
+                 "was accepted")
+   end subroutine refuses_an_untabulated_order
+
+end module test_mqc_pcm
+
+program tester
+   use, intrinsic :: iso_fortran_env, only: error_unit
+   use testdrive, only: run_testsuite, new_testsuite, testsuite_type
+   use test_mqc_pcm, only: collect_mqc_pcm_tests
+   implicit none
+   integer :: stat, is
+   type(testsuite_type), allocatable :: testsuites(:)
+   character(len=*), parameter :: fmt = '("#", *(1x, a))'
+
+   stat = 0
+   testsuites = [new_testsuite("mqc_pcm", collect_mqc_pcm_tests)]
+
+   do is = 1, size(testsuites)
+      write (error_unit, fmt) "Testing:", testsuites(is)%name
+      call run_testsuite(testsuites(is)%collect, error_unit, stat)
+   end do
+
+   if (stat > 0) then
+      write (error_unit, "(i0, 1x, a)") stat, "test(s) failed!"
+      error stop
+   end if
+end program tester

--- a/tools/cpu_validation/gen_cpu_validation.py
+++ b/tools/cpu_validation/gen_cpu_validation.py
@@ -348,6 +348,14 @@ HAND_MAINTAINED = {
     # through bse_to_pyscf like every reference here.
     "cpu/mqc/pcm/cpu_water_sto-3g_cpcm.json",
     "cpu/mqc/pcm/cpu_hydroxide_6-31g_iefpcm.json",
+    # The unrestricted and Kohn-Sham continuum. The two restricted cases above
+    # do not cover them, and both are combinations rather than features: the
+    # solvent operator is built from the total density and added to BOTH spin
+    # Fock matrices, and it sits in the Fock matrix beside the
+    # exchange-correlation potential. Either could be wired wrong and still
+    # converge to a plausible number.
+    "cpu/mqc/pcm/cpu_water_cation_6-31g_uhf_iefpcm.json",
+    "cpu/mqc/pcm/cpu_water_6-31g_pbe0_cpcm.json",
 }
 
 # SAPT0. The monomers are the deck's own `fragments`, so the geometry is an

--- a/tools/cpu_validation/gen_cpu_validation.py
+++ b/tools/cpu_validation/gen_cpu_validation.py
@@ -338,6 +338,16 @@ HAND_MAINTAINED = {
     "cpu/mqc/fmo/eembe_water3.json",
     "cpu/mqc/fmo/fmo3_water3.json",
     "cpu/mqc/fmo/eembe3_water3.json",
+    # Continuum solvation. PySCF *can* produce these references -- they were --
+    # but this script has no PCM support, so a regeneration would sweep the
+    # decks while their manifest entries stayed behind. The recipe, should they
+    # ever need regenerating: pyscf.solvent.pcm with the deck's method and
+    # dielectric, lebedev_order 29 (302 points), and radii_table = 1.2 * Bondi
+    # (pyscf.data.radii.VDW) -- NOT PySCF's default modified-Bondi cavity, whose
+    # hydrogen is 1.1 Angstrom against Bondi's 1.20 -- with the basis read
+    # through bse_to_pyscf like every reference here.
+    "cpu/mqc/pcm/cpu_water_sto-3g_cpcm.json",
+    "cpu/mqc/pcm/cpu_hydroxide_6-31g_iefpcm.json",
 }
 
 # SAPT0. The monomers are the deck's own `fragments`, so the geometry is an

--- a/validation/inputs/cpu/mqc/pcm/cpu_hydroxide_6-31g_iefpcm.json
+++ b/validation/inputs/cpu/mqc/pcm/cpu_hydroxide_6-31g_iefpcm.json
@@ -1,0 +1,34 @@
+{
+    "schema": {
+        "name": "mqc-frag",
+        "version": "1.0"
+    },
+    "molecules": [
+        {
+            "xyz": "../../../sample_inputs/oh.xyz",
+            "molecular_charge": -1,
+            "molecular_multiplicity": 1
+        }
+    ],
+    "model": {
+        "method": "hf",
+        "basis": "6-31g"
+    },
+    "keywords": {
+        "scf": {
+            "maxiter": 100,
+            "tolerance": 1e-12
+        },
+        "pcm": {
+            "method": "iefpcm",
+            "dielectric": 78.3553,
+            "angular_points": 302
+        }
+    },
+    "system": {
+        "logger": {
+            "level": "Verbose"
+        }
+    },
+    "driver": "Energy"
+}

--- a/validation/inputs/cpu/mqc/pcm/cpu_water_6-31g_pbe0_cpcm.json
+++ b/validation/inputs/cpu/mqc/pcm/cpu_water_6-31g_pbe0_cpcm.json
@@ -1,0 +1,38 @@
+{
+    "schema": {
+        "name": "mqc-frag",
+        "version": "1.0"
+    },
+    "molecules": [
+        {
+            "xyz": "../../../sample_inputs/w1.xyz",
+            "molecular_charge": 0,
+            "molecular_multiplicity": 1
+        }
+    ],
+    "model": {
+        "method": "dft",
+        "functional": "pbe0",
+        "basis": "6-31g"
+    },
+    "keywords": {
+        "scf": {
+            "maxiter": 100,
+            "tolerance": 1e-10
+        },
+        "pcm": {
+            "method": "cpcm",
+            "dielectric": 78.3553,
+            "angular_points": 302
+        },
+        "dft": {
+            "grid_level": 3
+        }
+    },
+    "system": {
+        "logger": {
+            "level": "Verbose"
+        }
+    },
+    "driver": "Energy"
+}

--- a/validation/inputs/cpu/mqc/pcm/cpu_water_cation_6-31g_uhf_iefpcm.json
+++ b/validation/inputs/cpu/mqc/pcm/cpu_water_cation_6-31g_uhf_iefpcm.json
@@ -1,0 +1,35 @@
+{
+    "schema": {
+        "name": "mqc-frag",
+        "version": "1.0"
+    },
+    "molecules": [
+        {
+            "xyz": "../../../sample_inputs/w1.xyz",
+            "molecular_charge": 1,
+            "molecular_multiplicity": 2
+        }
+    ],
+    "model": {
+        "method": "hf",
+        "basis": "6-31g"
+    },
+    "keywords": {
+        "scf": {
+            "maxiter": 100,
+            "tolerance": 1e-12,
+            "unrestricted": true
+        },
+        "pcm": {
+            "method": "iefpcm",
+            "dielectric": 78.3553,
+            "angular_points": 302
+        }
+    },
+    "system": {
+        "logger": {
+            "level": "Verbose"
+        }
+    },
+    "driver": "Energy"
+}

--- a/validation/inputs/cpu/mqc/pcm/cpu_water_sto-3g_cpcm.json
+++ b/validation/inputs/cpu/mqc/pcm/cpu_water_sto-3g_cpcm.json
@@ -1,0 +1,34 @@
+{
+    "schema": {
+        "name": "mqc-frag",
+        "version": "1.0"
+    },
+    "molecules": [
+        {
+            "xyz": "../../../sample_inputs/w1.xyz",
+            "molecular_charge": 0,
+            "molecular_multiplicity": 1
+        }
+    ],
+    "model": {
+        "method": "hf",
+        "basis": "sto-3g"
+    },
+    "keywords": {
+        "scf": {
+            "maxiter": 100,
+            "tolerance": 1e-12
+        },
+        "pcm": {
+            "method": "cpcm",
+            "dielectric": 78.3553,
+            "angular_points": 302
+        }
+    },
+    "system": {
+        "logger": {
+            "level": "Verbose"
+        }
+    },
+    "driver": "Energy"
+}

--- a/validation/validation_tests_cpu.json
+++ b/validation/validation_tests_cpu.json
@@ -2170,6 +2170,21 @@
             "reference_note": "PySCF RHF with pyscf.solvent.pcm IEF-PCM, same cavity settings as the C-PCM case above. An anion on purpose: its dielectric energy is -0.1483 Hartree against water's -0.0057, and the D-matrix terms that separate IEF-PCM from C-PCM are worth 5.1e-5 Hartree here -- far above tolerance, so solving the wrong model cannot pass. mqc reproduces the reference to 5e-12; the global 1e-9 applies."
         },
         {
+            "name": "UHF IEF-PCM water cation 6-31g (CPU)",
+            "input": "inputs/cpu/mqc/pcm/cpu_water_cation_6-31g_uhf_iefpcm.json",
+            "expected_energy": -75.727163666228,
+            "type": "unfragmented",
+            "reference_note": "PySCF UHF with pyscf.solvent.pcm IEF-PCM, same cavity as the restricted cases. The water cation doublet, because the two restricted cases above leave the unrestricted continuum untested: the solvent operator is built from the TOTAL density and added to both spin Fock matrices, so a version that fed it one spin or double-counted it would still converge and would still look ordinary. A non-degenerate open shell on purpose -- the OH radical's half-filled pi orients against the Lebedev grid and lands at 5e-7, which is the cavity discretisation rather than the SCF and would need a tolerance loose enough to hide real faults. mqc reproduces this to 1.3e-12; the global 1e-9 applies."
+        },
+        {
+            "name": "KS PBE0 C-PCM water 6-31g grid 3 (CPU)",
+            "input": "inputs/cpu/mqc/pcm/cpu_water_6-31g_pbe0_cpcm.json",
+            "expected_energy": -76.313799988684,
+            "tolerance": 1e-07,
+            "type": "unfragmented",
+            "reference_note": "PySCF RKS/PBE0 with pyscf.solvent.pcm C-PCM, same cavity as the Hartree-Fock cases, grid level 3 on both sides. Here for the combination rather than for either half: the solvent operator enters the Fock matrix alongside the exchange-correlation potential, and nothing else in the suite exercises both at once. The tolerance is 1e-7 rather than the global 1e-9, and the reason is measured rather than assumed: this same molecule, functional and basis WITHOUT any continuum differs from PySCF by 6.92e-9, and with the continuum by 6.96e-9. The continuum contributes 3.7e-11 of that. The residual is the quadrature grid -- both codes build a level-3 grid from the same tables and prune it differently -- so a tolerance tight enough to catch a PCM fault here would be reporting on the grid instead."
+        },
+        {
             "name": "FMO2 water trimer 6-31g (CPU)",
             "input": "inputs/cpu/mqc/fmo/fmo_water3.json",
             "expected_energy": -227.9705411684,

--- a/validation/validation_tests_cpu.json
+++ b/validation/validation_tests_cpu.json
@@ -2181,6 +2181,7 @@
             "input": "inputs/cpu/mqc/pcm/cpu_water_6-31g_pbe0_cpcm.json",
             "expected_energy": -76.313799988684,
             "tolerance": 1e-07,
+            "requires": "libxc",
             "type": "unfragmented",
             "reference_note": "PySCF RKS/PBE0 with pyscf.solvent.pcm C-PCM, same cavity as the Hartree-Fock cases, grid level 3 on both sides. Here for the combination rather than for either half: the solvent operator enters the Fock matrix alongside the exchange-correlation potential, and nothing else in the suite exercises both at once. The tolerance is 1e-7 rather than the global 1e-9, and the reason is measured rather than assumed: this same molecule, functional and basis WITHOUT any continuum differs from PySCF by 6.92e-9, and with the continuum by 6.96e-9. The continuum contributes 3.7e-11 of that. The residual is the quadrature grid -- both codes build a level-3 grid from the same tables and prune it differently -- so a tolerance tight enough to catch a PCM fault here would be reporting on the grid instead."
         },

--- a/validation/validation_tests_cpu.json
+++ b/validation/validation_tests_cpu.json
@@ -2156,6 +2156,20 @@
             "requires": "libxc"
         },
         {
+            "name": "RHF C-PCM water sto-3g (CPU)",
+            "input": "inputs/cpu/mqc/pcm/cpu_water_sto-3g_cpcm.json",
+            "expected_energy": -74.967441478848,
+            "type": "unfragmented",
+            "reference_note": "PySCF RHF with pyscf.solvent.pcm C-PCM at eps 78.3553, lebedev_order 29 (302 points per sphere) and radii_table = 1.2 * Bondi (pyscf.data.radii.VDW), which is mqc's own cavity -- PySCF's *default* cavity is modified Bondi with H at 1.1 Angstrom and does not match. Basis read from basis_sets/ like every other reference here; with PySCF's internal sto-3g table instead, this same comparison misses by 2.5e-8, which is the manifest's standing warning about basis digits playing out. mqc reproduces this number to 3e-12, so the case runs at the global 1e-9: a change in the cavity radii, the switching function, the surface-charge solve or the attenuated integrals misses by orders of magnitude more."
+        },
+        {
+            "name": "RHF IEF-PCM hydroxide anion 6-31g (CPU)",
+            "input": "inputs/cpu/mqc/pcm/cpu_hydroxide_6-31g_iefpcm.json",
+            "expected_energy": -75.458124582308,
+            "type": "unfragmented",
+            "reference_note": "PySCF RHF with pyscf.solvent.pcm IEF-PCM, same cavity settings as the C-PCM case above. An anion on purpose: its dielectric energy is -0.1483 Hartree against water's -0.0057, and the D-matrix terms that separate IEF-PCM from C-PCM are worth 5.1e-5 Hartree here -- far above tolerance, so solving the wrong model cannot pass. mqc reproduces the reference to 5e-12; the global 1e-9 applies."
+        },
+        {
             "name": "FMO2 water trimer 6-31g (CPU)",
             "input": "inputs/cpu/mqc/fmo/fmo_water3.json",
             "expected_energy": -227.9705411684,


### PR DESCRIPTION
Give the continuum operator its own timing stage

Fallout from rebasing onto the Fock/quadrature timing fix, and worth a commit
of its own rather than being folded silently into the rebase.

The continuum operator was charged to STAGE_FOCK by a lap in the SCF loop. That
lap no longer exists on main: `assemble_fock` closes its own stage, and the
caller's lap was removed because `report_lap` increments a stage's CALL COUNT as
well as its seconds, so lapping the same stage twice per iteration reported two
Fock builds per iteration.

Restoring that lap to carry the continuum would have reintroduced exactly the
bug the fix removed. So the continuum gets its own row instead, which is more
honest anyway: it is a separate physical step, and the row says what it costs.
On the dianion that is a fraction of a percent against the quadrature, which is
worth being able to see rather than infer.

The final Fock rebuild after convergence laps it too. It already applied the
operator -- it must, or the reported energy would be the gas-phase one -- but
did not lap, so the stage counted one fewer than the Fock builds it shadows.

Rebased onto main (12 commits, including the timing fix and a unit-test PR).
Re-verified after: PCM validation 4/4, ctest 104/104, both linters clean, and
the water C-PCM case still reproduces its reference to 3e-12.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>