### PR TITLE
Build DL-FIND in CI, and make it take a step

### DIFF
--- a/.github/workflows/local_conda_env.yml
+++ b/.github/workflows/local_conda_env.yml
@@ -50,6 +50,8 @@ jobs:
             # the default flips, this job stops matching what `cmake -B build`
             # produces and the mismatch shows up here rather than nowhere.
             hdf5: false
+            # DL-FIND likewise, and for the same reason.
+            dlfind: false
           # tblite built without libxc or the integrals backend -- a reduced
           # build, and only a build. The xTB validation is not run here: it
           # touches neither libxc nor the integrals, so on modern MPI it would
@@ -107,6 +109,30 @@ jobs:
             tblite: false
             legacy_mpi: false
             hdf5: true
+          # `MQC_ENABLE_DLFIND` appeared in no job, and it defaults to OFF, so
+          # `backends/dlfind/` had never been compiled here at all -- the
+          # bridge, its seven callbacks, and the `spec` array it hands DL-FIND.
+          # What CI did cover was `mqc_optimizer_types`, which is the
+          # optimizer's vocabulary and is built either way, so the tests read as
+          # though the optimizer were covered while the half that talks to
+          # DL-FIND was not compiled.
+          #
+          # The failure that says so: a `dlfind_optimize` argument added to the
+          # real bridge and not to `mqc_dlfind_bridge_stub` builds clean for
+          # anyone developing with the option on, and breaks every job here.
+          # Only a job with it ON compiles both halves against the same call.
+          #
+          # libcint comes with it so there is something to optimize *with*. A
+          # build-only job would prove the bridge links and nothing about
+          # whether it steps: the callbacks, the `spec` array and the geometry
+          # coming back all sit behind `api_dl_find`, which a compiler never
+          # calls. The validation step below runs a short Hartree-Fock
+          # optimization, which is the cheapest thing that exercises them.
+          - name: "with dlfind"
+            tblite: false
+            legacy_mpi: false
+            libcint: true
+            dlfind: true
           # The Python interface needs every backend in one library. backends.py
           # covers standalone and fragmented, xTB and Hartree-Fock -- three of
           # those four paths can break without the others noticing -- and
@@ -148,6 +174,7 @@ jobs:
                   -DMQC_ENABLE_LIBCINT=${{ matrix.libcint && 'ON' || 'OFF' }} \
                   -DMQC_USE_LIBFINT=${{ matrix.backend == 'libcint' && 'OFF' || 'ON' }} \
                   -DMQC_ENABLE_HDF5=${{ matrix.hdf5 && 'ON' || 'OFF' }} \
+                  -DMQC_ENABLE_DLFIND=${{ matrix.dlfind && 'ON' || 'OFF' }} \
                   -B build
           fi
           cmake --build build --parallel 2
@@ -190,6 +217,30 @@ jobs:
           # no longer reachable from Python, or is reachable and wrong.
           MQC_LIBRARY=$PWD/build/libmqc.so PYTHONPATH=$PWD/python \
             python3 python/examples/methods.py
+
+      # A geometry optimization, which is the only thing here that drives
+      # DL-FIND rather than merely linking it. Water in STO-3G from a distorted
+      # start: about fifty energy-and-gradient evaluations, a second or two, and
+      # it fails if the callbacks stop being called, if the geometry stops
+      # coming back through `dlf_put_coords`, or if the `spec` array stops
+      # describing the system.
+      #
+      # The manifest checks the structure as well as the energy. A wrong
+      # optimization can land inside an energy tolerance while sitting at a
+      # geometry nobody meant -- the potential is flat near the minimum, which
+      # is the whole difficulty -- so `expected_distances` is what actually
+      # constrains it.
+      #
+      # `--manifest validation_tests.json` also holds the two GFN2 cases; they
+      # require tblite, which this job does not build, so they skip rather than
+      # fail.
+      - name: Run the optimizer validation
+        if: matrix.dlfind
+        shell: bash -el {0}
+        run: |
+          conda activate mqc
+          cd validation
+          python3 run_validation.py --manifest validation_tests.json -v
 
       # Needs libxc as well as libcint: twelve of these cases name a functional
       # and are refused outright without it, which is how this step first went

