### PR TITLE
Let a deck say it is looking for a saddle, and read the result that way

### DIFF
--- a/mqc_docs/source/geometry_optimization.rst
+++ b/mqc_docs/source/geometry_optimization.rst
@@ -403,7 +403,8 @@ of the motion, which is the transfer.
 conjugate gradient and L-BFGS will report a minimum however the target is
 spelled, so the combination is a deck that cannot be satisfied rather than one
 that is satisfied slowly; use ``prfo``, or ``nr`` from a guess already near the
-ridge.
+ridge. This is refused whether the algorithm was named or left to the default,
+which is L-BFGS -- so a saddle search has to say which optimizer runs it.
 
 .. warning::
 
@@ -415,6 +416,13 @@ ridge.
    without converging while ``dlc`` converged in four. A deck that asks for both
    is warned; use ``dlc``, or ``hdlc`` for a cluster where plain DLC has no
    bonds to span the fragments.
+
+   ``cartesian`` is the *default* coordinate system, so this is what a saddle
+   search that never mentioned coordinates gets. The warning says so, and says
+   that the run will spend all of ``max_steps`` before giving up. It is a
+   warning rather than a refusal because a Cartesian saddle search can be made
+   to work, from a guess close enough that the reaction mode is already the
+   lowest eigenvalue, where a downhill algorithm cannot.
 
 .. _opt-constraints:
 

--- a/mqc_docs/source/geometry_optimization.rst
+++ b/mqc_docs/source/geometry_optimization.rst
@@ -275,6 +275,10 @@ All optional. Everything under ``keywords.optimization``:
      - engine
      - ``none``, ``powell``, ``bofill`` or ``auto``. Only the algorithms that
        hold a Hessian read it
+   * - ``target``
+     - ``minimum``
+     - ``minimum`` or ``saddle``. What the run is looking for, which decides
+       how ``hess_end`` reads its own result. See :ref:`saddle-search`
    * - ``frozen_atoms``
      - none
      - 0-based indices held at their input position. See :ref:`opt-constraints`
@@ -354,11 +358,63 @@ and an update thereafter, rather than a fresh one per step. ``bofill`` is the
 usual choice for a saddle point, because it does not assume the matrix is
 positive definite -- which at a transition state it is not.
 
+.. _saddle-search:
+
+Saying that a saddle is what you want
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 A P-RFO run converges on the same gradient criterion as a minimisation, so it
-tells you it found a stationary point and not what kind. Confirm it the same way
-you would a minimum, with a Hessian: exactly one imaginary frequency is a
-first-order saddle, and the mode it belongs to should be the one along the
-reaction coordinate.
+tells you it found a stationary point and not what kind. ``target`` says which
+kind was wanted, and ``hess_end`` then reads its own result against that::
+
+    "keywords": {
+      "optimization": {
+        "algorithm": "prfo",
+        "hessian_update": "bofill",
+        "coordinates": "dlc",
+        "target": "saddle",
+        "hess_end": true
+      }
+    }
+
+The curvature test does not change; which count is a pass does. With
+``target: "saddle"`` one imaginary frequency is success and is reported as
+such, no imaginary frequencies means the search fell off the ridge into a
+basin, and two or more means a higher-order stationary point that is not a
+transition state. With the default ``target: "minimum"`` those readings invert,
+which is the behaviour every existing deck already has.
+
+On success the imaginary mode is broken down by atom::
+
+    one imaginary frequency, 1245.77 cm-1: this is a first-order saddle point
+    the imaginary mode moves, most to least:
+       atom 3 H   85.7% of the motion
+       atom 2 C    7.7% of the motion
+       atom 1 N    6.6% of the motion
+
+That is the check no frequency count can make for you. One imaginary frequency
+proves a first-order saddle; it does not prove it is *your* saddle. A molecule
+has more than one and P-RFO finds whichever is nearest the guess, so the
+question is whether the mode moves the atoms whose bond is being made or
+broken. Above, on the ``HCN`` to ``HNC`` isomerisation, the hydrogen carries 86%
+of the motion, which is the transfer.
+
+``target: "saddle"`` is refused with a downhill algorithm. Steepest descent,
+conjugate gradient and L-BFGS will report a minimum however the target is
+spelled, so the combination is a deck that cannot be satisfied rather than one
+that is satisfied slowly; use ``prfo``, or ``nr`` from a guess already near the
+ridge.
+
+.. warning::
+
+   Do not run a saddle search in Cartesian coordinates. P-RFO maximises along
+   the lowest Hessian eigenvalue, and in Cartesians the lowest six modes are
+   translations and rotations -- so it follows a rotation instead of the
+   reaction mode and wanders. On the ``HCN``/``HNC`` saddle, from the same guess
+   and the same analytic Hessian, ``cartesian`` and ``hdlc`` both ran 60 steps
+   without converging while ``dlc`` converged in four. A deck that asks for both
+   is warned; use ``dlc``, or ``hdlc`` for a cluster where plain DLC has no
+   bonds to span the fragments.
 
 .. _opt-constraints:
 

--- a/src/io/mqc_config_adapter.f90
+++ b/src/io/mqc_config_adapter.f90
@@ -10,9 +10,11 @@ module mqc_config_adapter
    use mqc_calculation_keywords, only: hessian_keywords_t, aimd_keywords_t, scf_keywords_t
    use mqc_optimizer_types, only: optimizer_settings_t, &
                                   coordinates_from_string, algorithm_from_string, &
-                                  hessian_update_from_string, &
+                                  hessian_update_from_string, target_from_string, &
                                   OPT_COORDS_UNKNOWN, OPT_ALGO_UNKNOWN, &
-                                  OPT_HESSIAN_UPDATE_ENGINE
+                                  OPT_HESSIAN_UPDATE_ENGINE, OPT_TARGET_MINIMUM, &
+                                  OPT_TARGET_SADDLE, OPT_COORDS_CARTESIAN, &
+                                  algorithm_to_string, algorithm_finds_saddle
    use mqc_method_config, only: method_config_t
    use mqc_method_types, only: METHOD_TYPE_CCSD_T, METHOD_TYPE_GFN1, &
                                METHOD_TYPE_GFN2, METHOD_TYPE_EFP2
@@ -440,6 +442,50 @@ contains
                               "'. Use none, powell, bofill or auto.")
             end if
             return
