### PR TITLE
Stop superseded CI runs, except on main

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -7,6 +7,22 @@ on:
     branches: ["*"]
   workflow_dispatch:
 
+# Supersede a branch's own earlier run, but never a run on `main`.
+#
+# The asymmetry is the whole point. A cancelled PR run costs nothing: the push
+# that cancelled it is about to measure the same branch again. A cancelled
+# `main` run costs every PR opened afterwards, because codecov compares a pull
+# request against the base commit's report and a commit whose run was killed
+# has none -- the comparison then walks back to an older ancestor, or reports
+# nothing at all. That failure surfaces on pull requests that were never
+# cancelled themselves, which is what makes it hard to attribute.
+#
+# `head_ref` is set for pull_request events and empty otherwise, so the group
+# is per-PR-branch there and per-branch for the push on `main`.
+concurrency:
+  group: codecov-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   codecov:
     runs-on: ubuntu-latest

--- a/.github/workflows/local_conda_env.yml
+++ b/.github/workflows/local_conda_env.yml
@@ -2,6 +2,17 @@ name: Build MQC using local conda env (MPI, OpenMP, BLAS)
 
 on: [push]
 
+# One build per branch. A push supersedes the one before it on the same branch,
+# and the superseded run is cancelled rather than left to finish work nobody
+# will read -- the matrix is eleven jobs, so a branch pushed three times in an
+# hour was occupying the runners three times over.
+#
+# `github.ref` and not the workflow name: the group has to be per-branch or
+# every branch cancels every other one, which is the way this goes wrong.
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   cmake-build:
     name: CMake build (${{ matrix.name }})


### PR DESCRIPTION
A push to a branch that is already building starts a second full matrix and leaves the first one running. Eleven jobs apiece, so a branch pushed three times in an hour holds the runners three times over — and with a dozen open PRs, that is most of why anything queues at all. Recent history has five runs each on `perf/iterative-tdhf` and `feat/efp-keywords`, only the last of which anybody read.

## The build workflow cancels outright

`local_conda_env.yml` is `on: [push]`, keyed by `github.ref` so the group is per-branch. Keyed by workflow name instead, every branch would cancel every other one — the usual way this gets got wrong.

This does include pushes to `main`: back-to-back merges mean one merge can cancel the previous merge's build. If it turns out to matter to know *which* merge broke main, the one-line change is `cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}`.

## Coverage does not cancel on `main`

The asymmetry is the point, and it is the failure mode worth naming.

A cancelled PR run costs nothing — the push that cancelled it measures the same branch again a minute later. A cancelled `main` run costs every PR opened afterwards: codecov compares a pull request against the base commit's report, and a commit whose run was killed does not have one. The comparison then walks back to an older ancestor, or comes up empty.

That failure surfaces on pull requests which were never cancelled themselves, which is what makes it hard to attribute to this setting at all.

`github.head_ref` is set on `pull_request` events and empty otherwise, so the group is per-PR-branch there and per-branch for the push on `main`.

## What to watch after merge

The codecov comment on the next PR should still show a base comparison rather than an unknown base. That is the signal the `main` exemption is working.