### PR TITLE
Build HDF5 in CI, which nothing here was doing

### DIFF
--- a/.github/workflows/local_conda_env.yml
+++ b/.github/workflows/local_conda_env.yml
@@ -35,6 +35,10 @@ jobs:
             # value is here only so the validation steps below gate correctly;
             # the build itself passes no flags at all.
             libfint: true
+            # HDF5 is off by default, and this is where that is asserted: if
+            # the default flips, this job stops matching what `cmake -B build`
+            # produces and the mismatch shows up here rather than nowhere.
+            hdf5: false
           # tblite built without libxc or the integrals backend -- a reduced
           # build, and only a build. The xTB validation is not run here: it
           # touches neither libxc nor the integrals, so on modern MPI it would
@@ -79,6 +83,19 @@ jobs:
             legacy_mpi: false
             libcint: true
             libxc: true
+          # HDF5, which until this job existed was built by nothing in CI: the
+          # hand-written C bindings and the checkpoint backend are ~1200 lines
+          # that no workflow had ever compiled, and the option defaults to off
+          # so no other job reaches them. Nothing else is turned on -- the
+          # checkpoint does not depend on a backend, and what is under test is
+          # that the bindings still link against whatever HDF5 conda resolves
+          # to. `addtest(mqc_hdf5_checkpoint)` is registered only under this
+          # option, so the unit-test step below picks it up without a step of
+          # its own.
+          - name: "with hdf5"
+            tblite: false
+            legacy_mpi: false
+            hdf5: true
           # The Python interface needs every backend in one library. backends.py
           # covers standalone and fragmented, xTB and Hartree-Fock -- three of
           # those four paths can break without the others noticing -- and
@@ -119,6 +136,7 @@ jobs:
                   -DMQC_ENABLE_LIBXC=${{ matrix.libxc && 'ON' || 'OFF' }} \
                   -DMQC_ENABLE_LIBCINT=${{ matrix.libcint && 'ON' || 'OFF' }} \
                   -DMQC_USE_LIBFINT=${{ matrix.backend == 'libcint' && 'OFF' || 'ON' }} \
+                  -DMQC_ENABLE_HDF5=${{ matrix.hdf5 && 'ON' || 'OFF' }} \
                   -B build
           fi
           cmake --build build --parallel 2

--- a/.github/workflows/local_conda_env.yml
+++ b/.github/workflows/local_conda_env.yml
@@ -141,6 +141,17 @@ jobs:
           fi
           cmake --build build --parallel 2
 
+      # Printed rather than assumed. h5py links the same libhdf5 the Fortran
+      # writes with, so its version bounds get a vote on what conda resolves;
+      # if that ever pins HDF5 back, this is the line that says so.
+      - name: Report the HDF5 in use
+        if: matrix.hdf5
+        shell: bash -el {0}
+        run: |
+          conda activate mqc
+          conda list -n mqc "hdf5|h5py"
+          python3 -c "import h5py; print('h5py', h5py.__version__, 'links HDF5', h5py.version.hdf5_version)"
+
       - name: Run unit tests
         shell: bash -el {0}
         run: |

--- a/environment.yml
+++ b/environment.yml
@@ -11,6 +11,18 @@ dependencies:
   # was `int` before that), and every symbol the bindings name is still
   # exported by 2.0, so whatever conda-forge resolves to is in range.
   - hdf5
+  # Test-only, and it never enters the built program: mqc links the HDF5 C
+  # library and nothing else. What h5py buys is the one check the Fortran
+  # suite structurally cannot make -- that a block written from Fortran is
+  # readable *as the right tensor* by something that is not Fortran. A round
+  # trip through our own bindings is exact even when the declared shape is
+  # wrong, so only an outside reader can see it.
+  #
+  # Note it links the same conda `hdf5` above rather than bundling its own,
+  # which is what makes the check meaningful and also gives h5py's version
+  # bounds a vote on which HDF5 gets resolved. The CI step below prints what
+  # was chosen so a lagging h5py holding that back is visible, not silent.
+  - h5py
   #- gfortran=14.2.0
   - cmake
   - ninja

--- a/environment.yml
+++ b/environment.yml
@@ -5,6 +5,12 @@ dependencies:
   - python=3.12
   - openblas
   - openmpi
+  # The C library only. mqc binds the HDF5 C entry points by hand rather than
+  # using hdf5.mod, so nothing here has to match the Fortran compiler.
+  # Unpinned deliberately: h5_start enforces a 1.10 floor at run time (hid_t
+  # was `int` before that), and every symbol the bindings name is still
+  # exported by 2.0, so whatever conda-forge resolves to is in range.
+  - hdf5
   #- gfortran=14.2.0
   - cmake
   - ninja


### PR DESCRIPTION
`MQC_ENABLE_HDF5` appeared in no workflow. It defaults to OFF, so no job ever
reached it: `backends/hdf5/mqc_hdf5_bindings.f90` and `mqc_hdf5_checkpoint.f90`
— about 1200 lines, including a hand-written binding for every HDF5 C entry
point this program uses — had never been compiled by CI, let alone run.
`test/CMakeLists.txt` registers `addtest(mqc_hdf5_checkpoint)` under the same
option, so that test had never run either.

The new `with hdf5` job needs no step of its own: the test is named
`mqc_hdf5_checkpoint` and the existing `ctest -R "mqc"` picks it up. Nothing else
is enabled in that job — the checkpoint depends on no backend, and what is under
test is that the bindings still link.

`hdf5` goes into `environment.yml` unpinned. The C library is all that is needed,
since the bindings are hand-written rather than going through `hdf5.mod`, so
nothing has to match the Fortran compiler. Unpinned is safe in both directions:
`h5_start` enforces a 1.10 floor at run time because `hid_t` was `int` before
that, and all 37 symbols the bindings name are still exported by 2.0.0.

`h5py` comes in alongside it, test-only. There is a class of bug the Fortran
suite cannot see by construction: a block whose bytes are right and whose
declared shape is wrong. HDF5 declares extents in C order and Fortran's leftmost
index varies fastest, so writing `shape()` straight through produces a file that
round-trips through our own bindings exactly and is a different tensor to every
other reader. Only something that is not Fortran can tell the difference. It
links the conda `hdf5` rather than bundling its own, unlike the pip build — the
reader and the writer being the same library is what makes the check meaningful.
The new step prints the resolved version, so a lagging h5py holding the library
back is a line in the log rather than a discovery later.

The option stays OFF by default; the `default build (no flags)` job now carries
`hdf5: false` so that is asserted rather than assumed.

`feat/cc-amplitude-store` is stacked on this branch and is the reason it exists
separately.