+         end if
+      end if
+
+      if (allocated(mqc_config%opt_target)) then
+         driver_config%optimization%target = target_from_string(mqc_config%opt_target)
+         if (driver_config%optimization%target < OPT_TARGET_MINIMUM) then
+            if (present(error)) then
+               call error%set(ERROR_VALIDATION, &
+                              "Unknown keywords.optimization.target: '"// &
+                              trim(mqc_config%opt_target)// &
+                              "'. Use minimum or saddle.")
+            end if
+            return
+         end if
+      end if
+
+      ! A saddle is not something every algorithm can look for. Steepest
+      ! descent and the quasi-Newton minimisers go downhill by construction and
+      ! will report a minimum however the target is spelled, so asking them for
+      ! a saddle is a deck that cannot be satisfied rather than one that will
+      ! be satisfied slowly. Refused rather than silently switched: choosing an
+      ! optimizer on the user's behalf is how a run ends up being something
+      ! other than what was asked for.
+      if (driver_config%optimization%target == OPT_TARGET_SADDLE) then
+         if (.not. algorithm_finds_saddle(driver_config%optimization%algorithm)) then
+            if (present(error)) then
+               call error%set(ERROR_VALIDATION, &
+                              "keywords.optimization.target is 'saddle' but the algorithm is '"// &
+                              algorithm_to_string(driver_config%optimization%algorithm)// &
+                              "', which descends to a minimum. Use prfo, which "// &
+                              "maximises along one mode and minimises along the rest, or nr.")
+            end if
+            return
+         end if
+         ! Cartesian P-RFO maximises along the lowest eigenvalue, and in
+         ! Cartesian coordinates the lowest six are translations and rotations.
+         ! It follows one of those instead of the reaction mode and wanders. On
+         ! the HCN-HNC saddle that is 60 steps without converging in Cartesians
+         ! and four in DLC, from the same guess and the same Hessian.
+         if (driver_config%optimization%coordinates == OPT_COORDS_CARTESIAN) then
+            call logger%warning("  keywords.optimization: a saddle search in Cartesian "// &
+                                "coordinates follows a rotation, not the reaction mode.")
+            call logger%warning("     Use coordinates 'dlc' (or 'hdlc' for a cluster) "// &
+                                "unless you have a reason not to.")
          end if
       end if
 

--- a/src/io/mqc_config_adapter.f90
+++ b/src/io/mqc_config_adapter.f90
@@ -396,9 +396,12 @@ contains
       !! values may say belongs with the type that holds the constants. An
       !! unrecognised spelling is refused here by name, which is the only place
       !! that still has the string the user typed.
+      use pic_io, only: to_char
       type(mqc_config_t), intent(in) :: mqc_config
       type(driver_config_t), intent(inout) :: driver_config
       type(error_t), intent(inout), optional :: error
+
+      integer :: want
 
       if (allocated(mqc_config%opt_coordinates)) then
          driver_config%optimization%coordinates = &
@@ -445,9 +448,15 @@ contains
          end if
       end if
 
+      ! Parsed into a local and only then stored, which the siblings above do
+      ! not need to do: `error` is optional, and the callers that omit it -- the
+      ! session, the tests -- would otherwise carry the parse failure into the
+      ! driver, where a sentinel below OPT_TARGET_MINIMUM reads as "not a
+      ! saddle" and runs a minimisation. Refusing without `error` still has to
+      ! leave the default behind rather than a value nothing recognises.
       if (allocated(mqc_config%opt_target)) then
