### PR TITLE
Store coupled-cluster amplitudes in HDF5, so a killed run can resume

### DIFF
--- a/.github/workflows/local_conda_env.yml
+++ b/.github/workflows/local_conda_env.yml
@@ -207,6 +207,22 @@ jobs:
           conda list -n mqc "hdf5|h5py"
           python3 -c "import h5py; print('h5py', h5py.__version__, 'links HDF5', h5py.version.hdf5_version)"
 
+      # The one check the Fortran suite cannot make. A block written under the
+      # wrong declared shape holds the right bytes and round trips through our
+      # own bindings exactly, so every Fortran assertion passes and the file is
+      # a different tensor to h5py, h5dump and anything else. Being readable by
+      # something that is not Fortran is the whole reason this data is in HDF5,
+      # so it is checked by something that is not Fortran.
+      - name: Check the amplitude file's on-disk layout
+        if: matrix.hdf5
+        shell: bash -el {0}
+        run: |
+          conda activate mqc
+          cmake --build build --target check_amplitude_layout --parallel 2
+          cd validation
+          ../build/check_amplitude_layout
+          python3 check_amplitude_layout.py
+
       - name: Run unit tests
         shell: bash -el {0}
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -663,6 +663,14 @@ if(MQC_ENABLE_HDF5)
   add_executable(check_hdf5 ${PROJECT_SOURCE_DIR}/validation/check_hdf5.f90)
   target_include_directories(check_hdf5 PRIVATE "${CMAKE_BINARY_DIR}/modules")
   target_link_libraries(check_hdf5 PRIVATE ${main_lib})
+  # Writes the file that validation/check_amplitude_layout.py reads. Split in
+  # two because the check cannot be made from Fortran: a block stored under the
+  # wrong declared shape round trips through our own bindings exactly.
+  add_executable(check_amplitude_layout
+                 ${PROJECT_SOURCE_DIR}/validation/check_amplitude_layout.f90)
+  target_include_directories(check_amplitude_layout
+                             PRIVATE "${CMAKE_BINARY_DIR}/modules")
+  target_link_libraries(check_amplitude_layout PRIVATE ${main_lib})
 
 endif()
 
@@ -939,6 +947,7 @@ foreach(
         bench_mp2_gradient
         bench_ri_mp2_gradient
         bench_scf_gradient
+        check_amplitude_layout
         check_ao
         check_ao_deriv2
         check_bcast

--- a/backends/hdf5/CMakeLists.txt
+++ b/backends/hdf5/CMakeLists.txt
@@ -15,4 +15,5 @@
 #
 # Pulled in by the top-level CMakeLists when MQC_ENABLE_HDF5 is ON.
 target_sources(${main_lib} PRIVATE mqc_hdf5_bindings.f90
-                                   mqc_hdf5_checkpoint.f90)
+                                   mqc_hdf5_checkpoint.f90
+                                   mqc_hdf5_amplitudes.f90)

--- a/backends/hdf5/CMakeLists.txt
+++ b/backends/hdf5/CMakeLists.txt
@@ -14,6 +14,6 @@
 # to say it fails in Python rather than in CMake.
 #
 # Pulled in by the top-level CMakeLists when MQC_ENABLE_HDF5 is ON.
-target_sources(${main_lib} PRIVATE mqc_hdf5_bindings.f90
-                                   mqc_hdf5_checkpoint.f90
-                                   mqc_hdf5_amplitudes.f90)
+target_sources(
+  ${main_lib} PRIVATE mqc_hdf5_bindings.f90 mqc_hdf5_checkpoint.f90
+                      mqc_hdf5_amplitudes.f90)