--- a/tools/cpu_validation/gen_cpu_validation.py
+++ b/tools/cpu_validation/gen_cpu_validation.py
@@ -287,6 +287,14 @@ MP2_CASES = [
 # sweep below and vanish on the next regeneration.
 HAND_MAINTAINED = {
     "cpu/mqc/rhf/cpu_peptide46_sto-3g.json",
+    # A geometry optimization, which this script does not generate: every case
+    # it writes is a single point with a PySCF energy beside it, and there is no
+    # optimize category to put this in. It is here because it belongs with the
+    # other CPU decks and would be swept from anywhere under cpu/mqc otherwise.
+    # Its manifest entry is in validation_tests.json rather than the generated
+    # one, beside the two GFN2 optimizations it is the Hartree-Fock counterpart
+    # to.
+    "cpu/mqc/optimize/cpu_water_sto-3g_opt.json",
     # MAKEFP writes a fragment potential rather than returning an energy, so there
     # is no reference number for this script to generate or compare against. These
     # are examples of the deck shape, kept here so they are found where every other

--- a/validation/inputs/cpu/mqc/optimize/cpu_water_sto-3g_opt.json
+++ b/validation/inputs/cpu/mqc/optimize/cpu_water_sto-3g_opt.json
@@ -1,0 +1,34 @@
+{
+    "schema": {
+        "name": "cpu-water-sto-3g-opt",
+        "version": "1.0"
+    },
+    "molecules": [
+        {
+            "xyz": "../../../sample_inputs/w1.xyz",
+            "molecular_charge": 0,
+            "molecular_multiplicity": 1
+        }
+    ],
+    "model": {
+        "method": "hf",
+        "basis": "sto-3g"
+    },
+    "keywords": {
+        "scf": {
+            "maxiter": 100,
+            "tolerance": 1e-12
+        },
+        "optimization": {
+            "max_steps": 50,
+            "algorithm": "lbfgs",
+            "coordinates": "cartesian"
+        }
+    },
+    "system": {
+        "logger": {
+            "level": "Verbose"
+        }
+    },
+    "driver": "Optimize"
+}

--- a/validation/validation_tests.json
+++ b/validation/validation_tests.json
@@ -222,6 +222,23 @@
                 3.784614
             ],
             "distance_tolerance": 0.02
+        },
+        {
+            "name": "Optimize water HF/STO-3G (DL-FIND)",
+            "input": "inputs/cpu/mqc/optimize/cpu_water_sto-3g_opt.json",
+            "expected_energy": -74.965901217296,
+            "type": "unfragmented",
+            "requires": [
+                "libcint",
+                "dlfind"
+            ],
+            "tolerance": 1e-08,
+            "expected_distances": [
+                0.98941,
+                0.98941,
+                1.516159
+            ],
+            "distance_tolerance": 0.001
         }
     ]
 }


### PR DESCRIPTION
`MQC_ENABLE_DLFIND` appeared in no workflow and defaults to OFF, so `backends/dlfind/` had never been compiled here: the bridge, its seven callbacks, and the `spec` array it hands DL-FIND. What CI did run was `mqc_optimizer_types`, which is the optimizer's vocabulary and compiles either way -- so the suite read as though the optimizer were covered while the half that talks to DL-FIND was not built at all. `test/CMakeLists.txt` says as much beside that test and had said so for some time.

The failure that made it concrete: `dlfind_optimize` exists twice, once in the backend and once as `mqc_dlfind_bridge_stub`, and an argument added to one and not the other builds clean for anyone developing with the option on and breaks every job here. Neither side compiles both, which is exactly the drift a matrix is for.

A build-only job would have caught that one and little else. Everything interesting about this bridge is behind `api_dl_find` -- callbacks a compiler never calls, a geometry that comes back through `dlf_put_coords`, an integer array whose layout DL-FIND reads by offset -- so the job builds libcint too and runs a short Hartree-Fock optimization: water in STO-3G from a distorted start, about fifty gradients, a second or two.

The deck's reference is this program's own converged minimum, which is weaker than the CPU suite's PySCF numbers and worth naming. The energy at that geometry is not what is new -- 258 single points already check Hartree-Fock against PySCF -- what is new is that the optimizer arrives there, and for that a fixed point of our own is a regression test. The structure is pinned beside it because near a minimum the potential is flat enough that a wrong geometry lands inside any useful energy tolerance: r(OH) = 0.9894 A and 100.03 degrees, which is the STO-3G water structure the textbooks quote.

Hand-maintained, because the generator writes single points with PySCF references and has no optimize category, and anything under `cpu/mqc` that it did not write is swept on the next regeneration.

The job does not catch the reverse drift -- a stub change breaking the real bridge -- since no job builds both. That needs the same tests under both settings, which is more minutes than the gap is worth.