### PR TITLE
Show the ion SCFs a Fukui run solves

### DIFF
--- a/backends/libcint/mqc_libcint_fukui.f90
+++ b/backends/libcint/mqc_libcint_fukui.f90
@@ -246,8 +246,18 @@ contains
 
       ! The anion. One more electron, and a doublet because the neutral was
       ! closed shell.
+      !
+      ! Solved in the open, like the neutral before it. A Fukui run is three
+      ! SCFs and the ions are the two that misbehave: an anion in a basis with
+      ! no diffuse functions is where this fails, and it fails by converging
+      ! slowly or to something unbound rather than by stopping. Running it
+      ! silently meant the report could say the affinity was negative while
+      ! the evidence for why -- the iterations it took, the energy it settled
+      ! on, <S^2> for the doublet -- was never printed.
+      call logger%info("")
+      call logger%info("  Fukui: anion SCF, N+1 electrons")
       call run_libcint_uhf(mol, nelec + 1, 2, max_iter, energy_tol, density_tol, &
-                           .false., anion, error, xc=xc_arg)
+                           .true., anion, error, xc=xc_arg)
       if (error%has_error()) then
          call error%add_context("Fukui indices: the anion")
          return
@@ -274,8 +284,10 @@ contains
       deallocate (total)
 
       ! The cation.
+      call logger%info("")
+      call logger%info("  Fukui: cation SCF, N-1 electrons")
       call run_libcint_uhf(mol, nelec - 1, 2, max_iter, energy_tol, density_tol, &
-                           .false., cation, error, xc=xc_arg)
+                           .true., cation, error, xc=xc_arg)
       if (error%has_error()) then
          call error%add_context("Fukui indices: the cation")
          return

--- a/backends/libcint/mqc_libcint_rhf.f90
+++ b/backends/libcint/mqc_libcint_rhf.f90
@@ -958,7 +958,7 @@ contains
       call clk%lap(STAGE_FOCK)
       call clk%finish()
       call scf_table_footer(verbose, result%converged, result%iterations)
-      call clk%report("RHF", verbose)
+      call clk%report("UHF", verbose)
       if (verbose) then
          write (line, "(a,f12.8,a,f12.8)") "  <S^2> = ", result%spin_squared, &
             "   exact = ", 0.25_dp*real(n_alpha - n_beta, dp)*real(n_alpha - n_beta + 2, dp)


### PR DESCRIPTION
A Fukui calculation is three SCFs and only one of them was printed. The anion and cation were passed verbose = .false., so a run that took thirteen iterations to settle an unbound anion looked from the log like it had done nothing between the neutral energy and the table. Closes #269 

The ions are the two that misbehave. An anion in a basis with no diffuse functions is where this fails, and it fails by converging slowly or onto something unbound rather than by stopping -- water in 6-31G is exactly that case, and the report already says the affinity is negative. What was missing was the evidence: E(N+1) = -75.7904 sitting above E(N) = -75.9848, reached in 13 iterations, with <S^2> = 0.7578 for the doublet. All of it was computed and none of it was shown.

Each ion gets a line naming it first, because three SCF tables in a row are otherwise indistinguishable.

Also fixes the label those tables print. run_libcint_uhf reported its timings as "RHF timings", which was invisible while nothing ran it verbosely and is wrong twice per Fukui run now that something does.

Display only. The Fukui table, IP, EA and the descriptors are unchanged, checked by diffing a run against one from before. The dual row's sum prints as 0.0000 or -0.0000 from one run to the next, which is a signed zero on a quantity of order 1e-17 -- the same binary does it, so it predates this and is not from here.