### PR TITLE
Stop a Fortran comment from breaking the Ninja build

### DIFF
--- a/.github/workflows/local_conda_env.yml
+++ b/.github/workflows/local_conda_env.yml
@@ -62,6 +62,18 @@ jobs:
             tblite: true
             legacy_mpi: false
             build_only: true
+            # The one job that builds with Ninja, and it is not a formality.
+            # CMake's Ninja generator runs every Fortran source through
+            # `cpp -E` to scan module dependencies; the Makefile generator,
+            # which every other job here uses, does not. So a construct that is
+            # fine in a Fortran comment and not fine in C -- a literal
+            # slash-star, which `cpp` reads as opening a block comment that
+            # never closes -- breaks a Ninja build and nothing else. That is
+            # exactly what happened: `ninja` ships in environment.yml, nothing
+            # here used it, and the tree spent six days unbuildable that way
+            # with CI green throughout. A build-only job is the right home,
+            # since a generator fault is a build fault.
+            generator: Ninja
           - name: "no tblite"
             tblite: false
             legacy_mpi: false
@@ -164,11 +176,16 @@ jobs:
         run: |
           conda activate mqc
           export FC=gfortran
+          generator=""
+          if [ -n "${{ matrix.generator }}" ]; then
+            generator="-G ${{ matrix.generator }}"
+          fi
           if [ "${{ matrix.defaults }}" = "true" ]; then
             # Deliberately bare: passing any option here would defeat the job.
             cmake -B build
           else
-            cmake -DMQC_ENABLE_TBLITE=${{ matrix.tblite && 'ON' || 'OFF' }} \
+            cmake $generator \
+                  -DMQC_ENABLE_TBLITE=${{ matrix.tblite && 'ON' || 'OFF' }} \
                   -DPIC_USE_LEGACY_MPI=${{ matrix.legacy_mpi && 'ON' || 'OFF' }} \
                   -DMQC_ENABLE_LIBXC=${{ matrix.libxc && 'ON' || 'OFF' }} \
                   -DMQC_ENABLE_LIBCINT=${{ matrix.libcint && 'ON' || 'OFF' }} \

--- a/src/basis/mqc_aambs.f90
+++ b/src/basis/mqc_aambs.f90
@@ -170,10 +170,15 @@ contains
       !! Locate `aambs/aambs.json` on the basis search path
       !!
       !! In a subdirectory rather than beside the other basis sets, and
-      !! deliberately: `mqc_extract_basis_sets` deletes any `basis_sets/*.json`
-      !! that `MQC_BASIS_SETS` does not name, and this file is tracked rather
-      !! than extracted from the Basis Set Exchange bundle. The subdirectory is
-      !! what keeps a configure from removing it.
+      !! deliberately: `mqc_extract_basis_sets` deletes any `*.json` under
+      !! `basis_sets/` that `MQC_BASIS_SETS` does not name, and this file is
+      !! tracked rather than extracted from the Basis Set Exchange bundle. The
+      !! subdirectory is what keeps a configure from removing it.
+      !!
+      !! The glob is written `*.json` under `basis_sets/` rather than the
+      !! obvious way round because CMake's Ninja generator preprocesses every
+      !! Fortran source to scan module dependencies, and `cpp` reads a literal
+      !! slash-star as the start of a C comment that never closes.
       character(len=:), allocatable, intent(out) :: filename
       type(error_t), intent(out) :: error
 


### PR DESCRIPTION
`mqc_aambs.f90` documented that `mqc_extract_basis_sets` deletes any `basis_sets/*.json` the configure does not name. Written that way round, the comment contains a literal slash-star, and `cpp` reads that as opening a C block comment which then never closes:

    src/basis/mqc_aambs.f90:173:0: Error: unterminated comment

A Fortran comment has no business reaching `cpp` at all, and under the Makefile generator it does not. CMake's Ninja generator is the difference: it preprocesses every Fortran source with `-cpp -E` to scan module dependencies before compiling. So `cmake -G Ninja` has failed on the first file it touches since the comment was written, while every Makefile build succeeded.

Nothing caught it because every job here configures with a bare `cmake -B build` and takes the default generator. `ninja` is in environment.yml, so this is a path people take -- it just was not a path CI took. The `with tblite (build only)` job now takes it, which is where a generator fault belongs and costs no extra runner.

The glob is reworded rather than escaped, and the reason is recorded next to it so it does not get written back the obvious way round. It is the only occurrence in the tree.