-         driver_config%optimization%target = target_from_string(mqc_config%opt_target)
-         if (driver_config%optimization%target < OPT_TARGET_MINIMUM) then
+         want = target_from_string(mqc_config%opt_target)
+         if (want < OPT_TARGET_MINIMUM) then
             if (present(error)) then
                call error%set(ERROR_VALIDATION, &
                               "Unknown keywords.optimization.target: '"// &
@@ -456,6 +465,7 @@ contains
             end if
             return
          end if
+         driver_config%optimization%target = want
       end if
 
       ! A saddle is not something every algorithm can look for. Steepest
@@ -468,11 +478,25 @@ contains
       if (driver_config%optimization%target == OPT_TARGET_SADDLE) then
          if (.not. algorithm_finds_saddle(driver_config%optimization%algorithm)) then
             if (present(error)) then
-               call error%set(ERROR_VALIDATION, &
-                              "keywords.optimization.target is 'saddle' but the algorithm is '"// &
-                              algorithm_to_string(driver_config%optimization%algorithm)// &
-                              "', which descends to a minimum. Use prfo, which "// &
-                              "maximises along one mode and minimises along the rest, or nr.")
+               ! Named or defaulted, said differently. A deck with no
+               ! `algorithm` key at all gets the default, and a message that
+               ! quotes it back as though the user had chosen it sends them
+               ! looking for a line their file does not contain.
+               if (allocated(mqc_config%opt_algorithm)) then
+                  call error%set(ERROR_VALIDATION, &
+                                 "keywords.optimization.target is 'saddle' but the algorithm is '"// &
+                                 algorithm_to_string(driver_config%optimization%algorithm)// &
+                                 "', which descends to a minimum. Use prfo, which "// &
+                                 "maximises along one mode and minimises along the rest, or nr.")
+               else
+                  call error%set(ERROR_VALIDATION, &
+                                 "keywords.optimization.target is 'saddle' but no algorithm was "// &
+                                 "named, so the default '"// &
+                                 algorithm_to_string(driver_config%optimization%algorithm)// &
+                                 "' applies, and it descends to a minimum. Set "// &
+                                 "keywords.optimization.algorithm to prfo, which maximises along "// &
+                                 "one mode and minimises along the rest, or nr.")
+               end if
             end if
             return
          end if
@@ -481,9 +505,25 @@ contains
          ! It follows one of those instead of the reaction mode and wanders. On
          ! the HCN-HNC saddle that is 60 steps without converging in Cartesians
          ! and four in DLC, from the same guess and the same Hessian.
+         ! Warned rather than refused, because a Cartesian saddle search is a
+         ! deck that can be satisfied -- from a guess close enough that the
+         ! reaction mode is already the lowest eigenvalue -- where a downhill
+         ! algorithm is one that cannot. But Cartesian is the default
+         ! coordinate system, so a deck that simply never mentioned coordinates
+         ! lands here, which is why the warning says what it will cost rather
+         ! than only what it is.
          if (driver_config%optimization%coordinates == OPT_COORDS_CARTESIAN) then
-            call logger%warning("  keywords.optimization: a saddle search in Cartesian "// &
-                                "coordinates follows a rotation, not the reaction mode.")
+            if (allocated(mqc_config%opt_coordinates)) then
+               call logger%warning("  keywords.optimization: a saddle search in Cartesian "// &
+                                   "coordinates follows a rotation, not the reaction mode.")
+            else
+               call logger%warning("  keywords.optimization: no coordinates were named, so this "// &
+                                   "saddle search runs in Cartesians, where it follows a "// &
+                                   "rotation rather than the reaction mode.")
+            end if
+            call logger%warning("     Expect it to wander for all "// &
+                                to_char(driver_config%optimization%max_steps)// &
+                                " steps without converging.")
             call logger%warning("     Use coordinates 'dlc' (or 'hdlc' for a cluster) "// &
                                 "unless you have a reason not to.")
          end if

--- a/src/io/mqc_config_types.f90
+++ b/src/io/mqc_config_types.f90
@@ -417,6 +417,7 @@ module mqc_config_types
       logical :: opt_freeze_terms = .true.             !! Fix the MBE term list for the run
       logical :: opt_hess_end = .false.                !! Hessian at the converged geometry
       character(len=:), allocatable :: opt_hessian_update  !! none, powell, bofill, auto
+      character(len=:), allocatable :: opt_target  !! minimum or saddle
       real(dp) :: opt_timestep = -1.0_dp               !! Damped dynamics step
       real(dp) :: opt_friction = -1.0_dp               !! Damped dynamics start friction
       real(dp) :: opt_friction_factor = -1.0_dp        !! Friction decay while descending

--- a/src/io/mqc_json_config_reader.f90
+++ b/src/io/mqc_json_config_reader.f90
@@ -421,6 +421,7 @@ contains
       call optional_logical(json, "keywords.optimization.hess_end", config%opt_hess_end)
       call optional_string(json, "keywords.optimization.hessian_update", &
                            config%opt_hessian_update)
+      call optional_string(json, "keywords.optimization.target", config%opt_target)
       call optional_real(json, "keywords.optimization.timestep", config%opt_timestep)
       call optional_real(json, "keywords.optimization.friction", config%opt_friction)
       call optional_real(json, "keywords.optimization.friction_factor", &

--- a/src/io/mqc_json_schema.f90
+++ b/src/io/mqc_json_schema.f90
@@ -510,6 +510,7 @@ contains
       call allow(keys, "freeze_terms")
       call allow(keys, "hess_end")
       call allow(keys, "hessian_update")
+      call allow(keys, "target")
       call allow(keys, "frozen_atoms")
       call allow(keys, "constraints")
       call allow(keys, "timestep")

--- a/src/optimization/mqc_geometry_optimizer.f90
+++ b/src/optimization/mqc_geometry_optimizer.f90
@@ -44,6 +44,16 @@ module mqc_geometry_optimizer
                                       write_trajectory_xyz
    use mqc_frag_utils, only: generate_mbe_term_list
    implicit none
+
+   real(dp), parameter :: ZERO_FREQ_CM = 10.0_dp
+      !! Below this a mode is translation or rotation rather than a vibration,
+      !! and the same number the analysis prints its own summary against.
+   integer, parameter :: MAX_REACTION_MODE_ATOMS = 6
+      !! How many atoms of the imaginary mode to name. A reaction coordinate is
+      !! carried by a few atoms; listing all of them buries the few.
+   real(dp), parameter :: REACTION_MODE_FLOOR = 0.02_dp
+      !! Stop listing once an atom carries under 2% of the motion.
+   integer, parameter :: LINE_LEN = 256
    private
 
    public :: run_geometry_optimization
@@ -274,7 +284,7 @@ contains
             ! not the minimum, and reporting it beside a "did not converge"
             ! line invites it to be read as the minimum's.
             if (config%optimization%hess_end .and. converged .and. .not. error%has_error()) then
-               call run_final_hessian(sys_geom)
+               call run_final_hessian(sys_geom, config%optimization%target)
             end if
             if (.not. converged .and. .not. error%has_error()) then
                call error%set(ERROR_GENERIC, &
@@ -638,7 +648,7 @@ contains
                    .and. .not. config%method_config%scf%unrestricted
    end function is_restricted_hf
 
-   subroutine run_final_hessian(sys_geom)
+   subroutine run_final_hessian(sys_geom, target)
       !! A Hessian at the converged geometry, and the verdict it settles
       !!
       !! **What this is for.** A minimiser stops on the gradient, and a
@@ -656,11 +666,11 @@ contains
       !! written `output_<name>.json` and rewriting it here would replace that
       !! document with a different one after the fact.
       use mqc_vibrational_analysis, only: compute_vibrational_analysis
+      use mqc_optimizer_types, only: OPT_TARGET_SADDLE
       type(system_geometry_t), intent(in) :: sys_geom
-
-      !! Below this a mode is translation or rotation rather than a vibration,
-      !! and the same number the analysis prints its own summary against.
-      real(dp), parameter :: ZERO_FREQ_CM = 10.0_dp
+      integer, intent(in) :: target
+         !! What was being looked for. The curvature test is the same either
+         !! way; which count is the pass is not.
 
       type(calculation_result_t) :: result
       type(driver_config_t) :: hess_config
@@ -714,18 +724,107 @@ contains
          end if
       end do
 
-      if (n_imag == 0) then
-         call logger%info("  no imaginary frequencies: this is a minimum")
-      else if (n_imag == 1) then
-         call logger%warning("  one imaginary frequency, "//to_char(abs(worst))// &
-                             " cm-1: this is a first-order saddle point, not a minimum")
+      ! The same three cases, read against what was asked for. A first-order
+      ! saddle is the failure when a minimum was wanted and the success when it
+      ! was not, so the branch that changes is which one is logged as a warning.
+      if (target == OPT_TARGET_SADDLE) then
+         if (n_imag == 1) then
+            call logger%info("  one imaginary frequency, "//to_char(abs(worst))// &
+                             " cm-1: this is a first-order saddle point")
+            call report_reaction_mode(frequencies, cart_disp, sys_geom)
+         else if (n_imag == 0) then
+            call logger%warning("  no imaginary frequencies: this is a minimum, not a "// &
+                                "saddle. The search fell off the ridge -- start closer "// &
+                                "to the barrier, or use a path method to find a guess.")
+         else
+            call logger%warning("  "//to_char(n_imag)//" imaginary frequencies, the largest "// &
+                                to_char(abs(worst))//" cm-1: this is a stationary point of "// &
+                                "order "//to_char(n_imag)//", not a transition state")
+         end if
       else
-         call logger%warning("  "//to_char(n_imag)//" imaginary frequencies, the largest "// &
-                             to_char(abs(worst))//" cm-1: this is not a minimum")
+         if (n_imag == 0) then
+            call logger%info("  no imaginary frequencies: this is a minimum")
+         else if (n_imag == 1) then
+            call logger%warning("  one imaginary frequency, "//to_char(abs(worst))// &
+                                " cm-1: this is a first-order saddle point, not a minimum")
+         else
+            call logger%warning("  "//to_char(n_imag)//" imaginary frequencies, the largest "// &
+                                to_char(abs(worst))//" cm-1: this is not a minimum")
+         end if
       end if
       call logger%info(" ")
 
    end subroutine run_final_hessian
+
+   subroutine report_reaction_mode(frequencies, cart_disp, sys_geom)
+      !! Name the atoms the imaginary mode actually moves
+      !!
+      !! One imaginary frequency proves a first-order saddle. It does not prove
+      !! it is the saddle anybody wanted: the same molecule has more than one,
+      !! and P-RFO finds whichever is nearest the guess. What separates them is
+      !! which atoms move along the mode, and that is a chemist's judgement made
+      !! on a handful of numbers -- so the numbers are printed rather than left
+      !! in an eigenvector nothing displays.
+      !!
+      !! Displacements are ranked by the norm of each atom's own three
+      !! components, and the list stops once the remaining atoms carry little
+      !! enough to be noise. A transition state whose largest displacements are
+      !! not on the bond being made or broken is the wrong one, and that is
+      !! visible in three lines.
+      real(dp), intent(in) :: frequencies(:)
+      real(dp), intent(in) :: cart_disp(:, :)
+         !! `(3N, mode)`, Cartesian, one column per mode
+      type(system_geometry_t), intent(in) :: sys_geom
+
+      real(dp), allocatable :: amplitude(:)
+      integer, allocatable :: order(:)
+      integer :: n_atoms, k, imode, i, j, swap
+      real(dp) :: total
+      character(len=LINE_LEN) :: line
+
+      imode = 0
+      do k = 1, size(frequencies)
+         if (frequencies(k) < -ZERO_FREQ_CM) then
+            imode = k
+            exit
+         end if
+      end do
+      if (imode == 0) return
+      if (size(cart_disp, 2) < imode) return
+
+      n_atoms = size(sys_geom%element_numbers)
+      if (size(cart_disp, 1) < 3*n_atoms) return
+
+      allocate (amplitude(n_atoms), order(n_atoms))
+      do i = 1, n_atoms
+         amplitude(i) = norm2(cart_disp(3*i - 2:3*i, imode))
+         order(i) = i
+      end do
+      total = sum(amplitude)
+      if (total <= 0.0_dp) return
+
+      ! A selection sort over the atom count, which is the right algorithm here:
+      ! this runs once per optimization and the list printed is a handful long.
+      do i = 1, n_atoms - 1
+         do j = i + 1, n_atoms
+            if (amplitude(order(j)) > amplitude(order(i))) then
+               swap = order(i)
+               order(i) = order(j)
+               order(j) = swap
+            end if
+         end do
+      end do
+
+      call logger%info("  the imaginary mode moves, most to least:")
+      do k = 1, min(n_atoms, MAX_REACTION_MODE_ATOMS)
+         i = order(k)
+         if (amplitude(i)/total < REACTION_MODE_FLOOR) exit
+         write (line, "(a,i0,a,a,a,f5.1,a)") "     atom ", i, " ", &
+            trim(element_number_to_symbol(sys_geom%element_numbers(i))), &
+            "  ", 100.0_dp*amplitude(i)/total, "% of the motion"
+         call logger%info(trim(line))
+      end do
+   end subroutine report_reaction_mode
 
    subroutine record_step(n_atoms, coords, energy)
       !! Keep one accepted geometry, growing the trajectory to fit

--- a/src/optimization/mqc_geometry_optimizer.f90
+++ b/src/optimization/mqc_geometry_optimizer.f90
@@ -48,6 +48,12 @@ module mqc_geometry_optimizer
    real(dp), parameter :: ZERO_FREQ_CM = 10.0_dp
       !! Below this a mode is translation or rotation rather than a vibration,
       !! and the same number the analysis prints its own summary against.
+   real(dp), parameter :: NOISE_FREQ_CM = 0.1_dp
+      !! Under this a negative frequency is arithmetic, not physics: projection
+      !! zeroes the translation and rotation rows of the mass-weighted Hessian,
+      !! and their eigenvalues come back on either side of zero at the level of
+      !! rounding. Only negatives above this are worth mentioning as possibly
+      !! being a very flat mode.
    integer, parameter :: MAX_REACTION_MODE_ATOMS = 6
       !! How many atoms of the imaginary mode to name. A reaction coordinate is
       !! carried by a few atoms; listing all of them buries the few.
@@ -648,7 +654,7 @@ contains
                    .and. .not. config%method_config%scf%unrestricted
    end function is_restricted_hf
 
-   subroutine run_final_hessian(sys_geom, target)
+   subroutine run_final_hessian(sys_geom, want)
       !! A Hessian at the converged geometry, and the verdict it settles
       !!
       !! **What this is for.** A minimiser stops on the gradient, and a
@@ -668,9 +674,12 @@ contains
       use mqc_vibrational_analysis, only: compute_vibrational_analysis
       use mqc_optimizer_types, only: OPT_TARGET_SADDLE
       type(system_geometry_t), intent(in) :: sys_geom
-      integer, intent(in) :: target
+      integer, intent(in) :: want
          !! What was being looked for. The curvature test is the same either
-         !! way; which count is the pass is not.
+         !! way; which count is the pass is not. Named `want` rather than
+         !! `target` so that it does not shadow the Fortran attribute of that
+         !! name; the config component it comes from keeps the keyword's own
+         !! spelling.
 
       type(calculation_result_t) :: result
       type(driver_config_t) :: hess_config
@@ -678,7 +687,7 @@ contains
       real(dp), allocatable :: frequencies(:), reduced_masses(:), force_constants(:)
       real(dp), allocatable :: cart_disp(:, :)
       integer :: k, n_imag
-      real(dp) :: worst
+      real(dp) :: worst, softest
 
       call logger%info(" ")
       call logger%info("  Hessian at the converged geometry (keywords.optimization.hess_end)")
@@ -717,17 +726,24 @@ contains
       ! complex number, which is why this is a comparison and not an `aimag`.
       n_imag = 0
       worst = 0.0_dp
+      softest = 0.0_dp
       do k = 1, size(frequencies)
          if (frequencies(k) < -ZERO_FREQ_CM) then
             n_imag = n_imag + 1
             worst = min(worst, frequencies(k))
+         else if (frequencies(k) < -NOISE_FREQ_CM) then
+            ! Negative, but under the floor that separates a vibration from a
+            ! projected translation. Kept because a very flat saddle looks
+            ! exactly like this, and reporting it as a minimum without saying
+            ! so is the one way this check can mislead.
+            softest = min(softest, frequencies(k))
          end if
       end do
 
       ! The same three cases, read against what was asked for. A first-order
       ! saddle is the failure when a minimum was wanted and the success when it
       ! was not, so the branch that changes is which one is logged as a warning.
-      if (target == OPT_TARGET_SADDLE) then
+      if (want == OPT_TARGET_SADDLE) then
          if (n_imag == 1) then
             call logger%info("  one imaginary frequency, "//to_char(abs(worst))// &
                              " cm-1: this is a first-order saddle point")
@@ -736,6 +752,13 @@ contains
             call logger%warning("  no imaginary frequencies: this is a minimum, not a "// &
                                 "saddle. The search fell off the ridge -- start closer "// &
                                 "to the barrier, or use a path method to find a guess.")
+            if (softest < 0.0_dp) then
+               call logger%warning("     but the lowest mode is "//to_char(abs(softest))// &
+                                   " cm-1 imaginary, under the floor that separates a "// &
+                                   "vibration from a projected translation. A very flat "// &
+                                   "saddle looks exactly like this, so read the frequency "// &
+                                   "table before taking the verdict above.")
+            end if
          else
             call logger%warning("  "//to_char(n_imag)//" imaginary frequencies, the largest "// &
                                 to_char(abs(worst))//" cm-1: this is a stationary point of "// &
@@ -815,7 +838,10 @@ contains
          end do
       end do
 
-      call logger%info("  the imaginary mode moves, most to least:")
+      ! Atoms are numbered from one, as everywhere else in this log. A deck
+      ! counts from zero, so the two differ by one and saying which this is
+      ! saves the reader checking against their own `frozen_atoms` list.
+      call logger%info("  the imaginary mode moves, most to least (atoms numbered from 1):")
       do k = 1, min(n_atoms, MAX_REACTION_MODE_ATOMS)
          i = order(k)
          if (amplitude(i)/total < REACTION_MODE_FLOOR) exit

--- a/src/optimization/mqc_optimizer_types.f90
+++ b/src/optimization/mqc_optimizer_types.f90
@@ -388,27 +388,31 @@ contains
       can = algorithm == OPT_ALGO_PRFO .or. algorithm == OPT_ALGO_NR
    end function algorithm_finds_saddle
 
-   pure function target_from_string(text) result(target)
+   pure function target_from_string(text) result(want)
       !! Parse what the deck says it is looking for
+      !!
+      !! The result is `want` and not `target`: the component these two read
+      !! and write keeps the keyword's own spelling, but a local of that name
+      !! shadows the Fortran attribute, which is legal and reads badly.
       character(len=*), intent(in) :: text
-      integer :: target
+      integer :: want
 
       select case (lowercase(text))
       case ("minimum", "min")
-         target = OPT_TARGET_MINIMUM
+         want = OPT_TARGET_MINIMUM
       case ("saddle", "ts", "transition_state", "transition-state")
-         target = OPT_TARGET_SADDLE
+         want = OPT_TARGET_SADDLE
       case default
-         target = -2   ! not a spelling anybody recognises
+         want = -2   ! not a spelling anybody recognises
       end select
    end function target_from_string
 
-   pure function target_to_string(target) result(text)
+   pure function target_to_string(want) result(text)
       !! Name a target, for the log
-      integer, intent(in) :: target
+      integer, intent(in) :: want
       character(len=:), allocatable :: text
 
-      select case (target)
+      select case (want)
       case (OPT_TARGET_MINIMUM)
          text = "minimum"
       case (OPT_TARGET_SADDLE)

--- a/src/optimization/mqc_optimizer_types.f90
+++ b/src/optimization/mqc_optimizer_types.f90
@@ -39,6 +39,8 @@ module mqc_optimizer_types
    public :: algorithm_from_string, algorithm_to_string
    public :: hessian_update_from_string, hessian_update_to_string
    public :: constraint_from_string, constraint_atom_count
+   public :: OPT_TARGET_MINIMUM, OPT_TARGET_SADDLE
+   public :: target_from_string, target_to_string, algorithm_finds_saddle
    public :: algorithm_needs_hessian
 
    ! This program's own numbering rather than DL-FIND's, even though DL-FIND is
@@ -86,6 +88,17 @@ module mqc_optimizer_types
       !! Damped molecular dynamics. Not a minimiser in the line-search sense:
       !! it integrates motion and bleeds energy out through a friction term, so
       !! it crosses small barriers a downhill method would stop at.
+
+   ! What the optimization is looking for. Not the same question as which
+   ! algorithm runs: P-RFO can be asked for either, and a Newton-Raphson run
+   ! settles on whatever stationary point it started nearest. Naming the target
+   ! separately is what lets the end-of-run Hessian say whether the thing found
+   ! is the thing wanted, rather than always reporting against "minimum".
+   integer, parameter :: OPT_TARGET_MINIMUM = 0
+   integer, parameter :: OPT_TARGET_SADDLE = 1
+      !! A first-order saddle: one imaginary frequency, and exactly one. Zero
+      !! means the search fell off the ridge into a basin; two or more means it
+      !! is a higher-order stationary point and not a transition state.
 
    ! How the engine carries curvature between steps once it has a Hessian.
    ! Only the algorithms that hold one pay attention to this.
@@ -142,6 +155,9 @@ module mqc_optimizer_types
          !! Choose the MBE term list once, at the starting geometry, and keep
          !! it for every step. See `mqc_geometry_optimizer` for why an
          !! optimization on a re-screened list is optimizing a moving target.
+      integer :: target = OPT_TARGET_MINIMUM
+         !! Whether this run is looking for a minimum or a first-order saddle.
+         !! Independent of `algorithm` on purpose -- see `OPT_TARGET_SADDLE`.
       integer :: hessian_update = OPT_HESSIAN_UPDATE_ENGINE
          !! How curvature is carried between steps once a Hessian exists.
          !! Ignored by the algorithms that never build one.
@@ -356,6 +372,51 @@ contains
 
       needs = algorithm == OPT_ALGO_PRFO .or. algorithm == OPT_ALGO_NR
    end function algorithm_needs_hessian
+
+   pure function algorithm_finds_saddle(algorithm) result(can)
+      !! Whether this algorithm can converge on a first-order saddle
+      !!
+      !! P-RFO by construction -- it maximises along one eigenvector and
+      !! minimises along the others. Newton-Raphson because it seeks a
+      !! vanishing gradient and does not care about the curvature it lands in,
+      !! so from a guess near the ridge it will settle there. Everything else
+      !! here goes downhill and will find a minimum however the deck spells the
+      !! target.
+      integer, intent(in) :: algorithm
+      logical :: can
+
+      can = algorithm == OPT_ALGO_PRFO .or. algorithm == OPT_ALGO_NR
+   end function algorithm_finds_saddle
+
+   pure function target_from_string(text) result(target)
+      !! Parse what the deck says it is looking for
+      character(len=*), intent(in) :: text
+      integer :: target
+
+      select case (lowercase(text))
+      case ("minimum", "min")
+         target = OPT_TARGET_MINIMUM
+      case ("saddle", "ts", "transition_state", "transition-state")
+         target = OPT_TARGET_SADDLE
+      case default
+         target = -2   ! not a spelling anybody recognises
+      end select
+   end function target_from_string
+
+   pure function target_to_string(target) result(text)
+      !! Name a target, for the log
+      integer, intent(in) :: target
+      character(len=:), allocatable :: text
+
+      select case (target)
+      case (OPT_TARGET_MINIMUM)
+         text = "minimum"
+      case (OPT_TARGET_SADDLE)
+         text = "saddle"
+      case default
+         text = "unknown"
+      end select
+   end function target_to_string
 
    pure function hessian_update_from_string(text) result(update)
       !! Parse the Hessian update scheme a deck asked for

--- a/src/vibrational/mqc_vibrational_analysis.f90
+++ b/src/vibrational/mqc_vibrational_analysis.f90
@@ -55,7 +55,10 @@ contains
       integer, intent(in) :: element_numbers(:)
          !! Atomic numbers for each atom (N atoms)
       real(dp), allocatable, intent(out) :: frequencies(:)
-         !! Vibrational frequencies in cm⁻¹ (3*N modes, or 3*N-6 if projected)
+         !! Vibrational frequencies in cm⁻¹. Always 3*N of them: projection
+         !! zeroes the translation and rotation modes rather than removing
+         !! them, so those come back at (or within rounding of) zero and the
+         !! array keeps its length either way.
       real(dp), allocatable, intent(out), optional :: eigenvalues_out(:)
          !! Raw eigenvalues from diagonalization (Hartree/Bohr²/amu)
       real(dp), allocatable, intent(out), optional :: eigenvectors(:, :)

--- a/test/test_mqc_config_adapter.f90
+++ b/test/test_mqc_config_adapter.f90
@@ -2,8 +2,9 @@ module test_mqc_config_adapter
    use testdrive, only: new_unittest, unittest_type, error_type, check
    use mqc_config_types, only: input_fragment_t, mqc_config_t
    use mqc_config_adapter, only: check_fragment_overlap, config_to_driver, driver_config_t
+   use mqc_optimizer_types, only: OPT_TARGET_MINIMUM, OPT_TARGET_SADDLE
    use mqc_method_types, only: METHOD_TYPE_GFN2
-   use mqc_calc_types, only: CALC_TYPE_ENERGY
+   use mqc_calc_types, only: CALC_TYPE_ENERGY, CALC_TYPE_OPTIMIZE
    use mqc_error, only: error_t
    implicit none
    private
@@ -21,7 +22,10 @@ contains
                   new_unittest("overlap_detection", test_overlap_detected), &
                   new_unittest("single_fragment_no_overlap", test_single_fragment), &
                   new_unittest("driver_global_groups", test_driver_global_groups), &
-                  new_unittest("driver_nodes_per_group", test_driver_nodes_per_group) &
+                  new_unittest("driver_nodes_per_group", test_driver_nodes_per_group), &
+                  new_unittest("saddle_target_reaches_driver", test_saddle_target), &
+                  new_unittest("saddle_needs_a_saddle_algorithm", test_saddle_algorithm), &
+                  new_unittest("unknown_target_refused", test_unknown_target) &
                   ]
    end subroutine collect_mqc_config_adapter_tests
 
@@ -161,6 +165,93 @@ contains
 
       call check(error, driver_config%global_groups, 0, "global_groups should default to 0")
    end subroutine test_driver_nodes_per_group
+
+   subroutine optimize_config(config)
+      !! The smallest deck that reaches the optimization vocabulary
+      type(mqc_config_t), intent(out) :: config
+
+      config%method = METHOD_TYPE_GFN2
+      config%calc_type = CALC_TYPE_OPTIMIZE
+      config%nfrag = 0
+   end subroutine optimize_config
+
+   subroutine test_saddle_target(error)
+      !! A saddle target with an algorithm that can look for one
+      type(error_type), allocatable, intent(out) :: error
+      type(mqc_config_t) :: config
+      type(driver_config_t) :: driver_config
+      type(error_t) :: parse_error
+
+      call optimize_config(config)
+      config%opt_target = "saddle"
+      config%opt_algorithm = "prfo"
+      config%opt_coordinates = "dlc"
+
+      call config_to_driver(config, driver_config, error=parse_error)
+
+      call check(error,.not. parse_error%has_error(), parse_error%get_message())
+      if (allocated(error)) return
+      call check(error, driver_config%optimization%target, OPT_TARGET_SADDLE, &
+                 "the target should reach the driver")
+   end subroutine test_saddle_target
+
+   subroutine test_saddle_algorithm(error)
+      !! Asked for a saddle, given a downhill optimizer
+      !!
+      !! Both spellings of the deck: one that names L-BFGS and one that names
+      !! no algorithm at all and gets it as the default. The second is the case
+      !! worth pinning -- it is the deck a first-time user writes, and it has to
+      !! be refused rather than run to a minimum and reported as a saddle.
+      type(error_type), allocatable, intent(out) :: error
+      type(mqc_config_t) :: config
+      type(driver_config_t) :: driver_config
+      type(error_t) :: parse_error
+
+      call optimize_config(config)
+      config%opt_target = "saddle"
+      config%opt_algorithm = "lbfgs"
+
+      call config_to_driver(config, driver_config, error=parse_error)
+      call check(error, parse_error%has_error(), &
+                 "a saddle search with a downhill algorithm should be refused")
+      if (allocated(error)) return
+
+      call optimize_config(config)
+      config%opt_target = "saddle"
+
+      call config_to_driver(config, driver_config, error=parse_error)
+      call check(error, parse_error%has_error(), &
+                 "a saddle search with the default algorithm should be refused too")
+   end subroutine test_saddle_algorithm
+
+   subroutine test_unknown_target(error)
+      !! A target nobody recognises, with and without somewhere to report it
+      !!
+      !! The second half is the point. `error` is optional and the session
+      !! omits it, so a parse failure that was written into the driver anyway
+      !! would sit there as a sentinel below OPT_TARGET_MINIMUM and read as
+      !! "not a saddle" -- a minimisation, run silently, from a deck that asked
+      !! for something else.
+      type(error_type), allocatable, intent(out) :: error
+      type(mqc_config_t) :: config
+      type(driver_config_t) :: driver_config
+      type(error_t) :: parse_error
+
+      call optimize_config(config)
+      config%opt_target = "banana"
+
+      call config_to_driver(config, driver_config, error=parse_error)
+      call check(error, parse_error%has_error(), &
+                 "an unrecognised target should be refused by name")
+      if (allocated(error)) return
+
+      call optimize_config(config)
+      config%opt_target = "banana"
+
+      call config_to_driver(config, driver_config)
+      call check(error, driver_config%optimization%target, OPT_TARGET_MINIMUM, &
+                 "a target that failed to parse must not reach the driver")
+   end subroutine test_unknown_target
 
 end module test_mqc_config_adapter
 

--- a/test/test_mqc_json_reader.f90
+++ b/test/test_mqc_json_reader.f90
@@ -84,6 +84,7 @@ contains
                   new_unittest("ormas_partition", test_ormas_keywords), &
                   new_unittest("full_valence_space", test_full_valence), &
                   new_unittest("optimization_hess_end", test_hess_end), &
+                  new_unittest("optimization_target", test_opt_target), &
                   new_unittest("error_malformed_json", test_malformed) &
                   ]
    end subroutine collect_mqc_json_reader_tests
@@ -1612,6 +1613,54 @@ contains
       call check(error,.not. config%opt_hess_end, &
                  "a deck that never asked should not get a Hessian")
    end subroutine test_hess_end
+
+   subroutine test_opt_target(error)
+      !! `keywords.optimization.target`, through the reader and the schema
+      !!
+      !! The key has to survive three separate gates before it means anything:
+      !! the schema allow-list, which refuses what it does not know; the
+      !! reader, which puts the string on the config; and the default, which
+      !! stays unallocated when nothing asked, so the type's own
+      !! `OPT_TARGET_MINIMUM` is what an existing deck still gets. The
+      !! vocabulary itself is checked in `test_mqc_optimizer_types`; what is
+      !! checked here is that the string arrives at all.
+      type(error_type), allocatable, intent(out) :: error
+      type(mqc_config_t) :: config
+      type(error_t) :: parse_error
+
+      call write_deck('"method": "hf", "basis": "sto-3g"', "Optimize", &
+                      '"optimization": {"target": "saddle", "algorithm": "prfo", '// &
+                      '"coordinates": "dlc"}', "", two_atoms())
+      call read_deck(config, parse_error)
+      call check(error,.not. parse_error%has_error(), parse_error%get_message())
+      if (allocated(error)) return
+      call check(error, allocated(config%opt_target), "the target should be read")
+      if (allocated(error)) return
+      call check(error, trim(config%opt_target) == "saddle", &
+                 "the target should arrive as it was spelled")
+      if (allocated(error)) return
+
+      ! Not mentioned. `optional_string` leaves the component unallocated, and
+      ! the adapter only assigns when it is allocated -- which is what keeps
+      ! every optimization written before this keyword existed a minimisation.
+      call write_deck('"method": "hf", "basis": "sto-3g"', "Optimize", &
+                      '"optimization": {"max_steps": 50}', "", two_atoms())
+      call read_deck(config, parse_error)
+      call check(error,.not. parse_error%has_error(), parse_error%get_message())
+      if (allocated(error)) return
+      call check(error,.not. allocated(config%opt_target), &
+                 "a deck that never asked should leave the target to its default")
+      if (allocated(error)) return
+
+      ! The schema gate. A misspelled key inside the optimization block is
+      ! refused before the reader sees it, so a typo cannot silently become a
+      ! minimisation reported as a saddle search.
+      call write_deck('"method": "hf", "basis": "sto-3g"', "Optimize", &
+                      '"optimization": {"targett": "saddle"}', "", two_atoms())
+      call read_deck(config, parse_error)
+      call check(error, parse_error%has_error(), &
+                 "a misspelled optimization key should be refused")
+   end subroutine test_opt_target
 
    subroutine test_full_valence(error)
       !! `keywords.mcscf.full_valence`, and that it is the only space named

--- a/test/test_mqc_optimizer_types.f90
+++ b/test/test_mqc_optimizer_types.f90
@@ -19,7 +19,10 @@ module test_mqc_optimizer_types
                                   hessian_update_from_string, &
                                   OPT_HESSIAN_UPDATE_ENGINE, OPT_HESSIAN_UPDATE_NONE, &
                                   OPT_HESSIAN_UPDATE_POWELL, OPT_HESSIAN_UPDATE_BOFILL, &
-                                  constraint_from_string, constraint_atom_count
+                                  constraint_from_string, constraint_atom_count, &
+                                  target_from_string, target_to_string, &
+                                  algorithm_finds_saddle, &
+                                  OPT_TARGET_MINIMUM, OPT_TARGET_SADDLE
    use mqc_calc_types, only: calc_type_from_string, calc_type_to_string, CALC_TYPE_OPTIMIZE
    use pic_types, only: dp
    implicit none
@@ -43,9 +46,80 @@ contains
                   new_unittest("optimize_driver_parses", test_optimize_driver_parses), &
                   new_unittest("new_algorithms_parse", test_new_algorithms), &
                   new_unittest("hessian_update_parses", test_hessian_update), &
-                  new_unittest("constraint_atom_counts", test_constraint_atoms) &
+                  new_unittest("constraint_atom_counts", test_constraint_atoms), &
+                  new_unittest("target_parses", test_target_parses), &
+                  new_unittest("target_roundtrip", test_target_roundtrip), &
+                  new_unittest("target_defaults_to_minimum", test_target_default), &
+                  new_unittest("only_saddle_capable_algorithms", test_saddle_capable) &
                   ]
    end subroutine collect_mqc_optimizer_types_tests
+
+   subroutine test_target_parses(error)
+      !! Every spelling a deck is likely to use, and one it is not
+      type(error_type), allocatable, intent(out) :: error
+
+      call check(error, target_from_string("minimum") == OPT_TARGET_MINIMUM)
+      if (allocated(error)) return
+      call check(error, target_from_string("min") == OPT_TARGET_MINIMUM)
+      if (allocated(error)) return
+      call check(error, target_from_string("saddle") == OPT_TARGET_SADDLE)
+      if (allocated(error)) return
+      call check(error, target_from_string("ts") == OPT_TARGET_SADDLE)
+      if (allocated(error)) return
+      call check(error, target_from_string("transition_state") == OPT_TARGET_SADDLE)
+      if (allocated(error)) return
+      call check(error, target_from_string("SADDLE") == OPT_TARGET_SADDLE, &
+                 "the target should be case-insensitive like its siblings")
+      if (allocated(error)) return
+      ! Negative rather than a default. A misspelled target that quietly became
+      ! "minimum" would run a completely different calculation from the one
+      ! asked for and report success.
+      call check(error, target_from_string("banana") < OPT_TARGET_MINIMUM, &
+                 "an unrecognised target must not fall back to a valid one")
+   end subroutine test_target_parses
+
+   subroutine test_target_roundtrip(error)
+      type(error_type), allocatable, intent(out) :: error
+
+      call check(error, target_from_string(target_to_string(OPT_TARGET_MINIMUM)) == &
+                 OPT_TARGET_MINIMUM)
+      if (allocated(error)) return
+      call check(error, target_from_string(target_to_string(OPT_TARGET_SADDLE)) == &
+                 OPT_TARGET_SADDLE)
+   end subroutine test_target_roundtrip
+
+   subroutine test_target_default(error)
+      !! An optimization nobody said anything about is a minimisation
+      type(error_type), allocatable, intent(out) :: error
+      type(optimizer_settings_t) :: settings
+
+      call check(error, settings%target == OPT_TARGET_MINIMUM, &
+                 "the default target must stay 'minimum'; every existing deck relies on it")
+   end subroutine test_target_default
+
+   subroutine test_saddle_capable(error)
+      !! Which algorithms can be asked for a saddle
+      !!
+      !! The downhill methods are the point of this test. Asking steepest
+      !! descent for a transition state is a deck that cannot be satisfied, and
+      !! it has to be refused rather than run to a minimum and reported as one.
+      type(error_type), allocatable, intent(out) :: error
+
+      call check(error, algorithm_finds_saddle(OPT_ALGO_PRFO), &
+                 "P-RFO is the saddle optimizer")
+      if (allocated(error)) return
+      call check(error, algorithm_finds_saddle(OPT_ALGO_NR), &
+                 "Newton-Raphson seeks a stationary point of any curvature")
+      if (allocated(error)) return
+      call check(error,.not. algorithm_finds_saddle(OPT_ALGO_LBFGS))
+      if (allocated(error)) return
+      call check(error,.not. algorithm_finds_saddle(OPT_ALGO_SD))
+      if (allocated(error)) return
+      call check(error,.not. algorithm_finds_saddle(OPT_ALGO_CG))
+      if (allocated(error)) return
+      call check(error,.not. algorithm_finds_saddle(OPT_ALGO_DAMPED), &
+                 "damped dynamics crosses barriers; it does not stop on them")
+   end subroutine test_saddle_capable
 
    subroutine test_coordinates_from_string(error)
       type(error_type), allocatable, intent(out) :: error


### PR DESCRIPTION
An optimization could always run P-RFO, and since the DL-FIND upgrade it has had Bofill updates and an analytic Hessian to run it with. What it could not do is say that a transition state was the point — a saddle search was a minimisation with unusual keywords, and success was reported as a warning: "this is a first-order saddle point, not a minimum".

`keywords.optimization.target` names what is wanted, and `hess_end` reads its own result against it. The curvature test is unchanged; which count is the pass is not. Under `saddle`, one imaginary frequency is success, zero means the search fell into a basin, two or more is a higher-order stationary point. Under the default `minimum` everything reads as it did before.

Two refusals/warnings, both found by running it:

* A saddle target with a downhill algorithm (SD, CG, L-BFGS) is refused — those report a minimum however the target is spelled.
* A saddle search in Cartesians is warned about. P-RFO maximises along the lowest Hessian eigenvalue, and in Cartesians the lowest six are translations and rotations. On HCN/HNC from one guess and one analytic Hessian: cartesian 60 steps no convergence, hdlc 60 steps no convergence, dlc converged in four.

On success the imaginary mode is broken down by atom — one imaginary frequency proves a first-order saddle, not that it is the saddle anybody wanted. On HCN/HNC the hydrogen carries 85.7% of the motion.

**Verified**: HCN → HNC saddle at HF/6-31G, converged in four steps to one imaginary frequency at 1245.77 cm-1; C-N 1.187, H-C 1.210, H-N 1.400 Å.

---

**Stack** (merge bottom-up):

1. #292 `feat/ts-search` — target: saddle, and read the result that way
2. #293 `feat/ts-neb` — NEB band with climbing image
3. #294 `feat/ts-dimer` — dimer method, Hessian-free
4. #295 `feat/ts-connect` — walk off the saddle both ways
5. #296 `feat/ts-mode-following` — zero modes, so P-RFO stops climbing rotations

This PR is #1 of the stack; it is based on the one below it, so its diff is only its own commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ER5Y9FP9PEWpXLVcy1atuu
