### PR TITLE
Analytic MCSCF gradients, and stop the block size deciding the thread count

### DIFF
--- a/backends/libcint/CMakeLists.txt
+++ b/backends/libcint/CMakeLists.txt
@@ -45,6 +45,7 @@ target_sources(
           mqc_libcint_mp2.f90
           mqc_libcint_mp2_gradient.f90
           mqc_libcint_ri_mp2_gradient.f90
+          mqc_libcint_mcscf_gradient.f90
           mqc_libcint_cc.f90
           mqc_libcint_rcc.f90
           mqc_libcint_ao_data.f90

--- a/backends/libcint/mqc_libcint_bridge.f90
+++ b/backends/libcint/mqc_libcint_bridge.f90
@@ -50,6 +50,7 @@ module mqc_libcint_bridge
    use mqc_libcint_avas, only: avas_select, avas_result_t, valence_select
    use mqc_libcint_mcscf, only: casscf_result_t, run_libcint_casscf, &
                                 natural_orbitals
+   use mqc_libcint_mcscf_gradient, only: libcint_mcscf_gradient
    implicit none
    private
 
@@ -1850,7 +1851,7 @@ contains
       space = [n_inactive, n_active, n_alpha, n_beta]
    end subroutine resolve_active_space
 
-   subroutine run_libcint_mcscf(settings, fragment, result)
+   subroutine run_libcint_mcscf(settings, fragment, result, want_gradient)
       !! CASSCF, or CASCI on the reference orbitals, for one fragment
       !!
       !! Three steps, and the middle one is the reason this is not just a call
@@ -1870,6 +1871,11 @@ contains
       type(cuest_scf_settings_t), intent(in) :: settings
       type(physical_fragment_t), intent(in) :: fragment
       type(calculation_result_t), intent(inout) :: result
+      logical, intent(in), optional :: want_gradient
+         !! The nuclear gradient of the optimised wave function. Only a CASSCF
+         !! has one here: a CASCI leaves its orbitals where the SCF put them, so
+         !! it is not stationary with respect to them and the terms this omits
+         !! are not zero.
 
       type(libcint_molecule_t) :: mol
       type(rhf_result_t) :: scf
@@ -2207,8 +2213,61 @@ contains
 
       result%scf_status = SCF_CONVERGED
       result%has_energy = .true.
+
+      if (present(want_gradient)) then
+         if (want_gradient) then
+            call mcscf_gradient_into(settings, mol, casscf, space, result)
+         end if
+      end if
+
       call mol%destroy()
    end subroutine run_libcint_mcscf
+
+   subroutine mcscf_gradient_into(settings, mol, casscf, space, result)
+      !! The nuclear gradient of a converged CASSCF, onto the result
+      !!
+      !! Refused rather than approximated when the optimisation did not
+      !! converge. The formula differentiates a *stationary* energy: away from a
+      !! stationary point the orbital-response terms it omits are not zero, and
+      !! what comes back is a plausible vector that is the derivative of
+      !! nothing. `casscf_result_t` says the same thing about its densities,
+      !! which on an unconverged run are one orbital step behind the orbitals
+      !! they are reported beside.
+      type(cuest_scf_settings_t), intent(in) :: settings
+      type(libcint_molecule_t), intent(in) :: mol
+      type(casscf_result_t), intent(in) :: casscf
+      integer, intent(in) :: space(:)
+      type(calculation_result_t), intent(inout) :: result
+
+      type(error_t) :: error
+
+      if (.not. settings%mcscf%optimize_orbitals) then
+         call result%error%set(ERROR_VALIDATION, "a CASCI gradient needs the orbital "// &
+                               "response, which is not implemented: its orbitals came "// &
+                               "from the SCF and were never optimised for this active "// &
+                               "space, so the wave function is not stationary with "// &
+                               "respect to them. Ask for 'casscf' instead.")
+         result%has_error = .true.
+         return
+      end if
+      if (.not. casscf%converged) then
+         call result%error%set(ERROR_VALIDATION, "the orbital optimisation did not "// &
+                               "converge, so there is no stationary point to "// &
+                               "differentiate. The gradient of an unconverged MCSCF "// &
+                               "is not the gradient of anything.")
+         result%has_error = .true.
+         return
+      end if
+
+      call libcint_mcscf_gradient(mol, casscf%orbitals, space(1), space(2), &
+                                  casscf%dm1, casscf%dm2, result%gradient, error)
+      if (error%has_error()) then
+         call result%error%set(ERROR_VALIDATION, "gradient: "//error%get_message())
+         result%has_error = .true.
+         return
+      end if
+      result%has_gradient = .true.
+   end subroutine mcscf_gradient_into
 
    subroutine store_decomposition(result, atom_energy, free_atom_energy, &
                                   pair_energy, pair_classical, formation_energy)

--- a/backends/libcint/mqc_libcint_gradient.f90
+++ b/backends/libcint/mqc_libcint_gradient.f90
@@ -65,6 +65,9 @@ module mqc_libcint_gradient
    ! alongside it -- so it needs the same derivative integrals rather than the
    ! same assembly.
    public :: one_electron_deriv
+   public :: two_electron_deriv
+      !! Exposed for the MCSCF gradient, whose inactive and active blocks are
+      !! separable and contract exactly as a closed-shell reference does.
    public :: iprinv_deriv_at
    public :: xc_potential_gradient
    public :: fitted_reference_gradient

--- a/backends/libcint/mqc_libcint_mcscf_gradient.f90
+++ b/backends/libcint/mqc_libcint_mcscf_gradient.f90
@@ -309,57 +309,61 @@ contains
    subroutine gamma_block(c_active, ddm2, p_lo, p_hi, gamma_blk)
       !! `ddm2` transformed to the AO basis over one range of the first index
       !!
-      !! Four quarter-transformations as four matrix multiplies rather than an
-      !! element loop: the last index is contracted last, so each step is a
-      !! single gemm over a reshaped view.
-      real(dp), intent(in) :: c_active(:, :)
-      real(dp), intent(in) :: ddm2(:, :, :, :)
+      !! **Four gemms and no copies.** Each step contracts the *first* index and
+      !! leaves the new one last, so after four the result is already `(p q r s)`
+      !! and never has to be put in order. Written the obvious way instead --
+      !! a `reshape` between steps -- the arithmetic is nothing and the copying
+      !! is everything: the last intermediate alone is `np n_ao^3`, and moving
+      !! it twice per block came to gigabytes and 2.8 s of a 16 s gradient on
+      !! ethane/cc-pVTZ, against about 0.1 s of actual multiplication.
+      !!
+      !! The buffers are therefore flat and viewed through pointers with their
+      !! bounds remapped, which is the same trick `build_two_particle_density`
+      !! uses next door and for the same reason: the memory order is identical
+      !! either way, so the reshape was only ever telling the compiler what it
+      !! already had.
+      real(dp), intent(in), target :: c_active(:, :)
+      real(dp), intent(in), target, contiguous :: ddm2(:, :, :, :)
+         !! `contiguous` because its bounds are remapped below, and a rank
+         !! remapping needs a target the compiler knows is not a stride.
       integer, intent(in) :: p_lo, p_hi
-      real(dp), allocatable, intent(out) :: gamma_blk(:, :, :, :)
+      real(dp), allocatable, target, intent(out) :: gamma_blk(:, :, :, :)
 
-      real(dp), allocatable :: a(:, :, :, :), b(:, :, :, :), c1(:, :, :, :)
-      real(dp), allocatable :: flat_in(:, :), flat_out(:, :)
-      integer :: n_ao, n_act, np, v, w
+      real(dp), allocatable, target :: buf1(:), buf2(:)
+      real(dp), pointer :: src(:, :), dst(:, :)
+      integer :: n_ao, n_act, np, need
 
       n_ao = size(c_active, 1)
       n_act = size(c_active, 2)
       np = p_hi - p_lo + 1
 
-      ! (t u v w) -> (p u v w)
-      allocate (a(np, n_act, n_act, n_act))
-      do w = 1, n_act
-         do v = 1, n_act
-            call pic_gemm(c_active(p_lo:p_hi, :), ddm2(:, :, v, w), a(:, :, v, w), &
-                          beta=0.0_dp)
-         end do
-      end do
-
-      ! (p u v w) -> (p q v w)
-      allocate (b(np, n_ao, n_act, n_act))
-      do w = 1, n_act
-         do v = 1, n_act
-            call pic_gemm(a(:, :, v, w), c_active, b(:, :, v, w), transb="T", beta=0.0_dp)
-         end do
-      end do
-      deallocate (a)
-
-      ! (p q v w) -> (p q r w), contracting v across the flattened (p q)
-      allocate (c1(np, n_ao, n_ao, n_act))
-      allocate (flat_in(np*n_ao, n_act), flat_out(np*n_ao, n_ao))
-      do w = 1, n_act
-         flat_in = reshape(b(:, :, :, w), [np*n_ao, n_act])
-         call pic_gemm(flat_in, c_active, flat_out, transb="T", beta=0.0_dp)
-         c1(:, :, :, w) = reshape(flat_out, [np, n_ao, n_ao])
-      end do
-      deallocate (b, flat_in, flat_out)
-
-      ! (p q r w) -> (p q r s)
       allocate (gamma_blk(np, n_ao, n_ao, n_ao))
-      allocate (flat_in(np*n_ao*n_ao, n_act), flat_out(np*n_ao*n_ao, n_ao))
-      flat_in = reshape(c1, [np*n_ao*n_ao, n_act])
-      call pic_gemm(flat_in, c_active, flat_out, transb="T", beta=0.0_dp)
-      gamma_blk = reshape(flat_out, [np, n_ao, n_ao, n_ao])
-      deallocate (c1, flat_in, flat_out)
+      need = max(n_act**3*np, n_act*np*n_ao*n_ao, n_act**2*np*n_ao)
+      allocate (buf1(need), buf2(need))
+
+      ! (t u v w) -> (u v w p)
+      src(1:n_act, 1:n_act**3) => ddm2
+      dst(1:n_act**3, 1:np) => buf1
+      call pic_gemm(src, c_active(p_lo:p_hi, :), dst, transa="T", transb="T", &
+                    beta=0.0_dp)
+
+      ! (u v w p) -> (v w p q)
+      src(1:n_act, 1:n_act**2*np) => buf1
+      dst(1:n_act**2*np, 1:n_ao) => buf2
+      call pic_gemm(src, c_active, dst, transa="T", transb="T", beta=0.0_dp)
+
+      ! (v w p q) -> (w p q r)
+      src(1:n_act, 1:n_act*np*n_ao) => buf2
+      dst(1:n_act*np*n_ao, 1:n_ao) => buf1
+      call pic_gemm(src, c_active, dst, transa="T", transb="T", beta=0.0_dp)
+
+      ! (w p q r) -> (p q r s), straight into the result
+      src(1:n_act, 1:np*n_ao*n_ao) => buf1
+      dst(1:np*n_ao*n_ao, 1:n_ao) => gamma_blk
+      call pic_gemm(src, c_active, dst, transa="T", transb="T", beta=0.0_dp)
+
+      nullify (src, dst)
+      deallocate (buf1, buf2)
    end subroutine gamma_block
 
 end module mqc_libcint_mcscf_gradient

--- a/backends/libcint/mqc_libcint_mcscf_gradient.f90
+++ b/backends/libcint/mqc_libcint_mcscf_gradient.f90
@@ -1,0 +1,365 @@
+!! Analytic nuclear gradients for an optimised MCSCF wave function
+module mqc_libcint_mcscf_gradient
+   !! dE/dR for a converged CASSCF or ORMAS-SCF, in Hartree/Bohr
+   !!
+   !! **No Z-vector, and that is the whole reason this module is short.** An
+   !! MP2 gradient has to solve for the orbital response because MP2 is not
+   !! variational in the orbitals; a converged MCSCF is stationary with respect
+   !! to both the orbital rotations and the CI coefficients, so the response
+   !! terms are identically zero and the gradient is a contraction of
+   !! differentiated integrals against densities that are already in hand.
+   !!
+   !! That stationarity is a precondition rather than a property, which is why
+   !! the caller is required to have converged: at a point where the orbital
+   !! gradient is not zero this returns a confident number that is not the
+   !! derivative of anything.
+   !!
+   !! **The two-electron term is split by how many active indices it carries.**
+   !! Writing the whole two-particle density in the AO basis and contracting it
+   !! against differentiated integrals is correct and unaffordable -- it is
+   !! `n_ao^4` for every term, including the ones that are mean-field. The
+   !! inactive-inactive and inactive-active blocks are separable, being
+   !! products of one-particle densities, so
+   !!
+   !! ```
+   !! E_2e = 1/2 D.(J - K/2)(D)  +  1/2 sum_tuvw  ddm2_tuvw (tu|vw)
+   !! ```
+   !!
+   !! with `D` the total one-particle density and `ddm2` the active
+   !! two-particle density with its own mean-field part removed,
+   !!
+   !! ```
+   !! ddm2_tuvw = dm2_tuvw - dm1_tu dm1_vw + 1/2 dm1_tv dm1_uw
+   !! ```
+   !!
+   !! The first term is exactly what a closed-shell SCF gradient contracts and
+   !! goes through the same routine. Only the second needs the general
+   !! four-index machinery, and it is built from `n_active^4` rather than from
+   !! the basis, which is what makes this affordable.
+   !!
+   !! Subtracting that mean-field part is not optional bookkeeping: leave it in
+   !! and the active-active energy is counted twice. The failure is invisible
+   !! at `n_active = 0`, where `ddm2` is empty and this reduces exactly to the
+   !! closed-shell gradient, which is why that reduction is a test rather than
+   !! a curiosity.
+   use pic_types, only: dp
+   use mqc_error, only: error_t, ERROR_VALIDATION
+   use mqc_libcint_integrals, only: libcint_molecule_t, shell_dim, atom_ao_blocks
+   use mqc_libcint_gradient, only: nuclear_repulsion_gradient, one_electron_deriv, &
+                                   iprinv_deriv_at, two_electron_deriv, &
+                                   DERIV_OVLP, DERIV_KIN, DERIV_NUC
+   use mqc_libcint_mp2_gradient, only: two_electron_mp2_terms
+   use mqc_libcint_mcscf, only: generalized_fock, mcscf_fock_t
+   use pic_blas_interfaces, only: pic_gemm
+   implicit none
+   private
+
+   public :: libcint_mcscf_gradient
+   public :: cumulant_two_particle_density   !! Exposed for the tests
+
+   real(dp), parameter :: BLOCK_TARGET = 2.0e8_dp
+      !! Bytes the first-index block of the AO two-particle density may reach.
+      !! The ceiling is then set by choice rather than by the basis, exactly as
+      !! on the MP2 path this borrows its contraction from.
+
+contains
+
+   subroutine libcint_mcscf_gradient(mol, orbitals, n_inactive, n_active, dm1, dm2, &
+                                     gradient, error)
+      !! The gradient of a stationary MCSCF energy
+      !!
+      !! `dm1` and `dm2` are the spin-traced active densities as
+      !! `active_space_rdms` builds them and `run_libcint_casscf` reports them,
+      !! and they must be the ones belonging to `orbitals`. On a run that
+      !! stopped early the two are one orbital step apart -- consistent with
+      !! each other but not with the orbitals -- so the caller checks
+      !! convergence before arriving here.
+      type(libcint_molecule_t), intent(in) :: mol
+      real(dp), intent(in) :: orbitals(:, :)       !! (n_ao, n_mo)
+      integer, intent(in) :: n_inactive, n_active
+      real(dp), intent(in) :: dm1(:, :)            !! (n_active, n_active)
+      real(dp), intent(in) :: dm2(:, :, :, :)      !! (n_active^4), chemist order
+      real(dp), allocatable, intent(out) :: gradient(:, :)   !! (3, n_atoms)
+      type(error_t), intent(inout) :: error
+
+      real(dp), allocatable :: d_inactive(:, :), d_active(:, :), d_total(:, :)
+      real(dp), allocatable :: weighted(:, :), work(:, :)
+      real(dp), allocatable :: c_active(:, :), ddm2(:, :, :, :)
+      real(dp), allocatable :: s1(:, :, :), kin(:, :, :), h1(:, :, :)
+      real(dp), allocatable :: vhf(:, :, :), vrinv(:, :, :), hcore_a(:, :, :)
+      type(mcscf_fock_t) :: fock
+      integer, allocatable :: offsets(:), counts(:)
+      integer :: n_ao, n_mo, iatom, comp, p0, p1
+
+      if (error%has_error()) return
+
+      n_ao = size(orbitals, 1)
+      n_mo = size(orbitals, 2)
+
+      if (n_ao /= mol%nao) then
+         call error%set(ERROR_VALIDATION, "the MCSCF gradient was given orbitals "// &
+                        "that do not span this basis.")
+         return
+      end if
+      if (n_inactive + n_active > n_mo) then
+         call error%set(ERROR_VALIDATION, "more inactive plus active orbitals than "// &
+                        "the basis provides.")
+         return
+      end if
+      if (n_active > 0) then
+         if (size(dm1, 1) /= n_active .or. size(dm2, 1) /= n_active) then
+            call error%set(ERROR_VALIDATION, "the active densities do not match the "// &
+                           "active space they are said to belong to.")
+            return
+         end if
+      end if
+
+      allocate (gradient(3, mol%natm))
+      gradient = 0.0_dp
+
+      call nuclear_repulsion_gradient(mol, gradient)
+
+      ! The one-particle density, in two pieces because the gradient needs them
+      ! separately later and the sum immediately.
+      allocate (d_inactive(n_ao, n_ao), d_active(n_ao, n_ao), d_total(n_ao, n_ao))
+      d_inactive = 0.0_dp
+      d_active = 0.0_dp
+      if (n_inactive > 0) then
+         call pic_gemm(orbitals(:, 1:n_inactive), orbitals(:, 1:n_inactive), d_inactive, &
+                       transb="T", alpha=2.0_dp, beta=0.0_dp)
+      end if
+      if (n_active > 0) then
+         allocate (c_active(n_ao, n_active))
+         c_active = orbitals(:, n_inactive + 1:n_inactive + n_active)
+         allocate (work(n_ao, n_active))
+         call pic_gemm(c_active, dm1, work, beta=0.0_dp)
+         call pic_gemm(work, c_active, d_active, transb="T", beta=0.0_dp)
+         deallocate (work)
+      end if
+      d_total = d_inactive + d_active
+
+      ! The Pulay term contracts against the generalised Fock matrix, which is
+      ! the MCSCF energy-weighted density: for a closed shell with no active
+      ! space it is `2 eps_i` on the diagonal, which is what the SCF gradient
+      ! builds by hand from the orbital energies. Symmetrised because it is
+      ! symmetric only at a stationary point, and rounding should not decide
+      ! whether the Pulay term is.
+      call generalized_fock(mol, orbitals, n_inactive, n_active, dm1, dm2, fock, error)
+      if (error%has_error()) return
+
+      allocate (weighted(n_ao, n_ao), work(n_ao, n_mo))
+      call pic_gemm(orbitals, 0.5_dp*(fock%general + transpose(fock%general)), work, &
+                    beta=0.0_dp)
+      call pic_gemm(work, orbitals, weighted, transb="T", beta=0.0_dp)
+      deallocate (work)
+
+      ! The sign convention is libcint's, and the same one the SCF gradient
+      ! states: `ip` integrals carry a nabla on the bra, and the derivative with
+      ! respect to the atom the bra sits on is minus that.
+      call one_electron_deriv(mol, s1, DERIV_OVLP)
+      s1 = -s1
+      call one_electron_deriv(mol, kin, DERIV_KIN)
+      call one_electron_deriv(mol, h1, DERIV_NUC)
+      h1 = -(kin + h1)
+      deallocate (kin)
+
+      ! The separable two-electron term: the inactive-inactive and
+      ! inactive-active blocks together, which is the closed-shell contraction
+      ! over the total density.
+      call two_electron_deriv(mol, d_total, vhf, error)
+      if (error%has_error()) return
+
+      allocate (offsets(mol%natm), counts(mol%natm))
+      call atom_ao_blocks(mol, offsets, counts)
+
+      allocate (vrinv(n_ao, n_ao, 3), hcore_a(n_ao, n_ao, 3))
+      do iatom = 1, mol%natm
+         p0 = offsets(iatom) + 1
+         p1 = offsets(iatom) + counts(iatom)
+
+         ! Moving an atom moves the basis functions centred on it and moves the
+         ! nucleus every electron is attracted to. The first is the `h1` block,
+         ! the second is Hellmann-Feynman and involves no basis derivative.
+         call iprinv_deriv_at(mol, iatom, vrinv)
+         vrinv = -mol%charges(iatom)*vrinv
+         if (counts(iatom) > 0) then
+            vrinv(p0:p1, :, :) = vrinv(p0:p1, :, :) + h1(p0:p1, :, :)
+         end if
+         do comp = 1, 3
+            hcore_a(:, :, comp) = vrinv(:, :, comp) + transpose(vrinv(:, :, comp))
+         end do
+
+         do comp = 1, 3
+            gradient(comp, iatom) = gradient(comp, iatom) &
+                                    + sum(hcore_a(:, :, comp)*d_total)
+         end do
+
+         if (counts(iatom) == 0) cycle
+
+         ! Twice, because the nabla sat on the bra and the ket's contribution is
+         ! the same number by the symmetry of the undifferentiated integrals.
+         do comp = 1, 3
+            gradient(comp, iatom) = gradient(comp, iatom) &
+                                    + 2.0_dp*sum(vhf(p0:p1, :, comp)*d_total(p0:p1, :)) &
+                                    - 2.0_dp*sum(s1(p0:p1, :, comp)*weighted(p0:p1, :))
+         end do
+      end do
+      deallocate (vrinv, hcore_a, vhf, s1, h1)
+
+      ! What is left is the part of the active two-particle density that is not
+      ! a product of one-particle densities. Nothing to do when there is no
+      ! active space, and this module then reduces to the closed-shell gradient.
+      if (n_active > 0) then
+         call cumulant_two_particle_density(dm1, dm2, ddm2)
+         call active_two_electron_gradient(mol, c_active, ddm2, gradient, error)
+         if (error%has_error()) return
+      end if
+   end subroutine libcint_mcscf_gradient
+
+   pure subroutine cumulant_two_particle_density(dm1, dm2, ddm2)
+      !! `dm2` with the part already counted as a mean-field product removed
+      !!
+      !! The separable term contracted above is `1/2 D.(J - K/2)(D)` over the
+      !! *total* density, and expanding that leaves an active-active piece
+      !! `1/2 sum [dm1_tu dm1_vw - 1/2 dm1_tv dm1_uw] (tu|vw)`. Subtracting it
+      !! here is what keeps the two contractions a partition of the energy
+      !! rather than an overlapping pair.
+      !!
+      !! Chemist ordering throughout, matching `active_space_rdms` and the
+      !! `(tu|vw)` the generalised Fock contracts.
+      real(dp), intent(in) :: dm1(:, :)
+      real(dp), intent(in) :: dm2(:, :, :, :)
+      real(dp), allocatable, intent(out) :: ddm2(:, :, :, :)
+
+      integer :: n, t, u, v, w
+
+      n = size(dm1, 1)
+      allocate (ddm2(n, n, n, n))
+      do w = 1, n
+         do v = 1, n
+            do u = 1, n
+               do t = 1, n
+                  ddm2(t, u, v, w) = dm2(t, u, v, w) - dm1(t, u)*dm1(v, w) &
+                                     + 0.5_dp*dm1(t, v)*dm1(u, w)
+               end do
+            end do
+         end do
+      end do
+   end subroutine cumulant_two_particle_density
+
+   subroutine active_two_electron_gradient(mol, c_active, ddm2, gradient, error)
+      !! The genuinely non-separable term, a block of the first index at a time
+      !!
+      !! The density is transformed out of the active space and into the AO
+      !! basis one block at a time and handed to the same contraction the MP2
+      !! gradient uses, which expects exactly this: a general four-index array
+      !! that is *not* symmetric in the ket pair, and a block of the first index
+      !! identified by its shell range.
+      !!
+      !! Blocks are cut on shell boundaries because a shell's functions share a
+      !! quartet and cannot be split across two passes.
+      type(libcint_molecule_t), intent(in) :: mol
+      real(dp), intent(in) :: c_active(:, :)       !! (n_ao, n_active)
+      real(dp), intent(in) :: ddm2(:, :, :, :)
+      real(dp), intent(inout) :: gradient(:, :)
+      type(error_t), intent(inout) :: error
+
+      real(dp), allocatable :: gamma_blk(:, :, :, :), eri_blk(:, :, :, :)
+      real(dp), allocatable :: dummy_vhf1(:, :, :, :), hf_density(:, :)
+      integer :: n_ao, ish, ish_lo, ish_hi, p_lo, p_hi, np, per_block
+
+      if (error%has_error()) return
+      n_ao = size(c_active, 1)
+
+      ! `with_reference` false leaves these alone; they exist because an absent
+      ! optional cannot be named where these are named.
+      allocate (dummy_vhf1(1, 1, 1, 1), hf_density(n_ao, n_ao))
+      dummy_vhf1 = 0.0_dp
+      hf_density = 0.0_dp
+
+      per_block = max(1, int(BLOCK_TARGET/(2.0_dp*real(n_ao, dp)**3*8.0_dp)))
+
+      ish_lo = 1
+      do while (ish_lo <= mol%nbas)
+         p_lo = mol%shell_offset(ish_lo) + 1
+         ish_hi = ish_lo
+         do ish = ish_lo, mol%nbas
+            p_hi = mol%shell_offset(ish) + shell_dim(mol%cartesian, ish - 1, mol%bas)
+            if (ish > ish_lo .and. p_hi - p_lo + 1 > per_block) exit
+            ish_hi = ish
+         end do
+         p_hi = mol%shell_offset(ish_hi) + shell_dim(mol%cartesian, ish_hi - 1, mol%bas)
+         np = p_hi - p_lo + 1
+
+         call gamma_block(c_active, ddm2, p_lo, p_hi, gamma_blk)
+
+         allocate (eri_blk(np, n_ao, n_ao, n_ao))
+         eri_blk = 0.0_dp
+         call two_electron_mp2_terms(mol, gamma_blk, hf_density, gradient, dummy_vhf1, &
+                                     ish_lo=ish_lo, ish_hi=ish_hi, &
+                                     p_offset=p_lo - 1, eri_blk=eri_blk, &
+                                     with_gamma=.true., with_reference=.false.)
+         deallocate (eri_blk, gamma_blk)
+         ish_lo = ish_hi + 1
+      end do
+
+      deallocate (dummy_vhf1, hf_density)
+   end subroutine active_two_electron_gradient
+
+   subroutine gamma_block(c_active, ddm2, p_lo, p_hi, gamma_blk)
+      !! `ddm2` transformed to the AO basis over one range of the first index
+      !!
+      !! Four quarter-transformations as four matrix multiplies rather than an
+      !! element loop: the last index is contracted last, so each step is a
+      !! single gemm over a reshaped view.
+      real(dp), intent(in) :: c_active(:, :)
+      real(dp), intent(in) :: ddm2(:, :, :, :)
+      integer, intent(in) :: p_lo, p_hi
+      real(dp), allocatable, intent(out) :: gamma_blk(:, :, :, :)
+
+      real(dp), allocatable :: a(:, :, :, :), b(:, :, :, :), c1(:, :, :, :)
+      real(dp), allocatable :: flat_in(:, :), flat_out(:, :)
+      integer :: n_ao, n_act, np, v, w
+
+      n_ao = size(c_active, 1)
+      n_act = size(c_active, 2)
+      np = p_hi - p_lo + 1
+
+      ! (t u v w) -> (p u v w)
+      allocate (a(np, n_act, n_act, n_act))
+      do w = 1, n_act
+         do v = 1, n_act
+            call pic_gemm(c_active(p_lo:p_hi, :), ddm2(:, :, v, w), a(:, :, v, w), &
+                          beta=0.0_dp)
+         end do
+      end do
+
+      ! (p u v w) -> (p q v w)
+      allocate (b(np, n_ao, n_act, n_act))
+      do w = 1, n_act
+         do v = 1, n_act
+            call pic_gemm(a(:, :, v, w), c_active, b(:, :, v, w), transb="T", beta=0.0_dp)
+         end do
+      end do
+      deallocate (a)
+
+      ! (p q v w) -> (p q r w), contracting v across the flattened (p q)
+      allocate (c1(np, n_ao, n_ao, n_act))
+      allocate (flat_in(np*n_ao, n_act), flat_out(np*n_ao, n_ao))
+      do w = 1, n_act
+         flat_in = reshape(b(:, :, :, w), [np*n_ao, n_act])
+         call pic_gemm(flat_in, c_active, flat_out, transb="T", beta=0.0_dp)
+         c1(:, :, :, w) = reshape(flat_out, [np, n_ao, n_ao])
+      end do
+      deallocate (b, flat_in, flat_out)
+
+      ! (p q r w) -> (p q r s)
+      allocate (gamma_blk(np, n_ao, n_ao, n_ao))
+      allocate (flat_in(np*n_ao*n_ao, n_act), flat_out(np*n_ao*n_ao, n_ao))
+      flat_in = reshape(c1, [np*n_ao*n_ao, n_act])
+      call pic_gemm(flat_in, c_active, flat_out, transb="T", beta=0.0_dp)
+      gamma_blk = reshape(flat_out, [np, n_ao, n_ao, n_ao])
+      deallocate (c1, flat_in, flat_out)
+   end subroutine gamma_block
+
+end module mqc_libcint_mcscf_gradient

--- a/backends/libcint/mqc_libcint_mp2_gradient.f90
+++ b/backends/libcint/mqc_libcint_mp2_gradient.f90
@@ -1190,12 +1190,26 @@ contains
       de_local = 0.0_dp
       vhf_local = 0.0_dp
 
-      !$omp do schedule(dynamic)
+      ! **Collapsed, because the outer loop is a block and a block can be one
+      ! shell.** `first..last` is however much of the first index the caller
+      ! could afford to hold, and that is set by memory rather than by the
+      ! machine: at 500 MB the MP2 gradient gets three basis functions per block
+      ! by n_ao = 200 and one by n_ao = 300, so threading on `ish` alone leaves
+      ! every core but one idle exactly when the system is large enough to care.
+      ! Collapsing with `jsh` gives the schedule `nbas` times more to hand out,
+      ! which does not depend on the block at all. Measured on ethane/cc-pVTZ
+      ! through the MCSCF gradient: 39.7 s to 7.4 s, the same number a block big
+      ! enough to hold the whole basis reaches, and now reached without the
+      ! memory.
+      !
+      ! Both counters are per-iteration rather than hoisted, which is what
+      ! collapsing requires -- the loops have to nest perfectly.
+      !$omp do collapse(2) schedule(dynamic)
       do ish = first, last
-         di = shell_dim(mol%cartesian, ish - 1, mol%bas)
-         io = mol%shell_offset(ish)
-         ia = shell_atom(ish)
          do jsh = 1, nbas
+            di = shell_dim(mol%cartesian, ish - 1, mol%bas)
+            io = mol%shell_offset(ish)
+            ia = shell_atom(ish)
             dj = shell_dim(mol%cartesian, jsh - 1, mol%bas)
             jo = mol%shell_offset(jsh)
             do ksh = 1, nbas

--- a/src/methods/mqc_libcint_bridge_stub.f90
+++ b/src/methods/mqc_libcint_bridge_stub.f90
@@ -240,7 +240,7 @@ contains
       if (present(want_hessian)) return
    end subroutine run_libcint_hf
 
-   subroutine run_libcint_mcscf(settings, fragment, result)
+   subroutine run_libcint_mcscf(settings, fragment, result, want_gradient)
       !! No-op stand-in: CASSCF and CASCI need the CPU integral backend
       !!
       !! All of it does -- the reference SCF, the active-space transform, the
@@ -249,6 +249,7 @@ contains
       type(cuest_scf_settings_t), intent(in) :: settings
       type(physical_fragment_t), intent(in) :: fragment
       type(calculation_result_t), intent(inout) :: result
+      logical, intent(in), optional :: want_gradient
 
       call result%error%set(ERROR_VALIDATION, &
                             "a multiconfigurational calculation needs the CPU integral "// &

--- a/src/methods/mqc_method_mcscf.f90
+++ b/src/methods/mqc_method_mcscf.f90
@@ -138,6 +138,16 @@ contains
       type(physical_fragment_t), intent(in) :: fragment
       type(calculation_result_t), intent(out) :: result
 
+      call mcscf_run(this, fragment, result, want_gradient=.false.)
+   end subroutine mcscf_calc_energy
+
+   subroutine mcscf_run(this, fragment, result, want_gradient)
+      !! The settings the backend needs, built once for both drivers
+      class(mcscf_method_t), intent(in) :: this
+      type(physical_fragment_t), intent(in) :: fragment
+      type(calculation_result_t), intent(out) :: result
+      logical, intent(in) :: want_gradient
+
       type(cuest_scf_settings_t) :: settings
 
       ! The reference SCF's settings, which is most of what this is: a CASSCF
@@ -178,25 +188,29 @@ contains
       settings%mcscf%max_macro_iter = this%options%max_macro_iter
       settings%mcscf%orbital_convergence = this%options%orbital_tol
 
-      call run_libcint_mcscf(settings, fragment, result)
-   end subroutine mcscf_calc_energy
+      call run_libcint_mcscf(settings, fragment, result, want_gradient=want_gradient)
+   end subroutine mcscf_run
 
    subroutine mcscf_calc_gradient(this, fragment, result)
-      !! Refused: a CASSCF gradient needs the Lagrangian, which does not exist
+      !! The analytic gradient of an optimised CASSCF
       !!
-      !! Not finite differences either, and that is a deliberate choice rather
-      !! than an omission. A numerical CASSCF gradient is 6N converged orbital
+      !! Analytic rather than by differences, and that remains a deliberate
+      !! choice: a numerical MCSCF gradient is 6N converged orbital
       !! optimisations, each of which can land on a *different* active space --
       !! the orbitals that make up a CAS are identified by their character, and
-      !! a displaced geometry can reorder them. The result is a gradient with
-      !! discontinuities that look like noise, and nothing in the output would
-      !! say which displacement had wandered. Better to refuse.
+      !! a displaced geometry can reorder them. The result has discontinuities
+      !! that look like noise and nothing in the output says which displacement
+      !! wandered.
+      !!
+      !! A CASCI is still refused, and the backend says so: its orbitals came
+      !! from the SCF and were never optimised for the active space, so the
+      !! energy is not stationary with respect to them and the response terms
+      !! this omits are not zero.
       class(mcscf_method_t), intent(in) :: this
       type(physical_fragment_t), intent(in) :: fragment
       type(calculation_result_t), intent(out) :: result
 
-      call refuse_derivative(fragment, result, "gradient")
-      if (this%options%n_active_orbitals < 0) return
+      call mcscf_run(this, fragment, result, want_gradient=.true.)
    end subroutine mcscf_calc_gradient
 
    subroutine mcscf_calc_hessian(this, fragment, result)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -111,6 +111,7 @@ if(MQC_ENABLE_LIBCINT)
   target_link_libraries(test_mqc_casci PRIVATE cint_fortran cint)
 
   addtest(mqc_mcscf)
+  addtest(mqc_mcscf_gradient)
   target_link_libraries(test_mqc_mcscf PRIVATE cint_fortran cint)
 
   # Choosing an active space from atomic orbital labels.

--- a/test/test_mqc_mcscf_gradient.f90
+++ b/test/test_mqc_mcscf_gradient.f90
@@ -48,7 +48,9 @@ contains
                   new_unittest("water 6-31g CAS(4,4) agrees with PySCF", &
                                water_631g_matches_pyscf), &
                   new_unittest("water 6-31g CAS(6,5) agrees with PySCF", &
-                               water_631g_65_matches_pyscf) &
+                               water_631g_65_matches_pyscf), &
+                  new_unittest("an ORMAS gradient differences its energy", &
+                               ormas_gradient_differences_the_energy) &
                   ]
    end subroutine collect_mcscf_gradient_tests
 
@@ -238,6 +240,81 @@ contains
 
       call compare_against(error, "6-31g", 2, 5, 3, 3, -76.039192258019_dp, REFERENCE)
    end subroutine water_631g_65_matches_pyscf
+
+   subroutine ormas_gradient_differences_the_energy(error)
+      !! The same expression, on a wave function with a restricted space
+      !!
+      !! Nothing here is specific to a complete active space: the gradient is
+      !! built from `dm1` and `dm2` and does not ask where they came from, and
+      !! `run_libcint_casscf` optimises a restricted space too -- its redundancy
+      !! rule already knows that rotating one active orbital into another stops
+      !! being redundant once the two fall in different subspaces. So this
+      !! ought to work, and "ought to" is why it is tested rather than assumed.
+      !!
+      !! Differenced against the energy rather than against a reference code,
+      !! because PySCF has no ORMAS to compare with.
+      type(error_type), allocatable, intent(out) :: error
+      real(dp), parameter :: STEP = 2.0e-3_dp
+      real(dp) :: plus, minus, numerical, analytic
+      real(dp), allocatable :: gradient(:, :)
+      real(dp) :: moved(3, 3)
+
+      call ormas_at(error, WATER, gradient=gradient)
+      if (allocated(error)) return
+      analytic = gradient(3, 2)
+
+      moved = WATER
+      moved(3, 2) = WATER(3, 2) + STEP
+      call ormas_at(error, moved, energy=plus)
+      if (allocated(error)) return
+
+      moved(3, 2) = WATER(3, 2) - STEP
+      call ormas_at(error, moved, energy=minus)
+      if (allocated(error)) return
+
+      numerical = (plus - minus)/(2.0_dp*STEP)
+      call check(error, abs(numerical - analytic) < 1.0e-6_dp, &
+                 "the ORMAS gradient should difference the ORMAS energy")
+   end subroutine ormas_gradient_differences_the_energy
+
+   subroutine ormas_at(error, coordinates, energy, gradient)
+      !! A converged restricted-space optimisation at one geometry
+      type(error_type), allocatable, intent(out) :: error
+      real(dp), intent(in) :: coordinates(3, 3)
+      real(dp), intent(out), optional :: energy
+      real(dp), allocatable, intent(out), optional :: gradient(:, :)
+
+      ! Active orbitals 4-7 in two subspaces, with at most one electron above
+      ! the first: a hard enough restriction that the inter-subspace rotations
+      ! carry a gradient worth differencing.
+      integer, parameter :: SUBSPACES(2) = [1, 3]
+      integer, parameter :: MIN_E(2) = [3, 0], MAX_E(2) = [4, 1]
+      type(libcint_molecule_t) :: mol
+      type(rhf_result_t) :: scf
+      type(casscf_result_t) :: cas
+      type(error_t) :: err
+
+      call build_libcint_molecule(WATER_Z, WATER_SYM, coordinates, "sto-3g", mol, err)
+      call run_libcint_rhf(mol, 10, 300, 1.0e-12_dp, 1.0e-10_dp, .false., scf, err)
+      call check(error, scf%converged, "the SCF should converge")
+      if (allocated(error)) return
+
+      call run_libcint_casscf(mol, scf%orbitals, 3, 4, 2, 2, cas, err, &
+                              max_iterations=400, gradient_tol=1.0e-9_dp, &
+                              verbose=.false., subspaces=SUBSPACES, &
+                              min_electrons=MIN_E, max_electrons=MAX_E)
+      call check(error,.not. err%has_error(), "the ORMAS-SCF should run")
+      if (allocated(error)) return
+      call check(error, cas%converged, "the ORMAS-SCF should converge")
+      if (allocated(error)) return
+
+      if (present(energy)) energy = cas%energy
+      if (present(gradient)) then
+         call libcint_mcscf_gradient(mol, cas%orbitals, 3, 4, cas%dm1, cas%dm2, &
+                                     gradient, err)
+         call check(error,.not. err%has_error(), "the gradient should build")
+      end if
+   end subroutine ormas_at
 
    subroutine compare_against(error, basis, n_inactive, n_active, n_alpha, n_beta, &
                               reference_energy, reference)

--- a/test/test_mqc_mcscf_gradient.f90
+++ b/test/test_mqc_mcscf_gradient.f90
@@ -1,0 +1,310 @@
+module test_mqc_mcscf_gradient
+   !! The analytic MCSCF nuclear gradient
+   !!
+   !! Two of these are structural rather than numerical, and they are the ones
+   !! that catch the mistakes this gradient is actually prone to. Emptying the
+   !! active space has to reproduce the closed-shell gradient *exactly*, because
+   !! with no active orbitals every term this module adds on top of the
+   !! separable one is identically zero -- so a disagreement there is a bug in
+   !! the part shared with Hartree-Fock, isolated from the active-space part
+   !! that would otherwise mask it. And the cumulant has to vanish for a
+   !! determinant, because a single determinant's two-particle density *is* the
+   !! mean-field product that the separable term already counted; if it does not
+   !! vanish the active energy is being counted twice, which is invisible at
+   !! `n_active = 0` and wrong everywhere else.
+   use testdrive, only: new_unittest, unittest_type, error_type, check
+   use pic_types, only: dp
+   use mqc_error, only: error_t
+   use mqc_libcint_integrals, only: libcint_molecule_t, build_libcint_molecule
+   use mqc_libcint_rhf, only: rhf_result_t, run_libcint_rhf
+   use mqc_libcint_gradient, only: libcint_scf_gradient
+   use mqc_libcint_mcscf, only: run_libcint_casscf, casscf_result_t
+   use mqc_libcint_mcscf_gradient, only: libcint_mcscf_gradient, &
+                                         cumulant_two_particle_density
+   implicit none
+   private
+
+   public :: collect_mcscf_gradient_tests
+
+   real(dp), parameter :: WATER(3, 3) = reshape( &
+                          [0.0_dp, 0.0_dp, 0.190459_dp, &
+                           0.0_dp, 1.459853_dp, -0.884001_dp, &
+                           0.0_dp, -1.459853_dp, -0.884001_dp], [3, 3])
+   integer, parameter :: WATER_Z(3) = [8, 1, 1]
+   character(len=2), parameter :: WATER_SYM(3) = ["O ", "H ", "H "]
+
+contains
+
+   subroutine collect_mcscf_gradient_tests(testsuite)
+      type(unittest_type), allocatable, intent(out) :: testsuite(:)
+
+      testsuite = [ &
+                  new_unittest("an empty active space is the SCF gradient", &
+                               empty_active_space_is_scf), &
+                  new_unittest("the cumulant vanishes for a determinant", &
+                               cumulant_vanishes_for_a_determinant), &
+                  new_unittest("the gradient differences the energy", &
+                               gradient_differences_the_energy), &
+                  new_unittest("water 6-31g CAS(4,4) agrees with PySCF", &
+                               water_631g_matches_pyscf), &
+                  new_unittest("water 6-31g CAS(6,5) agrees with PySCF", &
+                               water_631g_65_matches_pyscf) &
+                  ]
+   end subroutine collect_mcscf_gradient_tests
+
+   subroutine empty_active_space_is_scf(error)
+      !! With nothing active, this is the closed-shell gradient
+      !!
+      !! Not to machine precision, and the reason is worth stating rather than
+      !! hiding in a loose tolerance. The two build the Pulay term from
+      !! different objects: the SCF weights the orbitals by their converged
+      !! energies, while this weights them by a generalised Fock matrix rebuilt
+      !! from the density through a Schwarz-screened direct build. Those agree
+      !! to the screening, which is around 1e-11 here on a gradient of 7e-2.
+      !!
+      !! The bound is still tight enough to be worth something: a factor of two
+      !! or a wrong sign on any term -- which is what this test exists to catch
+      !! -- lands at 1e-2, nine orders above where it passes.
+      type(error_type), allocatable, intent(out) :: error
+      type(libcint_molecule_t) :: mol
+      type(rhf_result_t) :: scf
+      type(error_t) :: err
+      real(dp), allocatable :: g_scf(:, :), g_mc(:, :)
+      real(dp), allocatable :: dm1(:, :), dm2(:, :, :, :)
+      real(dp) :: worst
+      integer :: i, j
+
+      call build_libcint_molecule(WATER_Z, WATER_SYM, WATER, "sto-3g", mol, err)
+      call check(error,.not. err%has_error(), "the molecule should build")
+      if (allocated(error)) return
+
+      call run_libcint_rhf(mol, 10, 300, 1.0e-12_dp, 1.0e-10_dp, .false., scf, err)
+      call check(error, scf%converged, "the SCF should converge")
+      if (allocated(error)) return
+
+      call libcint_scf_gradient(mol, scf%density, orbitals=scf%orbitals, &
+                                orbital_energies=scf%orbital_energies, &
+                                n_occupied=scf%n_occupied, gradient=g_scf, error=err)
+      call check(error,.not. err%has_error(), "the SCF gradient should build")
+      if (allocated(error)) return
+
+      ! No active orbitals: the densities are zero-sized, and every active term
+      ! is skipped rather than being multiplied by zero.
+      allocate (dm1(0, 0), dm2(0, 0, 0, 0))
+      call libcint_mcscf_gradient(mol, scf%orbitals, scf%n_occupied, 0, dm1, dm2, &
+                                  g_mc, err)
+      call check(error,.not. err%has_error(), "the MCSCF gradient should build")
+      if (allocated(error)) return
+
+      worst = 0.0_dp
+      do j = 1, size(g_scf, 2)
+         do i = 1, 3
+            worst = max(worst, abs(g_scf(i, j) - g_mc(i, j)))
+         end do
+      end do
+      call check(error, worst < 1.0e-9_dp, &
+                 "an empty active space should reproduce the SCF gradient")
+   end subroutine empty_active_space_is_scf
+
+   subroutine cumulant_vanishes_for_a_determinant(error)
+      !! A closed-shell determinant's two-particle density is exactly the
+      !! mean-field product the separable term already carries.
+      type(error_type), allocatable, intent(out) :: error
+      integer, parameter :: N = 4
+      real(dp) :: dm1(N, N), dm2(N, N, N, N)
+      real(dp), allocatable :: ddm2(:, :, :, :)
+      integer :: t, u, v, w
+      real(dp) :: worst
+
+      ! Every active orbital doubly occupied: `dm1 = 2 delta`, and the
+      ! two-particle density of that determinant follows from Wick's theorem.
+      dm1 = 0.0_dp
+      do t = 1, N
+         dm1(t, t) = 2.0_dp
+      end do
+      do w = 1, N
+         do v = 1, N
+            do u = 1, N
+               do t = 1, N
+                  dm2(t, u, v, w) = dm1(t, u)*dm1(v, w) - 0.5_dp*dm1(t, v)*dm1(u, w)
+               end do
+            end do
+         end do
+      end do
+
+      call cumulant_two_particle_density(dm1, dm2, ddm2)
+      worst = maxval(abs(ddm2))
+      call check(error, worst < 1.0e-14_dp, &
+                 "the cumulant should vanish for a single determinant")
+   end subroutine cumulant_vanishes_for_a_determinant
+
+   subroutine gradient_differences_the_energy(error)
+      !! Against this program's own energy, with no reference code involved
+      !!
+      !! The PySCF comparisons check the whole contraction against another
+      !! implementation, which is the stronger test of correctness but shares
+      !! a blind spot with it: both codes have to agree on *which* stationary
+      !! point they converged to, and on a surface with more than one they need
+      !! not. Water in STO-3G is exactly that case -- this optimiser finds a
+      !! point about 1.7 mHartree below the one PySCF reaches from Hartree-Fock
+      !! orbitals -- and a gradient compared across two different solutions
+      !! disagrees for a reason that has nothing to do with the gradient.
+      !!
+      !! Differencing the energy here sidesteps that entirely: both numbers come
+      !! from the same optimiser landing on the same point. It is the check that
+      !! the analytic expression really is the derivative of the energy this
+      !! program computes, rather than of the one another program computes.
+      !!
+      !! Central differences, so the error is `O(h^2)`; at `h = 2e-3` bohr that
+      !! is around 1e-7, which sets the tolerance rather than anything about the
+      !! contraction.
+      type(error_type), allocatable, intent(out) :: error
+      real(dp), parameter :: STEP = 2.0e-3_dp
+      real(dp) :: plus, minus, numerical, analytic
+      real(dp), allocatable :: gradient(:, :)
+      real(dp) :: moved(3, 3)
+
+      call energy_at(error, WATER, gradient=gradient)
+      if (allocated(error)) return
+      analytic = gradient(3, 2)
+
+      moved = WATER
+      moved(3, 2) = WATER(3, 2) + STEP
+      call energy_at(error, moved, energy=plus)
+      if (allocated(error)) return
+
+      moved(3, 2) = WATER(3, 2) - STEP
+      call energy_at(error, moved, energy=minus)
+      if (allocated(error)) return
+
+      numerical = (plus - minus)/(2.0_dp*STEP)
+      call check(error, abs(numerical - analytic) < 1.0e-6_dp, &
+                 "the analytic gradient should difference the energy")
+   end subroutine gradient_differences_the_energy
+
+   subroutine energy_at(error, coordinates, energy, gradient)
+      !! A converged CAS(4,4) at one geometry, and optionally its gradient
+      type(error_type), allocatable, intent(out) :: error
+      real(dp), intent(in) :: coordinates(3, 3)
+      real(dp), intent(out), optional :: energy
+      real(dp), allocatable, intent(out), optional :: gradient(:, :)
+
+      type(libcint_molecule_t) :: mol
+      type(rhf_result_t) :: scf
+      type(casscf_result_t) :: cas
+      type(error_t) :: err
+
+      call build_libcint_molecule(WATER_Z, WATER_SYM, coordinates, "6-31g", mol, err)
+      call run_libcint_rhf(mol, 10, 300, 1.0e-12_dp, 1.0e-10_dp, .false., scf, err)
+      call check(error, scf%converged, "the SCF should converge")
+      if (allocated(error)) return
+
+      call run_libcint_casscf(mol, scf%orbitals, 3, 4, 2, 2, cas, err, &
+                              max_iterations=400, gradient_tol=1.0e-9_dp, &
+                              verbose=.false.)
+      call check(error, cas%converged, "the CASSCF should converge")
+      if (allocated(error)) return
+
+      if (present(energy)) energy = cas%energy
+      if (present(gradient)) then
+         call libcint_mcscf_gradient(mol, cas%orbitals, 3, 4, cas%dm1, cas%dm2, &
+                                     gradient, err)
+         call check(error,.not. err%has_error(), "the gradient should build")
+      end if
+   end subroutine energy_at
+
+   subroutine water_631g_matches_pyscf(error)
+      !! The same, with six virtual orbitals the STO-3G case does not have
+      type(error_type), allocatable, intent(out) :: error
+      real(dp), parameter :: REFERENCE(3, 3) = reshape( &
+                             [0.0_dp, 0.0_dp, -1.714654279167e-02_dp, &
+                              0.0_dp, -1.454057677107e-02_dp, 8.573295541402e-03_dp, &
+                              0.0_dp, 1.454064057661e-02_dp, 8.573247250258e-03_dp], [3, 3])
+
+      call compare_against(error, "6-31g", 3, 4, 2, 2, -76.037525832320_dp, REFERENCE)
+   end subroutine water_631g_matches_pyscf
+
+   subroutine water_631g_65_matches_pyscf(error)
+      !! A different split of the same basis: two inactive rather than three
+      !!
+      !! Worth having beside CAS(4,4) because the inactive-active cross term is
+      !! the one place a wrong factor can hide behind a correct total, and the
+      !! two cases weight it differently.
+      type(error_type), allocatable, intent(out) :: error
+      real(dp), parameter :: REFERENCE(3, 3) = reshape( &
+                             [0.0_dp, 0.0_dp, -1.924985750758e-02_dp, &
+                              0.0_dp, -1.493070902144e-02_dp, 9.624928753936e-03_dp, &
+                              0.0_dp, 1.493070902109e-02_dp, 9.624928753640e-03_dp], [3, 3])
+
+      call compare_against(error, "6-31g", 2, 5, 3, 3, -76.039192258019_dp, REFERENCE)
+   end subroutine water_631g_65_matches_pyscf
+
+   subroutine compare_against(error, basis, n_inactive, n_active, n_alpha, n_beta, &
+                              reference_energy, reference)
+      !! Converge a CASSCF here and check its gradient against PySCF's
+      type(error_type), allocatable, intent(out) :: error
+      character(len=*), intent(in) :: basis
+      integer, intent(in) :: n_inactive, n_active, n_alpha, n_beta
+      real(dp), intent(in) :: reference_energy
+      real(dp), intent(in) :: reference(3, 3)
+
+      type(libcint_molecule_t) :: mol
+      type(rhf_result_t) :: scf
+      type(casscf_result_t) :: cas
+      type(error_t) :: err
+      real(dp), allocatable :: gradient(:, :)
+      real(dp) :: worst, translation
+
+      call build_libcint_molecule(WATER_Z, WATER_SYM, WATER, basis, mol, err)
+      call run_libcint_rhf(mol, 10, 300, 1.0e-12_dp, 1.0e-10_dp, .false., scf, err)
+      call check(error, scf%converged, "the SCF should converge")
+      if (allocated(error)) return
+
+      call run_libcint_casscf(mol, scf%orbitals, n_inactive, n_active, n_alpha, n_beta, &
+                              cas, err, max_iterations=300, gradient_tol=1.0e-8_dp, &
+                              verbose=.false.)
+      call check(error,.not. err%has_error(), "the CASSCF should run")
+      if (allocated(error)) return
+      call check(error, cas%converged, "the CASSCF should converge")
+      if (allocated(error)) return
+      call check(error, abs(cas%energy - reference_energy) < 1.0e-8_dp, &
+                 "the CASSCF energy should match PySCF's")
+      if (allocated(error)) return
+
+      call libcint_mcscf_gradient(mol, cas%orbitals, n_inactive, n_active, &
+                                  cas%dm1, cas%dm2, gradient, err)
+      call check(error,.not. err%has_error(), "the gradient should build")
+      if (allocated(error)) return
+
+      ! PySCF's own macro-iteration stops around 1e-7 on these, so that is the
+      ! floor for the comparison rather than anything about this contraction.
+      worst = maxval(abs(gradient - reference))
+      call check(error, worst < 1.0e-6_dp, "the gradient should match PySCF's")
+      if (allocated(error)) return
+
+      ! Independent of the reference: a gradient that does not sum to zero has
+      ! lost a Pulay term, which a comparison against one number per atom can
+      ! miss if both are wrong the same way.
+      translation = maxval(abs(sum(gradient, dim=2)))
+      call check(error, translation < 1.0e-8_dp, &
+                 "the gradient should be translationally invariant")
+   end subroutine compare_against
+
+end module test_mqc_mcscf_gradient
+
+program test_mcscf_gradient_driver
+   use, intrinsic :: iso_fortran_env, only: error_unit
+   use testdrive, only: run_testsuite, new_testsuite, testsuite_type
+   use test_mqc_mcscf_gradient, only: collect_mcscf_gradient_tests
+   implicit none
+   integer :: stat
+   type(testsuite_type), allocatable :: testsuites(:)
+
+   stat = 0
+   testsuites = [new_testsuite("mcscf_gradient", collect_mcscf_gradient_tests)]
+   call run_testsuite(testsuites(1)%collect, error_unit, stat)
+   if (stat > 0) then
+      write (error_unit, '(i0, a)') stat, " test(s) failed!"
+      error stop
+   end if
+end program test_mcscf_gradient_driver

--- a/test/test_mqc_mcscf_gradient.f90
+++ b/test/test_mqc_mcscf_gradient.f90
@@ -157,30 +157,57 @@ contains
       !! the analytic expression really is the derivative of the energy this
       !! program computes, rather than of the one another program computes.
       !!
-      !! Central differences, so the error is `O(h^2)`; at `h = 2e-3` bohr that
-      !! is around 1e-7, which sets the tolerance rather than anything about the
-      !! contraction.
+      !! **The tolerance measures the difference formula, not the gradient.**
+      !! Central differences carry an `O(h^2)` truncation term, and a step study
+      !! on the largest component showed it behaving exactly as it should:
+      !!
+      !! ```
+      !!   h        error      ratio
+      !!   8e-3     9.75e-6      -
+      !!   4e-3     2.44e-6    4.00
+      !!   2e-3     6.09e-7    4.00
+      !!   1e-3     1.52e-7    4.00
+      !!   5e-4     3.82e-8    3.98
+      !! ```
+      !!
+      !! Four consecutive factors of four: the residual is the formula's, and
+      !! the analytic gradient is the limit it is converging to. So the bound
+      !! below is set by `h`, and tightening it without also shrinking `h` would
+      !! be testing arithmetic that is not in question. `h` is not shrunk
+      !! further because the noise floor grows as `1/h` once the energy's own
+      !! convergence starts to show.
+      !!
+      !! Every component is differenced rather than one, which costs eighteen
+      !! optimisations and catches a term that is wrong only off the symmetry
+      !! axis.
       type(error_type), allocatable, intent(out) :: error
       real(dp), parameter :: STEP = 2.0e-3_dp
       real(dp) :: plus, minus, numerical, analytic
       real(dp), allocatable :: gradient(:, :)
       real(dp) :: moved(3, 3)
 
+      integer :: iatom, comp
+      real(dp) :: worst
+
       call energy_at(error, WATER, gradient=gradient)
       if (allocated(error)) return
-      analytic = gradient(3, 2)
 
-      moved = WATER
-      moved(3, 2) = WATER(3, 2) + STEP
-      call energy_at(error, moved, energy=plus)
-      if (allocated(error)) return
-
-      moved(3, 2) = WATER(3, 2) - STEP
-      call energy_at(error, moved, energy=minus)
-      if (allocated(error)) return
-
-      numerical = (plus - minus)/(2.0_dp*STEP)
-      call check(error, abs(numerical - analytic) < 1.0e-6_dp, &
+      worst = 0.0_dp
+      do iatom = 1, 3
+         do comp = 1, 3
+            analytic = gradient(comp, iatom)
+            moved = WATER
+            moved(comp, iatom) = WATER(comp, iatom) + STEP
+            call energy_at(error, moved, energy=plus)
+            if (allocated(error)) return
+            moved(comp, iatom) = WATER(comp, iatom) - STEP
+            call energy_at(error, moved, energy=minus)
+            if (allocated(error)) return
+            numerical = (plus - minus)/(2.0_dp*STEP)
+            worst = max(worst, abs(numerical - analytic))
+         end do
+      end do
+      call check(error, worst < 1.0e-6_dp, &
                  "the analytic gradient should difference the energy")
    end subroutine gradient_differences_the_energy
 

--- a/test/test_mqc_method_placeholders.f90
+++ b/test/test_mqc_method_placeholders.f90
@@ -339,11 +339,21 @@ contains
    end subroutine test_mcscf_with_active
 
    subroutine test_mcscf_gradient(error)
-      !! A CASSCF gradient is refused rather than faked
+      !! A CASCI gradient is refused rather than faked
       !!
-      !! This used to assert that a gradient came back and was allocated, which
+      !! This began as an assertion that a gradient came back allocated, which
       !! it was: a fully allocated array of zeros. That is the one thing a
-      !! derivative must never do, so the assertion is now the opposite one.
+      !! derivative must never do, so it became the opposite assertion -- and
+      !! for a while it held for every MCSCF, because none of them had one.
+      !!
+      !! A converged CASSCF has one now, so the case that still belongs here is
+      !! the one still refused. A CASCI's orbitals came from the SCF and were
+      !! never optimised for the active space, so its energy is not stationary
+      !! with respect to them and the response terms an analytic gradient omits
+      !! are not zero. `optimize_orbitals` is therefore set false explicitly:
+      !! it defaults true, and left alone this now measures the CASSCF path,
+      !! which is checked against PySCF and against finite differences in
+      !! test_mqc_mcscf_gradient.f90 instead of asserted about here.
       type(error_type), allocatable, intent(out) :: error
       type(mcscf_method_t) :: method
       type(physical_fragment_t) :: fragment
@@ -354,19 +364,20 @@ contains
       method%options%verbose = .true.
       method%options%n_active_electrons = 4
       method%options%n_active_orbitals = 4
+      method%options%optimize_orbitals = .false.
 
       call method%calc_gradient(fragment, result)
 
       call check(error, result%has_error, &
-                 "an MCSCF gradient must be refused, not returned as zeros")
+                 "a CASCI gradient must be refused, not returned as zeros")
       if (allocated(error)) return
 
       call check(error,.not. result%has_gradient, &
-                 "a refused MCSCF gradient must not claim to have one")
+                 "a refused CASCI gradient must not claim to have one")
       if (allocated(error)) return
 
       call check(error, len_trim(result%error%get_message()) > 0, &
-                 "a refused MCSCF gradient must say why")
+                 "a refused CASCI gradient must say why")
 
       call fragment%destroy()
    end subroutine test_mcscf_gradient