--- a/backends/hdf5/mqc_hdf5_amplitudes.f90
+++ b/backends/hdf5/mqc_hdf5_amplitudes.f90
@@ -1,0 +1,490 @@
+!! HDF5 store for coupled-cluster amplitudes, so a killed run can resume
+module mqc_hdf5_amplitudes
+   !! A small number of large fixed-shape arrays, overwritten in place --
+   !! which is the opposite of what `mqc_hdf5_checkpoint` next door does, and
+   !! the reason this is a separate module rather than four more procedures on
+   !! that type. That one appends a record per fragment and is keyed by a
+   !! monomer tuple; this one holds `t1`, `t2`, `l1` and `l2` for a single
+   !! calculation and rewrites them every macro-iteration. Sharing a type
+   !! would mean an append-only contract that neither honours.
+   !!
+   !! **Why the T amplitudes are stored and not only Lambda.** The Lambda
+   !! equations are built from `t1` and `t2` at every iteration -- every
+   !! intermediate in `lambda_intermediates` takes them as input. A file with
+   !! `l1` and `l2` alone cannot restart anything: the resumed run would have
+   !! to solve CCSD again to rebuild what it needs to use them, at which point
+   !! it may as well have solved Lambda too. The pair travels together or it
+   !! is not a restart.
+   !!
+   !! **A kill must not be able to produce a plausible file.** The failure that
+   !! matters here is not a crash, it is a resumed run that converges smoothly
+   !! to the wrong number because `l2` was half-written when the job died. The
+   !! guard is the same trick `mqc_hdf5_checkpoint` uses for `n_valid` and it
+   !! is worth stating in full: `complete` is an attribute that starts at zero,
+   !! every array is written, the file is flushed, and only then does
+   !! `complete` become one. A reader that finds zero treats the file as if it
+   !! held nothing. So the window a kill can lose is one macro-iteration, and
+   !! what it loses is always the whole iteration rather than part of an array.
+   !!
+   !! **The fingerprint is a refusal, not a hint.** Amplitudes belong to a
+   !! geometry, a basis, a frozen-core choice and an orbital count. Loading a
+   !! set that belongs to a different calculation gives iterations that
+   !! converge -- to a stationary point of the wrong equations. A mismatch
+   !! therefore stops the run rather than starting fresh, because starting
+   !! fresh silently is how a restart flag turns into hours of wasted compute
+   !! nobody notices.
+   use, intrinsic :: iso_c_binding, only: c_loc, c_char, c_size_t
+   use pic_types, only: dp
+   use mqc_error, only: error_t, ERROR_IO, ERROR_VALIDATION
+   use mqc_hdf5_bindings, only: hid_t, hsize_t, herr_t, h5_start, c_string, &
+                                H5F_ACC_TRUNC, H5F_ACC_RDWR, H5P_DEFAULT, H5S_ALL, &
+                                H5F_SCOPE_LOCAL, H5T_NATIVE_DOUBLE, H5T_NATIVE_INT, &
+                                H5T_STD_I32LE, H5T_C_S1, &
+                                H5Fcreate, H5Fopen, H5Fclose, H5Fflush, &
+                                H5Screate, H5Screate_simple, H5Sclose, &
+                                H5Sget_simple_extent_dims, H5Sget_simple_extent_ndims, &
+                                H5Dcreate2, H5Dopen2, H5Dclose, H5Dwrite, H5Dread, &
+                                H5Dget_space, H5Lexists, &
+                                H5Acreate2, H5Aopen, H5Awrite, H5Aread, H5Aclose, H5Aexists, &
+                                H5Tcopy, H5Tset_size, H5Tclose
+   implicit none
+   private
+
+   public :: hdf5_amplitudes_t
+   public :: hdf5_amplitudes_available
+
+   integer, parameter :: FP_LEN = 17   !! 16 hex digits and a terminator
+
+   type :: hdf5_amplitudes_t
+      !! An open amplitude file, and what a resumed run needs to know about it
+      logical :: active = .false.
+      logical :: resumable = .false.
+         !! A complete set was found and the fingerprint matched. False on a
+         !! new file and false on one whose last write was interrupted; a
+         !! caller reads this to decide between resuming and starting from the
+         !! MP2 guess, and never has to ask why.
+      integer :: iteration = 0
+      real(dp) :: energy = 0.0_dp
+      integer(hid_t) :: file = -1
+   contains
+      procedure :: open => amp_open
+      procedure, private :: put_2d => amp_put_2d
+      procedure, private :: put_4d => amp_put_4d
+      generic :: put => put_2d, put_4d
+      procedure, private :: get_2d => amp_get_2d
+      procedure, private :: get_4d => amp_get_4d
+      generic :: get => get_2d, get_4d
+      procedure :: commit => amp_commit
+      procedure :: close => amp_close
+   end type hdf5_amplitudes_t
+
+contains
+
+   pure function hdf5_amplitudes_available() result(available)
+      !! Whether this build can store amplitudes
+      logical :: available
+      available = .true.
+   end function hdf5_amplitudes_available
+
+   subroutine amp_open(this, path, fingerprint, error)
+      !! Open `path`, creating it if absent and validating it if not
+      class(hdf5_amplitudes_t), intent(inout) :: this
+      character(len=*), intent(in) :: path
+      character(len=*), intent(in) :: fingerprint
+      type(error_t), intent(inout) :: error
+
+      logical :: exists
+      character(len=FP_LEN) :: stored
+      integer :: complete
+
+      this%active = .false.
+      this%resumable = .false.
+      this%iteration = 0
+      this%energy = 0.0_dp
+
+      if (.not. h5_start()) then
+         call error%set(ERROR_IO, "the HDF5 library would not initialise, so "// &
+                        trim(path)//" cannot be used for amplitudes")
+         return
+      end if
+
+      inquire (file=path, exist=exists)
+      if (exists) then
+         this%file = H5Fopen(c_string(path), H5F_ACC_RDWR, H5P_DEFAULT)
+         if (this%file < 0) then
+            call error%set(ERROR_IO, trim(path)//" exists but is not a readable HDF5 file")
+            return
+         end if
+
+         call read_string_attr(this%file, "fingerprint", stored)
+         if (trim(stored) /= trim(fingerprint)) then
+            call error%set(ERROR_VALIDATION, "amplitude file "//trim(path)//" was written "// &
+                           "by a different calculation (fingerprint "//trim(stored)// &
+                           ", this run is "//trim(fingerprint)//"). Its amplitudes solve "// &
+                           "another geometry, basis or frozen-core choice; resuming from "// &
+                           "them would converge to a stationary point of the wrong "// &
+                           "equations. Delete it, or point the run at another file.")
+            return
+         end if
+
+         ! Zero means the last run was killed while writing. Whatever is in
+         ! the datasets may be a complete iteration or half of one, and there
+         ! is no way to tell from here -- so it is worth nothing either way.
+         call read_int_attr(this%file, "complete", complete)
+         if (complete == 1) then
+            this%resumable = .true.
+            call read_int_attr(this%file, "iteration", this%iteration)
+            call read_double_attr(this%file, "energy", this%energy)
+         end if
+      else
+         this%file = H5Fcreate(c_string(path), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT)
+         if (this%file < 0) then
+            call error%set(ERROR_IO, "could not create amplitude file "//trim(path))
+            return
+         end if
+         call write_string_attr(this%file, "fingerprint", fingerprint)
+         call write_int_attr(this%file, "complete", 0)
+      end if
+
+      this%active = .true.
+   end subroutine amp_open
+
+   subroutine amp_put_2d(this, name, values)
+      !! Store a rank-2 amplitude block, overwriting any previous one
+      class(hdf5_amplitudes_t), intent(inout) :: this
+      character(len=*), intent(in) :: name
+      real(dp), intent(in), contiguous, target :: values(:, :)
+
+      integer(hsize_t) :: dims(2)
+
+      if (.not. this%active) return
+      dims = int(shape(values), hsize_t)
+      call put_block(this, name, 2, dims, c_loc(values))
+   end subroutine amp_put_2d
+
+   subroutine amp_put_4d(this, name, values)
+      !! Store a rank-4 amplitude block, overwriting any previous one
+      class(hdf5_amplitudes_t), intent(inout) :: this
+      character(len=*), intent(in) :: name
+      real(dp), intent(in), contiguous, target :: values(:, :, :, :)
+
+      integer(hsize_t) :: dims(4)
+
+      if (.not. this%active) return
+      dims = int(shape(values), hsize_t)
+      call put_block(this, name, 4, dims, c_loc(values))
+   end subroutine amp_put_4d
+
+   subroutine put_block(this, name, rank, dims, buffer)
+      !! The shared body: create on first write, reopen and overwrite after
+      !!
+      !! `complete` drops to zero here rather than in `commit`, and that
+      !! ordering is the whole guarantee. From the first byte of the first
+      !! array until the flush in `commit` succeeds, the file advertises
+      !! itself as unusable; a kill anywhere in that window leaves a reader
+      !! that declines rather than one that believes half an array.
+      use, intrinsic :: iso_c_binding, only: c_ptr
+      type(hdf5_amplitudes_t), intent(inout) :: this
+      character(len=*), intent(in) :: name
+      integer, intent(in) :: rank
+      integer(hsize_t), intent(in) :: dims(:)
+      type(c_ptr), intent(in) :: buffer
+
+      integer(hid_t) :: space, dset
+      integer(hsize_t) :: file_dims(size(dims))
+      integer(herr_t) :: ignored
+
+      call write_int_attr(this%file, "complete", 0)
+
+      ! The extents are reversed on the way in, and this is not cosmetic.
+      ! HDF5 declares a dataset in C order -- first extent slowest-varying --
+      ! while Fortran's leftmost index is the fastest. Writing `shape(values)`
+      ! straight through stores the right bytes under the wrong declared
+      ! shape: `t1(3,5)` becomes a 3x5 dataset whose rows interleave the two
+      ! indices, so the round trip through this module is exact and every
+      ! other reader in existence gets nonsense. Reversed, the dataset is 5x3
+      ! and `t1_h5[a, i] == t1(i, a)` in h5py, h5dump and anything else --
+      ! which is the entire reason for storing this in HDF5 rather than in a
+      ! stream of unformatted records. HDF5's own Fortran API reverses here
+      ! too, for exactly this reason.
+      file_dims = dims(rank:1:-1)
+
+      if (H5Lexists(this%file, c_string(name), H5P_DEFAULT) > 0) then
+         dset = H5Dopen2(this%file, c_string(name), H5P_DEFAULT)
+      else
+         space = H5Screate_simple(rank, file_dims, file_dims)
+         dset = H5Dcreate2(this%file, c_string(name), H5T_NATIVE_DOUBLE, space, &
+                           H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT)
+         ignored = H5Sclose(space)
+      end if
+      if (dset < 0) return
+
+      ignored = H5Dwrite(dset, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, buffer)
+      ignored = H5Dclose(dset)
+   end subroutine put_block
+
+   subroutine amp_get_2d(this, name, values, error)
+      !! Read a rank-2 block back, allocated to the shape the file records
+      class(hdf5_amplitudes_t), intent(in) :: this
+      character(len=*), intent(in) :: name
+      real(dp), allocatable, intent(out), target :: values(:, :)
+      type(error_t), intent(inout) :: error
+
+      integer(hsize_t) :: dims(2)
+      integer(hid_t) :: dset
+
+      call open_block(this, name, 2, dims, dset, error)
+      if (error%has_error() .or. dset < 0) return
+      allocate (values(dims(1), dims(2)))
+      call read_block(dset, c_loc(values))
+   end subroutine amp_get_2d
+
+   subroutine amp_get_4d(this, name, values, error)
+      !! Read a rank-4 block back, allocated to the shape the file records
+      class(hdf5_amplitudes_t), intent(in) :: this
+      character(len=*), intent(in) :: name
+      real(dp), allocatable, intent(out), target :: values(:, :, :, :)
+      type(error_t), intent(inout) :: error
+
+      integer(hsize_t) :: dims(4)
+      integer(hid_t) :: dset
+
+      call open_block(this, name, 4, dims, dset, error)
+      if (error%has_error() .or. dset < 0) return
+      allocate (values(dims(1), dims(2), dims(3), dims(4)))
+      call read_block(dset, c_loc(values))
+   end subroutine amp_get_4d
+
+   subroutine open_block(this, name, want_rank, dims, dset, error)
+      !! Locate a block and report its shape, refusing one of the wrong rank
+      !!
+      !! The rank check is not defensive clutter. `l1` and `l2` are written by
+      !! name, and a caller that asks for one and is handed the other would
+      !! otherwise get an allocation of the right total size and the wrong
+      !! meaning -- the same class of bug as a fragment reading its
+      !! neighbour's gradient, and just as quiet.
+      class(hdf5_amplitudes_t), intent(in) :: this
+      character(len=*), intent(in) :: name
+      integer, intent(in) :: want_rank
+      integer(hsize_t), intent(out) :: dims(:)
+      integer(hid_t), intent(out) :: dset
+      type(error_t), intent(inout) :: error
+
+      integer(hid_t) :: space
+      integer(hsize_t) :: file_dims(size(dims)), maxdims(size(dims))
+      integer :: rank
+      integer(herr_t) :: ignored
+
+      dset = -1
+      dims = 0
+
+      if (.not. this%active) then
+         call error%set(ERROR_IO, "no amplitude file is open, so "//trim(name)// &
+                        " cannot be read")
+         return
+      end if
+
+      if (H5Lexists(this%file, c_string(name), H5P_DEFAULT) <= 0) then
+         call error%set(ERROR_VALIDATION, "the amplitude file holds no block named "// &
+                        trim(name))
+         return
+      end if
+
+      dset = H5Dopen2(this%file, c_string(name), H5P_DEFAULT)
+      if (dset < 0) then
+         call error%set(ERROR_IO, "could not open the amplitude block "//trim(name))
+         return
+      end if
+
+      space = H5Dget_space(dset)
+      rank = int(H5Sget_simple_extent_ndims(space))
+      if (rank /= want_rank) then
+         ignored = H5Sclose(space)
+         ignored = H5Dclose(dset)
+         dset = -1
+         call error%set(ERROR_VALIDATION, "the amplitude block "//trim(name)//" is stored "// &
+                        "with a rank this reader did not ask for; the file was written by "// &
+                        "a different version of this program.")
+         return
+      end if
+      ! Reversed back, to undo the C-order declaration made on write.
+      ignored = H5Sget_simple_extent_dims(space, file_dims, maxdims)
+      dims = file_dims(rank:1:-1)
+      ignored = H5Sclose(space)
+   end subroutine open_block
+
+   subroutine read_block(dset, buffer)
+      use, intrinsic :: iso_c_binding, only: c_ptr
+      integer(hid_t), intent(in) :: dset
+      type(c_ptr), intent(in) :: buffer
+
+      integer(herr_t) :: ignored
+
+      ignored = H5Dread(dset, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, buffer)
+      ignored = H5Dclose(dset)
+   end subroutine read_block
+
+   subroutine amp_commit(this, iteration, energy)
+      !! Declare everything written since the last commit to be a usable set
+      !!
+      !! The flush has to land before `complete` is raised, and they cannot be
+      !! reordered by anything: a `complete` that reaches the disk ahead of
+      !! the arrays it describes is exactly the file this design exists to
+      !! prevent.
+      class(hdf5_amplitudes_t), intent(inout) :: this
+      integer, intent(in) :: iteration
+      real(dp), intent(in) :: energy
+
+      integer(herr_t) :: ignored
+
+      if (.not. this%active) return
+
+      ignored = H5Fflush(this%file, H5F_SCOPE_LOCAL)
+      call write_int_attr(this%file, "iteration", iteration)
+      call write_double_attr(this%file, "energy", energy)
+      call write_int_attr(this%file, "complete", 1)
+      ignored = H5Fflush(this%file, H5F_SCOPE_LOCAL)
+
+      this%iteration = iteration
+      this%energy = energy
+      this%resumable = .true.
+   end subroutine amp_commit
+
+   subroutine amp_close(this)
+      class(hdf5_amplitudes_t), intent(inout) :: this
+      integer(herr_t) :: ignored
+
+      if (this%file >= 0) ignored = H5Fclose(this%file)
+      this%file = -1
+      this%active = .false.
+   end subroutine amp_close
+
+   ! -- attributes ----------------------------------------------------------
+   ! Scalars live as attributes rather than one-element datasets: HDF5 keeps
+   ! them in the object header, so reading `complete` on open costs no seek
+   ! into the data, which is the whole point of checking it first.
+
+   subroutine write_int_attr(file, name, value)
+      integer(hid_t), intent(in) :: file
+      character(len=*), intent(in) :: name
+      integer, intent(in) :: value
+
+      integer(hid_t) :: space, attr
+      integer, target :: buffer(1)
+      integer(herr_t) :: ignored
+
+      buffer(1) = value
+      if (H5Aexists(file, c_string(name)) > 0) then
+         attr = H5Aopen(file, c_string(name), H5P_DEFAULT)
+      else
+         space = H5Screate(0)
+         attr = H5Acreate2(file, c_string(name), H5T_STD_I32LE, space, &
+                           H5P_DEFAULT, H5P_DEFAULT)
+         ignored = H5Sclose(space)
+      end if
+      ignored = H5Awrite(attr, H5T_NATIVE_INT, c_loc(buffer))
+      ignored = H5Aclose(attr)
+   end subroutine write_int_attr
+
+   subroutine read_int_attr(file, name, value)
+      integer(hid_t), intent(in) :: file
+      character(len=*), intent(in) :: name
+      integer, intent(out) :: value
+
+      integer(hid_t) :: attr
+      integer, target :: buffer(1)
+      integer(herr_t) :: ignored
+
+      value = 0
+      if (H5Aexists(file, c_string(name)) <= 0) return
+      attr = H5Aopen(file, c_string(name), H5P_DEFAULT)
+      buffer(1) = 0
+      ignored = H5Aread(attr, H5T_NATIVE_INT, c_loc(buffer))
+      ignored = H5Aclose(attr)
+      value = buffer(1)
+   end subroutine read_int_attr
+
+   subroutine write_double_attr(file, name, value)
+      integer(hid_t), intent(in) :: file
+      character(len=*), intent(in) :: name
+      real(dp), intent(in) :: value
+
+      integer(hid_t) :: space, attr
+      real(dp), target :: buffer(1)
+      integer(herr_t) :: ignored
+
+      buffer(1) = value
+      if (H5Aexists(file, c_string(name)) > 0) then
+         attr = H5Aopen(file, c_string(name), H5P_DEFAULT)
+      else
+         space = H5Screate(0)
+         attr = H5Acreate2(file, c_string(name), H5T_NATIVE_DOUBLE, space, &
+                           H5P_DEFAULT, H5P_DEFAULT)
+         ignored = H5Sclose(space)
+      end if
+      ignored = H5Awrite(attr, H5T_NATIVE_DOUBLE, c_loc(buffer))
+      ignored = H5Aclose(attr)
+   end subroutine write_double_attr
+
+   subroutine read_double_attr(file, name, value)
+      integer(hid_t), intent(in) :: file
+      character(len=*), intent(in) :: name
+      real(dp), intent(out) :: value
+
+      integer(hid_t) :: attr
+      real(dp), target :: buffer(1)
+      integer(herr_t) :: ignored
+
+      value = 0.0_dp
+      if (H5Aexists(file, c_string(name)) <= 0) return
+      attr = H5Aopen(file, c_string(name), H5P_DEFAULT)
+      buffer(1) = 0.0_dp
+      ignored = H5Aread(attr, H5T_NATIVE_DOUBLE, c_loc(buffer))
+      ignored = H5Aclose(attr)
+      value = buffer(1)
+   end subroutine read_double_attr
+
+   subroutine write_string_attr(file, name, text)
+      integer(hid_t), intent(in) :: file
+      character(len=*), intent(in) :: name, text
+
+      integer(hid_t) :: space, atype, attr
+      character(kind=c_char), target :: buffer(FP_LEN)
+      integer(herr_t) :: ignored
+
+      buffer = c_string(text)
+      atype = H5Tcopy(H5T_C_S1)
+      ignored = H5Tset_size(atype, int(FP_LEN, c_size_t))
+      space = H5Screate(0)
+      attr = H5Acreate2(file, c_string(name), atype, space, H5P_DEFAULT, H5P_DEFAULT)
+      ignored = H5Awrite(attr, atype, c_loc(buffer))
+      ignored = H5Aclose(attr)
+      ignored = H5Sclose(space)
+      ignored = H5Tclose(atype)
+   end subroutine write_string_attr
+
+   subroutine read_string_attr(file, name, text)
+      integer(hid_t), intent(in) :: file
+      character(len=*), intent(in) :: name
+      character(len=*), intent(out) :: text
+
+      integer(hid_t) :: atype, attr
+      character(kind=c_char), target :: buffer(FP_LEN)
+      integer(herr_t) :: ignored
+      integer :: i
+
+      text = ""
+      if (H5Aexists(file, c_string(name)) <= 0) return
+      atype = H5Tcopy(H5T_C_S1)
+      ignored = H5Tset_size(atype, int(FP_LEN, c_size_t))
+      attr = H5Aopen(file, c_string(name), H5P_DEFAULT)
+      ignored = H5Aread(attr, atype, c_loc(buffer))
+      ignored = H5Aclose(attr)
+      ignored = H5Tclose(atype)
+      do i = 1, min(FP_LEN - 1, len(text))
+         if (iachar(buffer(i)) == 0) exit
+         text(i:i) = buffer(i)
+      end do
+   end subroutine read_string_attr
+
+end module mqc_hdf5_amplitudes

--- a/backends/hdf5/mqc_hdf5_bindings.f90
+++ b/backends/hdf5/mqc_hdf5_bindings.f90
@@ -35,6 +35,7 @@ module mqc_hdf5_bindings
              H5Dclose, H5Dcreate2, H5Dget_space, H5Dopen2, H5Dread, H5Dset_extent, H5Dwrite, &
              H5Fclose, H5Fcreate, H5Fflush, H5Fopen, H5Lexists, H5Pclose, H5Pcreate, &
              H5Pset_chunk, H5Sclose, H5Screate, H5Screate_simple, H5Sselect_hyperslab, &
+             H5Sget_simple_extent_dims, H5Sget_simple_extent_ndims, &
              H5Tclose, H5Tcopy, H5Tset_size, H5open
 
    !> Assumed-size dummies below are allowed deliberately and individually.
@@ -161,6 +162,30 @@ module mqc_hdf5_bindings
          integer(hid_t), value :: space
          integer(herr_t) :: status
       end function H5Sclose
+
+      !> Shape of a stored dataset, so a reader can allocate before it reads.
+      !  `maxdims` is a real array rather than an optional C null: nothing here
+      !  needs the unlimited bounds, and a dummy array costs one stack slot
+      !  against a c_ptr dance at every call site.
+      function H5Sget_simple_extent_ndims(space) result(rank) &
+         bind(C, name="H5Sget_simple_extent_ndims")
+         import :: hid_t, c_int
+         implicit none
+         integer(hid_t), value :: space
+         integer(c_int) :: rank
+      end function H5Sget_simple_extent_ndims
+
+      function H5Sget_simple_extent_dims(space, dims, maxdims) result(rank) &
+         bind(C, name="H5Sget_simple_extent_dims")
+         import :: hid_t, hsize_t, c_int
+         implicit none
+         integer(hid_t), value :: space
+         ! allow(assumed-size)
+         integer(hsize_t), intent(out) :: dims(*)
+         ! allow(assumed-size)
+         integer(hsize_t), intent(out) :: maxdims(*)
+         integer(c_int) :: rank
+      end function H5Sget_simple_extent_dims
 
       function H5Sselect_hyperslab(space, op, start, stride, count, block) result(status) &
          bind(C, name="H5Sselect_hyperslab")

--- a/src/io/CMakeLists.txt
+++ b/src/io/CMakeLists.txt
@@ -16,5 +16,6 @@ target_sources(
 # both here is a hard error there whatever CMake is told. Only one of the two is
 # ever compiled, the same arrangement as mqc_cuest_bridge_stub.
 if(NOT MQC_ENABLE_HDF5)
-  target_sources(${main_lib} PRIVATE mqc_hdf5_checkpoint_stub.f90)
+  target_sources(${main_lib} PRIVATE mqc_hdf5_checkpoint_stub.f90
+                                     mqc_hdf5_amplitudes_stub.f90)
 endif()

--- a/src/io/mqc_hdf5_amplitudes_stub.f90
+++ b/src/io/mqc_hdf5_amplitudes_stub.f90
@@ -1,0 +1,117 @@
+!! Stand-in for the amplitude store when the build has no HDF5
+module mqc_hdf5_amplitudes
+   !! Same name, same type, same procedures as the real backend, and every one
+   !! of them declines.
+   !!
+   !! A stub rather than a preprocessor conditional at each call site, matching
+   !! `mqc_hdf5_checkpoint_stub` beside it: the coupled-cluster code reads the
+   !! same either way, and there is exactly one place where "this build cannot
+   !! do that" is decided. `hdf5_amplitudes_available` is how a caller asks in
+   !! advance, so a CC gradient can refuse up front and name the build option
+   !! instead of dying somewhere less useful.
+   !!
+   !! `resumable` is `.false.` here for the same reason it is `.false.` after
+   !! an interrupted write: a caller that branches on it starts from the MP2
+   !! guess and needs no knowledge of which build it is in.
+   use pic_types, only: dp
+   use mqc_error, only: error_t, ERROR_VALIDATION
+   implicit none
+   private
+
+   public :: hdf5_amplitudes_t
+   public :: hdf5_amplitudes_available
+
+   character(len=*), parameter :: NO_HDF5 = &
+                                  "this build has no HDF5, so coupled-cluster amplitudes cannot be stored "// &
+                                  "or resumed; configure with -DMQC_ENABLE_HDF5=ON. A CCSD energy needs "// &
+                                  "none of this and runs unchanged."
+
+   type :: hdf5_amplitudes_t
+      logical :: active = .false.
+      logical :: resumable = .false.
+      integer :: iteration = 0
+      real(dp) :: energy = 0.0_dp
+   contains
+      procedure :: open => amp_open
+      procedure, private :: put_2d => amp_put_2d
+      procedure, private :: put_4d => amp_put_4d
+      generic :: put => put_2d, put_4d
+      procedure, private :: get_2d => amp_get_2d
+      procedure, private :: get_4d => amp_get_4d
+      generic :: get => get_2d, get_4d
+      procedure :: commit => amp_commit
+      procedure :: close => amp_close
+   end type hdf5_amplitudes_t
+
+contains
+
+   pure function hdf5_amplitudes_available() result(available)
+      !! Whether this build can store amplitudes
+      logical :: available
+      available = .false.
+   end function hdf5_amplitudes_available
+
+   subroutine amp_open(this, path, fingerprint, error)
+      class(hdf5_amplitudes_t), intent(inout) :: this
+      character(len=*), intent(in) :: path
+      character(len=*), intent(in) :: fingerprint
+      type(error_t), intent(inout) :: error
+
+      this%active = .false.
+      this%resumable = .false.
+      call error%set(ERROR_VALIDATION, trim(path)//" cannot be opened: "//NO_HDF5)
+      if (len_trim(fingerprint) == 0) return
+   end subroutine amp_open
+
+   subroutine amp_put_2d(this, name, values)
+      class(hdf5_amplitudes_t), intent(inout) :: this
+      character(len=*), intent(in) :: name
+      real(dp), intent(in), contiguous, target :: values(:, :)
+
+      if (this%active .or. len_trim(name) == 0 .or. size(values) < 0) return
+   end subroutine amp_put_2d
+
+   subroutine amp_put_4d(this, name, values)
+      class(hdf5_amplitudes_t), intent(inout) :: this
+      character(len=*), intent(in) :: name
+      real(dp), intent(in), contiguous, target :: values(:, :, :, :)
+
+      if (this%active .or. len_trim(name) == 0 .or. size(values) < 0) return
+   end subroutine amp_put_4d
+
+   subroutine amp_get_2d(this, name, values, error)
+      class(hdf5_amplitudes_t), intent(in) :: this
+      character(len=*), intent(in) :: name
+      real(dp), allocatable, intent(out), target :: values(:, :)
+      type(error_t), intent(inout) :: error
+
+      allocate (values(0, 0))
+      call error%set(ERROR_VALIDATION, trim(name)//" cannot be read: "//NO_HDF5)
+      if (this%active) return
+   end subroutine amp_get_2d
+
+   subroutine amp_get_4d(this, name, values, error)
+      class(hdf5_amplitudes_t), intent(in) :: this
+      character(len=*), intent(in) :: name
+      real(dp), allocatable, intent(out), target :: values(:, :, :, :)
+      type(error_t), intent(inout) :: error
+
+      allocate (values(0, 0, 0, 0))
+      call error%set(ERROR_VALIDATION, trim(name)//" cannot be read: "//NO_HDF5)
+      if (this%active) return
+   end subroutine amp_get_4d
+
+   subroutine amp_commit(this, iteration, energy)
+      class(hdf5_amplitudes_t), intent(inout) :: this
+      integer, intent(in) :: iteration
+      real(dp), intent(in) :: energy
+
+      if (this%active .or. iteration < 0 .or. energy /= energy) return
+   end subroutine amp_commit
+
+   subroutine amp_close(this)
+      class(hdf5_amplitudes_t), intent(inout) :: this
+      this%active = .false.
+   end subroutine amp_close
+
+end module mqc_hdf5_amplitudes

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -376,8 +376,8 @@ addtest(mqc_capi_run)
 if(MQC_ENABLE_HDF5)
   addtest(mqc_hdf5_checkpoint)
   # The amplitude store is guarded the same way, and for a sharper reason: the
-  # stub's every procedure declines, so a suite run against it would assert
-  # only that refusals refuse.
+  # stub's every procedure declines, so a suite run against it would assert only
+  # that refusals refuse.
   addtest(mqc_hdf5_amplitudes)
 endif()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -375,6 +375,10 @@ addtest(mqc_capi_run)
 # ragged packing and sort ordering follows the same guard the format does.
 if(MQC_ENABLE_HDF5)
   addtest(mqc_hdf5_checkpoint)
+  # The amplitude store is guarded the same way, and for a sharper reason: the
+  # stub's every procedure declines, so a suite run against it would assert
+  # only that refusals refuse.
+  addtest(mqc_hdf5_amplitudes)
 endif()
 
 if(MQC_ENABLE_TBLITE)

--- a/test/test_mqc_hdf5_amplitudes.f90
+++ b/test/test_mqc_hdf5_amplitudes.f90
@@ -1,0 +1,301 @@
+!! Coupled-cluster amplitudes surviving a restart, and refusing not to
+!!
+!! What is checked here is the set of failures that would otherwise be
+!! *silent* -- a resumed run that iterates smoothly to a number nobody can
+!! tell is wrong:
+!!
+!!   * `t2` and `l2` come back with the right **shape**, not merely the right
+!!     element count. A rank-4 block read as the wrong extents is the same
+!!     total size and a different tensor
+!!   * a file whose last write was interrupted reports `resumable = .false.`
+!!     rather than handing back half an iteration. This is the one that has no
+!!     loud failure mode at all: the arrays are present and readable, they
+!!     just do not solve anything
+!!   * amplitudes from a **different calculation** are refused, not loaded.
+!!     Resuming from the wrong fingerprint converges -- to a stationary point
+!!     of another set of equations
+!!   * asking for a block by the wrong rank is refused rather than reshaped
+!!
+!! None of this is reachable from a chemical deck. A CC run either resumes or
+!! it does not; it cannot be killed at a chosen instant and then asked which
+!! numbers came back. That is why it belongs in the unit suite.
+module test_mqc_hdf5_amplitudes
+   use pic_types, only: dp
+   use testdrive, only: new_unittest, unittest_type, error_type, check
+   use mqc_hdf5_amplitudes, only: hdf5_amplitudes_t, hdf5_amplitudes_available
+   use mqc_error, only: error_t
+   implicit none
+   private
+
+   public :: collect_hdf5_amplitudes
+
+   character(len=*), parameter :: PATH = "test_amps.h5"
+   character(len=*), parameter :: FP = "a41c07de9b3f5521"
+   character(len=*), parameter :: OTHER_FP = "0000deadbeef0000"
+
+   integer, parameter :: NOCC = 3, NVIR = 5
+
+contains
+
+   subroutine collect_hdf5_amplitudes(testsuite)
+      type(unittest_type), allocatable, intent(out) :: testsuite(:)
+
+      testsuite = [ &
+                  new_unittest("round trip preserves shape and values", test_round_trip), &
+                  new_unittest("an interrupted write is not resumable", test_torn_write), &
+                  new_unittest("a foreign fingerprint is refused", test_wrong_fingerprint), &
+                  new_unittest("a missing block is refused", test_missing_block), &
+                  new_unittest("the wrong rank is refused", test_wrong_rank), &
+                  new_unittest("a second commit overwrites in place", test_overwrite) &
+                  ]
+   end subroutine collect_hdf5_amplitudes
+
+   subroutine test_round_trip(error)
+      type(error_type), allocatable, intent(out) :: error
+
+      type(hdf5_amplitudes_t) :: store
+      type(error_t) :: err
+      real(dp), allocatable :: t1(:, :), t2(:, :, :, :)
+      real(dp), allocatable :: back1(:, :), back2(:, :, :, :)
+
+      if (.not. hdf5_amplitudes_available()) return
+      call fresh()
+      call make_t1(t1)
+      call make_t2(t2)
+
+      call store%open(PATH, FP, err)
+      call check(error,.not. err%has_error(), "opening a new store should succeed")
+      if (allocated(error)) return
+      call check(error,.not. store%resumable, "a new store has nothing to resume")
+      if (allocated(error)) return
+
+      call store%put("t1", t1)
+      call store%put("t2", t2)
+      call store%commit(7, -0.25_dp)
+      call store%close()
+
+      call store%open(PATH, FP, err)
+      call check(error,.not. err%has_error(), "reopening should succeed")
+      if (allocated(error)) return
+      call check(error, store%resumable, "a committed store is resumable")
+      if (allocated(error)) return
+      call check(error, store%iteration, 7)
+      if (allocated(error)) return
+      call check(error, store%energy, -0.25_dp, thr=0.0_dp)
+      if (allocated(error)) return
+
+      call store%get("t1", back1, err)
+      call check(error,.not. err%has_error(), "t1 should read back")
+      if (allocated(error)) return
+      call store%get("t2", back2, err)
+      call check(error,.not. err%has_error(), "t2 should read back")
+      if (allocated(error)) return
+      call store%close()
+
+      ! Shape before values: a wrong extent that happens to hold the right
+      ! numbers in the wrong places is the failure this is here to catch.
+      call check(error, all(shape(back1) == [NOCC, NVIR]), "t1 shape")
+      if (allocated(error)) return
+      call check(error, all(shape(back2) == [NOCC, NVIR, NOCC, NVIR]), "t2 shape")
+      if (allocated(error)) return
+      call check(error, maxval(abs(back1 - t1)), 0.0_dp, thr=0.0_dp)
+      if (allocated(error)) return
+      call check(error, maxval(abs(back2 - t2)), 0.0_dp, thr=0.0_dp)
+   end subroutine test_round_trip
+
+   subroutine test_torn_write(error)
+      !! Write, then write again without committing, and reopen
+      !!
+      !! This is what a kill looks like from the next run's side: the datasets
+      !! exist and are readable, and there is nothing in their contents to say
+      !! they are half of one iteration and half of another. Only `complete`
+      !! knows, which is why `put` clears it before touching the data.
+      type(error_type), allocatable, intent(out) :: error
+
+      type(hdf5_amplitudes_t) :: store
+      type(error_t) :: err
+      real(dp), allocatable :: t1(:, :), t2(:, :, :, :)
+
+      if (.not. hdf5_amplitudes_available()) return
+      call fresh()
+      call make_t1(t1)
+      call make_t2(t2)
+
+      call store%open(PATH, FP, err)
+      call store%put("t1", t1)
+      call store%put("t2", t2)
+      call store%commit(1, -0.1_dp)
+      ! A second iteration that never reaches its commit.
+      call store%put("t1", 2.0_dp*t1)
+      call store%close()
+
+      call store%open(PATH, FP, err)
+      call check(error,.not. err%has_error(), "the file should still open")
+      if (allocated(error)) return
+      call check(error,.not. store%resumable, &
+                 "an uncommitted write must leave the store unresumable")
+      call store%close()
+   end subroutine test_torn_write
+
+   subroutine test_wrong_fingerprint(error)
+      type(error_type), allocatable, intent(out) :: error
+
+      type(hdf5_amplitudes_t) :: store
+      type(error_t) :: err
+      real(dp), allocatable :: t1(:, :)
+
+      if (.not. hdf5_amplitudes_available()) return
+      call fresh()
+      call make_t1(t1)
+
+      call store%open(PATH, FP, err)
+      call store%put("t1", t1)
+      call store%commit(1, -0.1_dp)
+      call store%close()
+
+      call store%open(PATH, OTHER_FP, err)
+      call check(error, err%has_error(), &
+                 "amplitudes from another calculation must be refused")
+      call store%close()
+   end subroutine test_wrong_fingerprint
+
+   subroutine test_missing_block(error)
+      type(error_type), allocatable, intent(out) :: error
+
+      type(hdf5_amplitudes_t) :: store
+      type(error_t) :: err
+      real(dp), allocatable :: t1(:, :), back(:, :, :, :)
+
+      if (.not. hdf5_amplitudes_available()) return
+      call fresh()
+      call make_t1(t1)
+
+      call store%open(PATH, FP, err)
+      call store%put("t1", t1)
+      call store%commit(1, -0.1_dp)
+      call store%get("l2", back, err)
+      call check(error, err%has_error(), "a block never written must be refused")
+      call store%close()
+   end subroutine test_missing_block
+
+   subroutine test_wrong_rank(error)
+      !! Ask for the rank-2 block as rank-4
+      type(error_type), allocatable, intent(out) :: error
+
+      type(hdf5_amplitudes_t) :: store
+      type(error_t) :: err
+      real(dp), allocatable :: t1(:, :), back(:, :, :, :)
+
+      if (.not. hdf5_amplitudes_available()) return
+      call fresh()
+      call make_t1(t1)
+
+      call store%open(PATH, FP, err)
+      call store%put("t1", t1)
+      call store%commit(1, -0.1_dp)
+      call store%get("t1", back, err)
+      call check(error, err%has_error(), "reading a rank-2 block as rank-4 must be refused")
+      call store%close()
+   end subroutine test_wrong_rank
+
+   subroutine test_overwrite(error)
+      !! The file must not grow a second copy when an iteration is rewritten
+      type(error_type), allocatable, intent(out) :: error
+
+      type(hdf5_amplitudes_t) :: store
+      type(error_t) :: err
+      real(dp), allocatable :: t1(:, :), back(:, :)
+
+      if (.not. hdf5_amplitudes_available()) return
+      call fresh()
+      call make_t1(t1)
+
+      call store%open(PATH, FP, err)
+      call store%put("t1", t1)
+      call store%commit(1, -0.1_dp)
+      call store%put("t1", 3.0_dp*t1)
+      call store%commit(2, -0.2_dp)
+      call store%close()
+
+      call store%open(PATH, FP, err)
+      call check(error, store%iteration, 2)
+      if (allocated(error)) return
+      call store%get("t1", back, err)
+      call store%close()
+      call check(error,.not. err%has_error(), "the rewritten block should read back")
+      if (allocated(error)) return
+      call check(error, all(shape(back) == [NOCC, NVIR]), "shape after rewrite")
+      if (allocated(error)) return
+      call check(error, maxval(abs(back - 3.0_dp*t1)), 0.0_dp, thr=0.0_dp)
+      if (allocated(error)) return
+      call fresh()
+   end subroutine test_overwrite
+
+   ! -- fixtures ------------------------------------------------------------
+   ! Every element encodes its own indices, so a block that came back
+   ! transposed or offset is caught by its values and not only by its size.
+
+   subroutine make_t1(t1)
+      real(dp), allocatable, intent(out) :: t1(:, :)
+      integer :: i, a
+
+      allocate (t1(NOCC, NVIR))
+      do a = 1, NVIR
+         do i = 1, NOCC
+            t1(i, a) = real(100*i + a, dp)
+         end do
+      end do
+   end subroutine make_t1
+
+   subroutine make_t2(t2)
+      real(dp), allocatable, intent(out) :: t2(:, :, :, :)
+      integer :: i, a, j, b
+
+      allocate (t2(NOCC, NVIR, NOCC, NVIR))
+      do b = 1, NVIR
+         do j = 1, NOCC
+            do a = 1, NVIR
+               do i = 1, NOCC
+                  t2(i, a, j, b) = real(1000*i + 100*a + 10*j + b, dp)
+               end do
+            end do
+         end do
+      end do
+   end subroutine make_t2
+
+   subroutine fresh()
+      !! Remove the scratch file, so a test starts from nothing
+      integer :: unit
+      logical :: exists
+
+      inquire (file=PATH, exist=exists)
+      if (exists) then
+         open (newunit=unit, file=PATH, status="old", action="readwrite")
+         close (unit, status="delete")
+      end if
+   end subroutine fresh
+
+end module test_mqc_hdf5_amplitudes
+
+program tester
+   use, intrinsic :: iso_fortran_env, only: error_unit
+   use testdrive, only: run_testsuite, new_testsuite, testsuite_type
+   use test_mqc_hdf5_amplitudes, only: collect_hdf5_amplitudes
+   implicit none
+   integer :: stat, is
+   type(testsuite_type), allocatable :: testsuites(:)
+   character(len=*), parameter :: fmt = '("#", *(1x, a))'
+
+   stat = 0
+   testsuites = [new_testsuite("mqc_hdf5_amplitudes", collect_hdf5_amplitudes)]
+
+   do is = 1, size(testsuites)
+      write (error_unit, fmt) "Testing:", testsuites(is)%name
+      call run_testsuite(testsuites(is)%collect, error_unit, stat)
+   end do
+
+   if (stat > 0) then
+      write (error_unit, "(i0, 1x, a)") stat, "test(s) failed!"
+      error stop
+   end if
+end program tester

--- a/validation/check_amplitude_layout.f90
+++ b/validation/check_amplitude_layout.f90
@@ -1,0 +1,79 @@
+!! Writes an amplitude file for a reader that is not Fortran to check
+!!
+!!     cmake -B build -DMQC_ENABLE_HDF5=ON
+!!     cmake --build build --target check_amplitude_layout
+!!     ./build/check_amplitude_layout && python3 validation/check_amplitude_layout.py
+!!
+!! This program asserts nothing about the file it writes, and that is the
+!! point. The failure it exists to catch is invisible from inside Fortran:
+!! HDF5 declares extents in C order while Fortran's leftmost index varies
+!! fastest, so a block written with `shape()` passed straight through holds
+!! the right bytes under the wrong declared shape. Reading it back through
+!! the same bindings is exact, because the same mistake is made twice. Only a
+!! reader with the opposite convention can see it, so the assertions live in
+!! the Python script and all this does is produce the evidence.
+!!
+!! **The extents are deliberately all different.** `t2(2,3,4,5)` rather than
+!! anything square: a reversal bug in a block whose dimensions match is
+!! undetectable, and `nocc`/`nvir` being equal is exactly the accident that
+!! would let one through on a small test case.
+program check_amplitude_layout
+   use pic_types, only: dp
+   use mqc_error, only: error_t
+   use mqc_hdf5_amplitudes, only: hdf5_amplitudes_t
+   implicit none
+
+   character(len=*), parameter :: PATH = "amplitude_layout.h5"
+   character(len=*), parameter :: FP = "1234abcd5678ef90"
+   integer, parameter :: N1 = 2, N2 = 3, N3 = 4, N4 = 5
+   integer, parameter :: ITERATION = 3
+   real(dp), parameter :: ENERGY = -0.5_dp
+
+   type(hdf5_amplitudes_t) :: store
+   type(error_t) :: err
+   real(dp), allocatable :: t1(:, :), t2(:, :, :, :)
+   integer :: i, a, j, b, unit
+   logical :: exists
+
+   ! Every element encodes its own indices, so a block that arrives
+   ! transposed is caught by its values and not only by its shape.
+   allocate (t1(N1, N2))
+   do a = 1, N2
+      do i = 1, N1
+         t1(i, a) = real(100*i + a, dp)
+      end do
+   end do
+
+   allocate (t2(N1, N2, N3, N4))
+   do b = 1, N4
+      do j = 1, N3
+         do a = 1, N2
+            do i = 1, N1
+               t2(i, a, j, b) = real(1000*i + 100*a + 10*j + b, dp)
+            end do
+         end do
+      end do
+   end do
+
+   inquire (file=PATH, exist=exists)
+   if (exists) then
+      open (newunit=unit, file=PATH, status="old", action="readwrite")
+      close (unit, status="delete")
+   end if
+
+   call store%open(PATH, FP, err)
+   if (err%has_error()) then
+      write (*, "(a)") "could not open "//PATH//": "//err%get_message()
+      error stop 1
+   end if
+
+   call store%put("t1", t1)
+   call store%put("t2", t2)
+   call store%commit(ITERATION, ENERGY)
+   call store%close()
+
+   write (*, "(a)") "wrote "//PATH
+   write (*, "(a,4(1x,i0))") "  t1 Fortran extents:", N1, N2
+   write (*, "(a,4(1x,i0))") "  t2 Fortran extents:", N1, N2, N3, N4
+   write (*, "(a)") "  a C-order reader must see these reversed"
+end program check_amplitude_layout

--- a/validation/check_amplitude_layout.py
+++ b/validation/check_amplitude_layout.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Check that a Fortran-written amplitude file is the right tensor to C.
+
+Run `check_amplitude_layout` first; it writes `amplitude_layout.h5` and
+asserts nothing about it.
+
+WHY THIS IS NOT A FORTRAN TEST
+------------------------------
+It cannot be one. HDF5 declares a dataset in C order -- first extent
+slowest-varying -- while Fortran's leftmost index varies fastest. Passing
+`shape(values)` straight into `H5Screate_simple` therefore stores the correct
+bytes under an incorrect declared shape: `t1(2,3)` becomes a 2x3 dataset whose
+rows interleave the two indices. Reading it back through the same bindings is
+exact, because the same convention is wrong on both sides, so every assertion
+a Fortran test could make passes. The file is only wrong to somebody else --
+h5py, h5dump, MATLAB, any C consumer -- and being readable by somebody else is
+the entire reason to use HDF5 rather than a stream of unformatted records.
+
+This ran as a manual cross-check once and immediately found the bug it is
+named for; it is here so that it runs every time instead.
+
+WHAT IS CHECKED, AND WHY BOTH HALVES ARE NEEDED
+-----------------------------------------------
+`h5dump -H` would show the declared extents and is free -- it ships inside
+the HDF5 package. It is not enough on its own: a "fix" that transposed the
+array in Fortran before writing, rather than reversing the extents, prints the
+right header over the wrong numbers. So the shapes are checked *and* every
+element is checked against the indices it encodes.
+"""
+import os
+import sys
+
+import h5py
+import numpy as np
+
+PATH = "amplitude_layout.h5"
+N1, N2, N3, N4 = 2, 3, 4, 5
+ITERATION = 3
+ENERGY = -0.5
+
+
+def main():
+    failures = []
+
+    with h5py.File(PATH, "r") as f:
+        # Attributes first: `complete` is what a resumed run trusts, and a
+        # file that says 0 here would be silently ignored rather than used.
+        got = f.attrs.get("complete")
+        if got != 1:
+            failures.append(f"complete is {got!r}, expected 1")
+        got = f.attrs.get("iteration")
+        if got != ITERATION:
+            failures.append(f"iteration is {got!r}, expected {ITERATION}")
+        got = f.attrs.get("energy")
+        if got != ENERGY:
+            failures.append(f"energy is {got!r}, expected {ENERGY}")
+
+        t1 = f["t1"][...]
+        t2 = f["t2"][...]
+
+    # Shape: reversed, because that is what C order means. All four extents
+    # of t2 differ, so a partial or wrong-axis reversal cannot pass.
+    if t1.shape != (N2, N1):
+        failures.append(f"t1 shape is {t1.shape}, expected {(N2, N1)} "
+                        f"(Fortran t1({N1},{N2}) reversed)")
+    if t2.shape != (N4, N3, N2, N1):
+        failures.append(f"t2 shape is {t2.shape}, expected {(N4, N3, N2, N1)} "
+                        f"(Fortran t2({N1},{N2},{N3},{N4}) reversed)")
+
+    # Values: the half a header dump cannot see. t1_h5[a, i] must be the
+    # element Fortran calls t1(i+1, a+1).
+    if t1.shape == (N2, N1):
+        want = np.fromfunction(
+            lambda a, i: 100 * (i + 1) + (a + 1), (N2, N1), dtype=float)
+        if not np.array_equal(t1, want):
+            failures.append("t1 values do not match t1_h5[a,i] == 100*i + a; "
+                            f"got\n{t1}\nwanted\n{want}")
+
+    if t2.shape == (N4, N3, N2, N1):
+        want = np.fromfunction(
+            lambda b, j, a, i: 1000 * (i + 1) + 100 * (a + 1) + 10 * (j + 1) + (b + 1),
+            (N4, N3, N2, N1), dtype=float)
+        if not np.array_equal(t2, want):
+            bad = np.argwhere(t2 != want)
+            failures.append(
+                f"t2 values do not match t2_h5[b,j,a,i] == 1000*i + 100*a + 10*j + b; "
+                f"{len(bad)} of {t2.size} elements differ, first at {tuple(bad[0])}")
+
+    if failures:
+        print(f"FAIL: {PATH} is not the tensor a C-order reader expects")
+        for line in failures:
+            print(f"  - {line}")
+        return 1
+
+    print(f"OK: {PATH} reads correctly from h5py "
+          f"(HDF5 {h5py.version.hdf5_version}, h5py {h5py.__version__})")
+    print(f"  t1 {t1.shape} and t2 {t2.shape}, both reversed as C order requires")
+    # Removed only on success, so a failing run leaves the evidence to h5dump.
+    os.remove(PATH)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
> Stacked on #263 — based on `feat/hdf5-ci`, which builds HDF5 in CI and adds
> h5py. Merge that one first; this diff is the amplitude store alone.

Stores `t1`, `t2`, `l1` and `l2` for one coupled-cluster calculation in HDF5 so
a killed run can resume.

A separate module from `mqc_hdf5_checkpoint` rather than more procedures on that
type. The checkpoint appends a record per fragment and is keyed by a monomer
tuple; this rewrites one calculation's amplitudes in place every
macro-iteration. Sharing a type would mean an append-only contract that neither
honours.

T amplitudes are stored and not only Lambda, because Lambda alone cannot restart
anything — every intermediate in `lambda_intermediates` is built from `t1` and
`t2`, so a resumed run holding only `l1` and `l2` would have to solve CCSD again
to use them.

## Two silent failures designed against

Both are the kind that converge smoothly to a wrong number rather than crashing.

**A kill mid-write must not leave a plausible file.** `complete` is an attribute
that `put` clears before touching any data and `commit` raises only after the
flush lands — the same trick `n_valid` plays next door. A reader finding zero
treats the file as empty, so the window a kill can lose is one macro-iteration,
whole rather than part of an array.

**The extents are reversed on the way to the file.** HDF5 declares a dataset in
C order while Fortran's leftmost index varies fastest. Written straight through,
the bytes are right and the declared shape is wrong, and a resumed run converges
to a stationary point of the wrong equations. `H5Sget_simple_extent_dims` and
`H5Sget_simple_extent_ndims` join the bindings so a reader can allocate before
it reads; both are exported by 1.10 and by 2.0.

## The check is made from outside Fortran

That dimension-order bug was found by reading the file with h5py by hand, and
the Fortran suite could not have found it: reading back through the same
bindings is exact, because the same convention is wrong on both sides. Every
assertion a Fortran test can make passes over a file that is a different tensor
to everyone else. Being readable by somebody else is the whole reason this data
is in HDF5, so the check is made by somebody else.

Split accordingly: `check_amplitude_layout.f90` writes and asserts nothing,
`check_amplitude_layout.py` reads and asserts everything. Both run in the
`with hdf5` job.

The extents are all different — `t2(2,3,4,5)` — because a reversal bug in a block
whose dimensions match is undetectable, and `nocc == nvir` on a small case is
exactly the accident that would let one through. Shapes *and* values are checked:
`h5dump -H` costs nothing and is still not enough, because a "fix" that transposes
in Fortran rather than reversing the extents prints a correct header over
incorrect numbers. Confirmed by mutating the writer to do exactly that.

Both mutations were run against this check before it was committed — extent
reversal removed, and data written on the wrong axes. It fails on each and passes
on neither, which is the only reason to believe it.

The stub in `src/io/` declines every call, so `fpm build` — which globs `src/` and
never sees `backends/` — still compiles, and a CC gradient asked for there refuses
by name instead of failing somewhere less useful.