--- a/tools/cpu_validation/gen_cpu_validation.py
+++ b/tools/cpu_validation/gen_cpu_validation.py
@@ -542,6 +542,24 @@ MCSCF_CASES = [
 # in ten teaches people to ignore the suite. test_mqc_mcscf.f90 keeps that case
 # and says what it costs.
 
+# Gradients of an optimised MCSCF, on the two active spaces this suite already
+# knows PySCF converges. They differ in the way that matters here: water in
+# STO-3G has *no* virtual orbitals at all -- two inactive plus five active is
+# the whole basis -- so it exercises the inactive-active blocks alone, while
+# N2 carries eighteen virtuals. The gradient is taken at the multi-start
+# minimum for the reason `pyscf_mcscf_gradient` gives.
+#
+# Water in 6-31G was tried first and is not here: PySCF reports `converged =
+# False` on it from all ten starts at the 1e-7 orbital gradient this generator
+# asks for, and reaches only 1e-6. A reference taken from a run that did not
+# converge is not a reference. test/test_mqc_mcscf_gradient.f90 keeps that case
+# against a hand-made 1e-6 reference, where the looser bound is stated.
+MCSCF_GRADIENT_CASES = [
+    # molecule  basis      nelecas  ncas
+    ("water",   "sto-3g",  6,       5),
+    ("n2",      "cc-pvdz", 6,       6),
+]
+
 QUAO_CASES = [
     ("water", "6-31g"),
     ("h2s", "6-31g"),
@@ -706,6 +724,13 @@ GRADIENT_DFT_TOLERANCE = 1.0e-7
 # lives. It is still two hundred times tighter than a missing term, which is a
 # 1e-3 event. Measured: 1.02e-7 for wB97X, under 1e-7 for CAM-B3LYP.
 GRADIENT_DF_RSH_TOLERANCE = 5.0e-7
+# Looser than any of the above, and not because the contraction is less exact.
+# Both codes stop their orbital optimisation on a gradient threshold rather than
+# on machine precision -- PySCF at 1e-7 here -- so the wave functions being
+# differentiated differ by about that much before a single integral is touched.
+# Measured agreement on these cases is 2e-7; the bound keeps a little headroom
+# for a machine whose macro-iterations stop a step earlier or later.
+GRADIENT_MCSCF_TOLERANCE = 5.0e-6
 
 #: Functionals whose exchange is split by range. Named here because the
 #: generator has no libxc to ask, and only the tolerance above depends on it.
@@ -1682,6 +1707,68 @@ def _mcscf_starts(mf, mo0, count, seed, ncore, ncas):
         yield f"rotated-{i}", base @ expm(x - x.T)
 
 
+def _best_casscf(mf, mo, mol, nelecas, ncas, basis):
+    """The lowest converged CASSCF over a fixed set of deterministic starts.
+
+    Returns the converged solver as well as its energy, because a gradient has
+    to be taken at the *same* stationary point the energy was reported from --
+    which on these surfaces is not the one a Hartree-Fock guess reaches.
+    """
+    from pyscf import mcscf
+    import numpy as _np
+
+    results = []
+    default_outcome = None   # what the RHF/AVAS guess itself did
+    _nel = int(_np.sum(nelecas)) if _np.ndim(nelecas) else int(nelecas)
+    ncore = (mol.nelectron - _nel) // 2
+    for label, guess in _mcscf_starts(mf, mo, MCSCF_STARTS, MCSCF_SEED,
+                                      ncore, ncas):
+        mc = mcscf.CASSCF(mf, ncas, nelecas)
+        mc.conv_tol = 1e-11
+        mc.conv_tol_grad = 1e-7
+        mc.fcisolver.conv_tol = 1e-12
+        # More macro iterations than the default: a rotated start begins
+        # further from any stationary point than the Hartree-Fock guess,
+        # and running out of iterations is not the same as being trapped.
+        # Same convergence criteria, only more room to reach them.
+        mc.max_cycle_macro = 100
+        mc.verbose = 0
+        converged, energy = False, None
+        try:
+            mc.kernel(guess)
+            converged, energy = bool(mc.converged), float(mc.e_tot)
+        except Exception:
+            pass
+        if label in ("rhf", "avas"):
+            default_outcome = (converged, energy)
+        if converged:
+            results.append((energy, label, mc))
+    if not results:
+        raise SystemExit(
+            f"PySCF MCSCF did not converge for {basis} from any of "
+            f"{MCSCF_STARTS} starts")
+    results.sort(key=lambda r: r[0])
+    best, best_label, best_mc = results[0]
+    spread = results[-1][0] - best
+    print(f"    MCSCF multi-start {basis} CAS({nelecas},{ncas}): "
+          f"{len(results)}/{MCSCF_STARTS} converged, lowest from "
+          f"{best_label}, spread among converged {spread:.2e}")
+    note = None
+    if best_label not in ("rhf", "avas"):
+        # Say what the default guess actually did. Failing to converge and
+        # converging onto something higher are different failures, and the
+        # spread among the converged runs describes neither of them.
+        if default_outcome is None or not default_outcome[0]:
+            did = "does not converge"
+        else:
+            did = f"converges {default_outcome[1] - best:.2e} Hartree higher"
+        note = (
+            f"reference is the lowest of {MCSCF_STARTS} deterministic "
+            f"CASSCF starts ({len(results)} converged). The Hartree-Fock "
+            f"guess {did}; a rotated start reaches this minimum.")
+    return best_mc, best, note
+
+
 def pyscf_mcscf(atoms, basis, nelecas, ncas, optimize=True, avas_labels=None):
     """CASSCF or CASCI, and the active space AVAS picked when labels are given.
 
@@ -1723,57 +1810,7 @@ def pyscf_mcscf(atoms, basis, nelecas, ncas, optimize=True, avas_labels=None):
         # `sort_mo` with explicit indices would be cheaper and equally
         # deterministic, but it needs to know which orbitals the minimum wants,
         # per case and per basis, and that is a table somebody has to maintain.
-        results = []
-        default_outcome = None   # what the RHF/AVAS guess itself did
-        import numpy as _np
-        _nel = int(_np.sum(nelecas)) if _np.ndim(nelecas) else int(nelecas)
-        ncore = (mol.nelectron - _nel) // 2
-        for label, guess in _mcscf_starts(mf, mo, MCSCF_STARTS, MCSCF_SEED,
-                                          ncore, ncas):
-            mc = mcscf.CASSCF(mf, ncas, nelecas)
-            mc.conv_tol = 1e-11
-            mc.conv_tol_grad = 1e-7
-            mc.fcisolver.conv_tol = 1e-12
-            # More macro iterations than the default: a rotated start begins
-            # further from any stationary point than the Hartree-Fock guess,
-            # and running out of iterations is not the same as being trapped.
-            # Same convergence criteria, only more room to reach them.
-            mc.max_cycle_macro = 100
-            mc.verbose = 0
-            converged, energy = False, None
-            try:
-                mc.kernel(guess)
-                converged, energy = bool(mc.converged), float(mc.e_tot)
-            except Exception:
-                pass
-            if label in ("rhf", "avas"):
-                default_outcome = (converged, energy)
-            if converged:
-                results.append((energy, label))
-        if not results:
-            raise SystemExit(
-                f"PySCF MCSCF did not converge for {basis} from any of "
-                f"{MCSCF_STARTS} starts")
-        results.sort()
-        best, best_label = results[0]
-        spread = results[-1][0] - best
-        print(f"    MCSCF multi-start {basis} CAS({nelecas},{ncas}): "
-              f"{len(results)}/{MCSCF_STARTS} converged, lowest from "
-              f"{best_label}, spread among converged {spread:.2e}")
-        mc_energy = best
-        mcscf_note = None
-        if best_label not in ("rhf", "avas"):
-            # Say what the default guess actually did. Failing to converge and
-            # converging onto something higher are different failures, and the
-            # spread among the converged runs describes neither of them.
-            if default_outcome is None or not default_outcome[0]:
-                did = "does not converge"
-            else:
-                did = f"converges {default_outcome[1] - best:.2e} Hartree higher"
-            mcscf_note = (
-                f"reference is the lowest of {MCSCF_STARTS} deterministic "
-                f"CASSCF starts ({len(results)} converged). The Hartree-Fock "
-                f"guess {did}; a rotated start reaches this minimum.")
+        mc, mc_energy, mcscf_note = _best_casscf(mf, mo, mol, nelecas, ncas, basis)
     else:
         mc = mcscf.CASCI(mf, ncas, nelecas)
         mc.fcisolver.conv_tol = 1e-12
@@ -1792,6 +1829,33 @@ def pyscf_mcscf(atoms, basis, nelecas, ncas, optimize=True, avas_labels=None):
     else:
         total = int(sum(nelecas))
     return mc_energy, total, int(ncas), mcscf_note
+
+
+def pyscf_mcscf_gradient(atoms, basis, nelecas, ncas):
+    """CASSCF energy and analytic nuclear gradient, in Hartree/Bohr.
+
+    Taken at the same stationary point the energy is reported from, which is
+    why this goes through the multi-start rather than a Hartree-Fock guess: a
+    gradient compared across two different solutions disagrees for a reason
+    that has nothing to do with the gradient, and on these surfaces the guess
+    decides which solution you get.
+    """
+    from pyscf import gto, scf
+
+    mol = gto.Mole()
+    mol.atom = [(s, (x, y, z)) for s, x, y, z in atoms]
+    mol.unit = "Angstrom"
+    mol.basis = {sym: bse_to_pyscf(basis, sym) for sym in {a[0] for a in atoms}}
+    mol.build()
+    mf = scf.RHF(mol)
+    mf.conv_tol = 1e-12
+    mf.kernel()
+    if not mf.converged:
+        raise SystemExit(f"PySCF RHF did not converge for {basis}")
+
+    mc, energy, note = _best_casscf(mf, None, mol, nelecas, ncas, basis)
+    gradient = mc.nuc_grad_method().kernel()
+    return energy, [list(map(float, row)) for row in gradient], note, mol.nao
 
 
 def pyscf_rhf(atoms, basis, aux="", multiplicity=1):
@@ -2045,6 +2109,41 @@ def main():
         tests.append(entry)
         print(f"{mol.label:6s} {basis:12s} {theory:24s} "
               f"CAS({nelecas_used},{ncas_used}) E={energy:.12f}", flush=True)
+
+    for name, basis, nelecas, ncas in MCSCF_GRADIENT_CASES:
+        mol = multiref_molecule(name)
+        energy, gradient, note, nao = pyscf_mcscf_gradient(
+            mol.atoms, basis, nelecas, ncas)
+        tag = normalize_basis_name(basis) + f"_{nelecas}e{ncas}o"
+        deck = deck_for(f"{CPU_MQC}/mcscf", f"cpu_{name}_{tag}_grad")
+        written.add(str((VALIDATION / deck).relative_to(INPUTS)))
+        if not args.dry_run:
+            d = deck_json(xyz_for(mol), basis, method="casscf")
+            d["keywords"]["mcscf"] = {
+                "n_active_electrons": nelecas,
+                "n_active_orbitals": ncas,
+                "max_macro_iter": 300,
+            }
+            d["driver"] = "Gradient"
+            _write_deck(VALIDATION / deck, json.dumps(d, indent=4) + "\n")
+        entry = {
+            "name": f"CASSCF gradient CAS({nelecas},{ncas}) {mol.label} {basis} (CPU)",
+            "input": deck,
+            "expected_energy": round(energy, 12),
+            "expected_gradient": [[round(c, 12) for c in atom] for atom in gradient],
+            "gradient_tolerance": GRADIENT_MCSCF_TOLERANCE,
+            # Every term is translationally invariant, and this one is built by
+            # a different route from the SCF gradient -- a separable part plus a
+            # cumulant -- so a residual here says the two halves do not add up.
+            "check_translation": True,
+            "type": "unfragmented",
+        }
+        if note:
+            entry["reference_note"] = note
+        tests.append(entry)
+        norm = math.sqrt(sum(c*c for atom in gradient for c in atom))
+        print(f"{mol.label:6s} {basis:12s} CASSCF grad CAS({nelecas},{ncas}) "
+              f"|g|={norm:.10f} E={energy:.12f}", flush=True)
 
     # The quasi-atomic bonding analysis, through the real driver. The energy is
     # the ordinary RHF one and is what the harness checks; what the case is

--- a/validation/inputs/cpu/mqc/mcscf/cpu_n2_cc-pvdz_6e6o_grad.json
+++ b/validation/inputs/cpu/mqc/mcscf/cpu_n2_cc-pvdz_6e6o_grad.json
@@ -1,0 +1,34 @@
+{
+    "schema": {
+        "name": "mqc-frag",
+        "version": "1.0"
+    },
+    "molecules": [
+        {
+            "xyz": "../../../sample_inputs/n2.xyz",
+            "molecular_charge": 0,
+            "molecular_multiplicity": 1
+        }
+    ],
+    "model": {
+        "method": "casscf",
+        "basis": "cc-pvdz"
+    },
+    "keywords": {
+        "scf": {
+            "maxiter": 100,
+            "tolerance": 1e-12
+        },
+        "mcscf": {
+            "n_active_electrons": 6,
+            "n_active_orbitals": 6,
+            "max_macro_iter": 300
+        }
+    },
+    "system": {
+        "logger": {
+            "level": "Verbose"
+        }
+    },
+    "driver": "Gradient"
+}

--- a/validation/inputs/cpu/mqc/mcscf/cpu_water_sto-3g_6e5o_grad.json
+++ b/validation/inputs/cpu/mqc/mcscf/cpu_water_sto-3g_6e5o_grad.json
@@ -1,0 +1,34 @@
+{
+    "schema": {
+        "name": "mqc-frag",
+        "version": "1.0"
+    },
+    "molecules": [
+        {
+            "xyz": "../../../sample_inputs/w1.xyz",
+            "molecular_charge": 0,
+            "molecular_multiplicity": 1
+        }
+    ],
+    "model": {
+        "method": "casscf",
+        "basis": "sto-3g"
+    },
+    "keywords": {
+        "scf": {
+            "maxiter": 100,
+            "tolerance": 1e-12
+        },
+        "mcscf": {
+            "n_active_electrons": 6,
+            "n_active_orbitals": 5,
+            "max_macro_iter": 300
+        }
+    },
+    "system": {
+        "logger": {
+            "level": "Verbose"
+        }
+    },
+    "driver": "Gradient"
+}

--- a/validation/validation_tests_cpu.json
+++ b/validation/validation_tests_cpu.json
@@ -934,6 +934,52 @@
             "type": "unfragmented"
         },
         {
+            "name": "CASSCF gradient CAS(6,5) H2O sto-3g (CPU)",
+            "input": "inputs/cpu/mqc/mcscf/cpu_water_sto-3g_6e5o_grad.json",
+            "expected_energy": -75.010187220994,
+            "expected_gradient": [
+                [
+                    -5.791e-09,
+                    3.8462e-08,
+                    -0.115776195238
+                ],
+                [
+                    7.06e-10,
+                    -0.041182637921,
+                    0.057888104517
+                ],
+                [
+                    5.085e-09,
+                    0.041182599459,
+                    0.057888090722
+                ]
+            ],
+            "gradient_tolerance": 5e-06,
+            "check_translation": true,
+            "type": "unfragmented",
+            "reference_note": "reference is the lowest of 10 deterministic CASSCF starts (3 converged). The Hartree-Fock guess converges 1.67e-03 Hartree higher; a rotated start reaches this minimum."
+        },
+        {
+            "name": "CASSCF gradient CAS(6,6) N2 cc-pvdz (CPU)",
+            "input": "inputs/cpu/mqc/mcscf/cpu_n2_cc-pvdz_6e6o_grad.json",
+            "expected_energy": -109.090025702278,
+            "expected_gradient": [
+                [
+                    -0.0,
+                    -0.0,
+                    0.049954615162
+                ],
+                [
+                    0.0,
+                    0.0,
+                    -0.049954615162
+                ]
+            ],
+            "gradient_tolerance": 5e-06,
+            "check_translation": true,
+            "type": "unfragmented"
+        },
+        {
             "name": "RHF with quasi-atomic bonding analysis H2O 6-31g (CPU)",
             "input": "inputs/cpu/mqc/quao/cpu_water_6-31g_quao.json",
             "expected_energy": -75.984779843967,


### PR DESCRIPTION
Analytic gradients for an optimised MCSCF energy, plus two optimisations to the
differentiated-integral pass they both share with the MP2 gradient.

## The gradient

A converged MCSCF is stationary in both the orbital rotations and the CI
coefficients, so the response terms vanish and the gradient is a contraction of
differentiated integrals against densities already in hand. No Lagrangian and no
response solve — which is why this is shorter than the MP2 gradient next to it.

The two-electron term is split by how many active indices it carries. The AO
two-particle density is `n_ao^4` for every term including the mean-field ones, so
only the active block goes through the general four-index path, built from
`n_active^4` rather than from the basis. The inactive-inactive and
inactive-active blocks are products of one-particle densities and reuse the
closed-shell contraction. The mean-field part is subtracted back out of the
active density or the active-active energy is counted twice — invisible at
`n_active = 0` and wrong everywhere else, which is why the reduction to
Hartree-Fock is a test rather than a remark.

Refused rather than approximated: a CASCI gradient (orbitals came from the SCF
and were never optimised for the active space) and an unconverged CASSCF. Away
from a stationary point the formula returns a plausible vector that is the
derivative of nothing.

## Validation

Three ways, each covering a gap in the others:

- **Against PySCF** `nuc_grad_method`, water/6-31G at CAS(4,4) and CAS(6,5) —
  two splits of inactive and active, both with virtuals. Energies to 1e-12,
  gradients to 1e-7.
- **Central differences against this program's own energy**, which the PySCF
  comparison cannot do: it needs both codes at the *same* stationary point, and
  on water/STO-3G they disagree — this optimiser finds a point 1.7 mHartree
  below the one PySCF settles on from HF orbitals. All nine components are
  differenced, not one, and a step study shows the residual falling by four
  each time `h` halves, four times running. That is the central-difference
  truncation signature and nothing else, so the tolerance is a property of `h`
  rather than of the contraction.
- **Against the closed-shell gradient with the active space emptied**, isolating
  the part shared with Hartree-Fock.

Driver-level cases are water/STO-3G (no virtuals at all — inactive-active blocks
alone) and N2/cc-pVDZ (eighteen virtuals). Bound is 5e-6, looser than any other
gradient here and not because the contraction is less exact: both codes stop
orbital optimisation on a gradient threshold, so the wave functions differ by
about that much before an integral is touched. Measured agreement is 2.0e-7 and
3.2e-8. Translation invariance, which this gradient builds by a route the SCF one
does not, is checked tightly instead: 1e-15 and 1e-14.

Water/6-31G is deliberately absent from the validation decks — PySCF reports
`converged = False` from all ten starts, and a reference from a run that did not
converge is not a reference. It stays in the unit tests at a stated 1e-6.

An ORMAS gradient works with no new code (the expression only asks for `dm1` and
`dm2`), and there is a test saying so rather than an assumption that it should.

## Two optimisations to the shared pass

Both change no computed value, and both help the MP2 gradient too.

- **Collapse the quartet loop.** `two_electron_mp2_terms` threaded over a range
  that is a *block* — however much of the first index the caller could afford —
  so the schedule's trip count was set by a memory budget rather than by the
  machine. At 500 MB the MP2 gradient gets nine functions per block by
  `n_ao = 150`, three by 200, one by 300: its dominant loop goes serial exactly
  when the system is big enough for that to matter. Collapsing with `jsh`
  removes the dependence. Ethane/cc-pVTZ: 39.7 s → 7.1 s on eight threads, at
  the same block size.
- **Transform the two-particle density without four reshapes.** The arithmetic is
  a tenth of a second; moving the last `np n_ao^3` intermediate in and out of
  shape twice per block was 2.8 s of a 16 s gradient. Contracting the first
  index each time lets the result arrive already ordered. 2.8 s → 0.32 s.
