### PR TITLE
Run a band between two structures, and let its climbing image find the top

### DIFF
--- a/backends/dlfind/mqc_dlfind_bridge.f90
+++ b/backends/dlfind/mqc_dlfind_bridge.f90
@@ -31,7 +31,8 @@ module mqc_dlfind_bridge
                                   OPT_ALGO_SD, OPT_ALGO_CG, OPT_ALGO_LBFGS, OPT_ALGO_PRFO, &
                                   OPT_ALGO_CG_AUTO, OPT_ALGO_NR, OPT_ALGO_DAMPED, &
                                   OPT_HESSIAN_UPDATE_ENGINE, hessian_i, &
-                                  algorithm_needs_hessian, constraint_atom_count
+                                  algorithm_needs_hessian, constraint_atom_count, &
+                                  NEB_ENDS_FREE, NEB_ENDS_PERPENDICULAR
    use mqc_error, only: error_t, ERROR_GENERIC, ERROR_VALIDATION
    implicit none
    private
@@ -47,6 +48,17 @@ module mqc_dlfind_bridge
    integer(c_int), parameter :: DLF_COORDS_DLC = 3
    integer(c_int), parameter :: DLF_COORDS_HDLC_TC = 2
    integer(c_int), parameter :: DLF_COORDS_DLC_TC = 4
+
+   ! Chain-of-states runs are selected through `icoord`, not through `iopt`:
+   ! DL-FIND reads the unit place as the coordinate system and the hundreds and
+   ! tens as what the band is. 10X is NEB with free endpoints, 11X endpoints
+   ! moving only perpendicular to their tangent, 12X frozen endpoints. 190 is
+   ! not NEB at all -- it is the quantum transition state search -- which is why
+   ! the offsets stop at 120 and are added to a unit place rather than used
+   ! whole. The implementation is improved-tangent NEB with a climbing image.
+   integer(c_int), parameter :: DLF_NEB_ENDS_FREE = 100
+   integer(c_int), parameter :: DLF_NEB_ENDS_PERPENDICULAR = 110
+   integer(c_int), parameter :: DLF_NEB_ENDS_FROZEN = 120
 
    integer(c_int), parameter :: DLF_OPT_SD = 0
    integer(c_int), parameter :: DLF_OPT_CG_AUTO = 1
@@ -85,6 +97,10 @@ module mqc_dlfind_bridge
    integer, allocatable, save :: atomic_numbers(:)
    integer, allocatable, save :: atom_residues(:)
    real(dp), allocatable, save :: initial_coords(:, :)
+   real(dp), allocatable, save :: endpoint_coords(:, :)
+      !! The second structure of a chain-of-states run, held here for the same
+      !! reason the geometry is: `cb_get_params` is a C callback and takes no
+      !! context of its own.
    real(dp), allocatable, save :: latest_coords(:, :)
    real(dp), save :: latest_energy = 0.0_dp
    logical, save :: have_result = .false.
@@ -122,7 +138,7 @@ contains
 
    subroutine dlfind_optimize(opt_settings, natoms, znuc, residues, coords, &
                               energy_gradient, step_taken, final_energy, error, &
-                              hessian)
+                              hessian, endpoint)
       !! Minimize `coords` in place, calling `energy_gradient` for each geometry
       !!
       !! Coordinates are Bohr in and Bohr out. On success `coords` holds the
@@ -142,12 +158,15 @@ contains
       real(dp), intent(out) :: final_energy
       type(error_t), intent(inout) :: error
       procedure(hessian_i), optional :: hessian
+      real(dp), intent(in), optional :: endpoint(:, :)
+         !! The product geometry, Bohr, same atom order as `coords`. Present
+         !! turns this into a chain-of-states run.
          !! Second derivatives, for the algorithms that climb rather than
          !! descend. Absent is not a refusal: DL-FIND falls back to two-point
          !! finite differences of the gradients it is already asking for, which
          !! costs `6N` of them per Hessian and gets the same answer.
 
-      integer(c_int) :: nvar, nspec
+      integer(c_int) :: nvar, nspec, nvar2_in
       integer :: k, n_cons_atoms, ncons_here
 
       final_energy = 0.0_dp
@@ -234,6 +253,11 @@ contains
       allocate (atomic_numbers(natoms), source=znuc)
       allocate (atom_residues(natoms), source=residues)
       allocate (initial_coords(3, natoms), source=coords)
+      ! Held for `cb_get_params`, and cleared when absent: this module's state is
+      ! `save`, so a second optimization in the same process would otherwise
+      ! inherit the previous run's path and quietly become a chain-of-states run.
+      if (allocated(endpoint_coords)) deallocate (endpoint_coords)
+      if (present(endpoint)) allocate (endpoint_coords(3, natoms), source=endpoint)
       allocate (latest_coords(3, natoms), source=coords)
 
       nvar = int(3*natoms, c_int)
@@ -258,10 +282,17 @@ contains
       if (allocated(opt_settings%constraints)) ncons_here = size(opt_settings%constraints)
       nspec = int(3*natoms + 5*ncons_here, c_int)
 
-      ! nvarin2 = 0: the second coordinate array carries NEB images, a reaction
-      ! path or per-atom masses and weights, none of which a minimization uses.
-      ! DL-FIND still hands the callback a length of max(nvarin2,1).
-      call api_dl_find(nvar, 0_c_int, nspec, 1_c_int, &
+      ! The second coordinate array carries NEB images, a reaction endpoint or
+      ! per-atom masses and weights. A minimization uses none of them and
+      ! passes zero, and DL-FIND still hands the callback a length of
+      ! max(nvarin2,1). A chain-of-states run passes one frame: the product.
+      ! DL-FIND interpolates the images between it and the geometry it was
+      ! given, so a path is two structures and a count rather than a file of
+      ! guesses.
+      nvar2_in = 0_c_int
+      if (allocated(endpoint_coords)) nvar2_in = int(3*natoms, c_int)
+
+      call api_dl_find(nvar, nvar2_in, nspec, 1_c_int, &
                        c_funloc(cb_error), &
                        c_funloc(cb_get_gradient), &
                        c_funloc(cb_get_hessian), &
@@ -433,7 +464,19 @@ contains
       nmass = 0_c_int
       nweight = 0_c_int
 
-      icoord = dlfind_coordinates(settings%coordinates)
+      ! A band only when a second structure was actually given. The deck asking
+      ! for images or a spring constant without an endpoint is not a path, and
+      ! silently running one from a single geometry would optimize something
+      ! nobody described.
+      if (allocated(endpoint_coords)) then
+         icoord = dlfind_coordinates(settings%coordinates, dlfind_neb_band(settings%neb_ends))
+         if (settings%n_images > 0) nimage = int(settings%n_images, c_int)
+         if (settings%neb_spring >= 0.0_dp) nebk = real(settings%neb_spring, c_double)
+         nframe = 1_c_int
+         coords2(1:3*n_atoms) = reshape(endpoint_coords, [3*n_atoms])
+      else
+         icoord = dlfind_coordinates(settings%coordinates)
+      end if
       iopt = dlfind_algorithm(settings%algorithm)
 
       tolerance = real(settings%gradient_tolerance, c_double)
@@ -656,9 +699,15 @@ contains
 
    end function dlfind_print_level
 
-   pure function dlfind_coordinates(coordinates) result(icoord)
+   pure function dlfind_coordinates(coordinates, band) result(icoord)
       !! This program's coordinate-system numbering, in DL-FIND's
+      !!
+      !! `band` is added on top: zero for an ordinary single-structure run, and
+      !! one of the `DLF_NEB_ENDS_*` offsets for a chain of states. The unit
+      !! place stays the coordinate system either way, which is exactly how
+      !! DL-FIND decodes it.
       integer, intent(in) :: coordinates
+      integer(c_int), intent(in), optional :: band
       integer(c_int) :: icoord
 
       select case (coordinates)
@@ -673,7 +722,23 @@ contains
       case default
          icoord = DLF_COORDS_CARTESIAN
       end select
+      if (present(band)) icoord = icoord + band
    end function dlfind_coordinates
+
+   pure function dlfind_neb_band(ends) result(band)
+      !! This program's endpoint treatment, as DL-FIND's `icoord` offset
+      integer, intent(in) :: ends
+      integer(c_int) :: band
+
+      select case (ends)
+      case (NEB_ENDS_FREE)
+         band = DLF_NEB_ENDS_FREE
+      case (NEB_ENDS_PERPENDICULAR)
+         band = DLF_NEB_ENDS_PERPENDICULAR
+      case default
+         band = DLF_NEB_ENDS_FROZEN
+      end select
+   end function dlfind_neb_band
 
    pure function dlfind_algorithm(algorithm) result(iopt)
       !! This program's algorithm numbering, in DL-FIND's

--- a/mqc_docs/source/geometry_optimization.rst
+++ b/mqc_docs/source/geometry_optimization.rst
@@ -279,6 +279,19 @@ All optional. Everything under ``keywords.optimization``:
      - ``minimum``
      - ``minimum`` or ``saddle``. What the run is looking for, which decides
        how ``hess_end`` reads its own result. See :ref:`saddle-search`
+   * - ``endpoint``
+     - none
+     - Path to a second geometry. Turns the run into a chain of states between
+       it and the starting structure. See :ref:`neb`
+   * - ``images``
+     - engine
+     - Images along the path, endpoints included. At least 3
+   * - ``neb_spring``
+     - engine
+     - Spring constant holding neighbouring images apart
+   * - ``neb_endpoints``
+     - ``frozen``
+     - ``frozen``, ``perpendicular`` or ``free``
    * - ``frozen_atoms``
      - none
      - 0-based indices held at their input position. See :ref:`opt-constraints`
@@ -357,6 +370,68 @@ around on anything but a small system.
 and an update thereafter, rather than a fresh one per step. ``bofill`` is the
 usual choice for a saddle point, because it does not assume the matrix is
 positive definite -- which at a transition state it is not.
+
+.. _neb:
+
+Finding the guess: a path between two structures
+-------------------------------------------------
+
+P-RFO converges on the saddle nearest where it starts, so the hard part of a
+transition state is usually the starting geometry rather than the optimization.
+Where reactant and product are both known, the path between them supplies one.
+
+Give the second structure as ``endpoint`` and the run becomes a nudged elastic
+band: a chain of images between the two, relaxed together, with springs holding
+neighbours apart so the chain cannot slide into either well::
+
+    "keywords": {
+      "optimization": {
+        "algorithm": "lbfgs",
+        "endpoint": "product.xyz",
+        "images": 7,
+        "neb_endpoints": "frozen"
+      }
+    }
+
+Only ``endpoint`` turns this on. ``images``, ``neb_spring`` or
+``neb_endpoints`` without it is refused rather than run as an ordinary
+optimization, because a deck that describes a band and supplies one structure
+has asked for something it did not provide.
+
+The two structures must be the same atoms in the same order. This is checked,
+and the check is worth more than it sounds: images are interpolated atom by
+atom, so a product written with two atoms swapped describes a reaction in which
+those atoms trade places. That band relaxes perfectly happily to something with
+no chemical meaning.
+
+The implementation is improved-tangent NEB with a climbing image. The climbing
+image is the one that matters for a transition state: once the band has settled,
+the highest image stops obeying the springs and is driven uphill along the path
+instead, so it converges on the barrier top rather than near it. Its geometry is
+what you hand to P-RFO.
+
+``neb_endpoints`` decides whether the two ends may move. ``frozen`` is the
+default and the usual case, since endpoints are normally already-optimized
+minima and relaxing them again spends images to move nothing.
+``perpendicular`` lets a slightly-off endpoint settle onto the path without
+sliding along it, and ``free`` relaxes them fully.
+
+.. note::
+
+   Images are interpolated on a straight line between the two structures, so
+   the interpolation has to be physical. On ammonia inversion it is: the
+   nitrogen passes through the plane of the hydrogens, which is the reaction.
+   On ``HCN`` to ``HNC`` it is not -- the hydrogen is at one end of the molecule
+   in the reactant and the other end in the product, and interpolating drives it
+   straight through both nuclei. The middle images then have no SCF and the run
+   stops with an energy evaluation failure. Where the straight line is
+   unphysical, optimize a rough intermediate by hand and start P-RFO from it
+   instead.
+
+Ammonia inversion, ``HF/STO-3G``, seven images: the band converges with the
+climbing image at the middle of the path, and the geometry it lands on has all
+four atoms coplanar -- the ``D3h`` transition state -- at a barrier of 0.0164
+Hartree, or 10.3 kcal/mol.
 
 .. _saddle-search:
 

--- a/src/io/mqc_config_adapter.f90
+++ b/src/io/mqc_config_adapter.f90
@@ -7,6 +7,7 @@ module mqc_config_adapter
    use mqc_physical_fragment, only: system_geometry_t, to_bohr
    use mqc_elements, only: element_symbol_to_number
    use mqc_error, only: error_t, ERROR_VALIDATION
+   use mqc_string_utils, only: int_to_text
    use mqc_calculation_keywords, only: hessian_keywords_t, aimd_keywords_t, scf_keywords_t
    use mqc_optimizer_types, only: optimizer_settings_t, &
                                   coordinates_from_string, algorithm_from_string, &
@@ -14,7 +15,9 @@ module mqc_config_adapter
                                   OPT_COORDS_UNKNOWN, OPT_ALGO_UNKNOWN, &
                                   OPT_HESSIAN_UPDATE_ENGINE, OPT_TARGET_MINIMUM, &
                                   OPT_TARGET_SADDLE, OPT_COORDS_CARTESIAN, &
-                                  algorithm_to_string, algorithm_finds_saddle
+                                  algorithm_to_string, algorithm_finds_saddle, &
+                                  neb_ends_from_string, NEB_ENDS_FROZEN, &
+                                  MIN_NEB_IMAGES
    use mqc_method_config, only: method_config_t
    use mqc_method_types, only: METHOD_TYPE_CCSD_T, METHOD_TYPE_GFN1, &
                                METHOD_TYPE_GFN2, METHOD_TYPE_EFP2
@@ -466,6 +469,59 @@ contains
             return
          end if
          driver_config%optimization%target = want
+      end if
+
+      if (allocated(mqc_config%opt_endpoint)) then
+         driver_config%optimization%endpoint = mqc_config%opt_endpoint
+      end if
+      driver_config%optimization%n_images = mqc_config%opt_n_images
+      driver_config%optimization%neb_spring = mqc_config%opt_neb_spring
+
+      if (allocated(mqc_config%opt_neb_ends)) then
+         driver_config%optimization%neb_ends = neb_ends_from_string(mqc_config%opt_neb_ends)
+         if (driver_config%optimization%neb_ends < NEB_ENDS_FROZEN) then
+            if (present(error)) then
+               call error%set(ERROR_VALIDATION, &
+                              "Unknown keywords.optimization.neb_endpoints: '"// &
+                              trim(mqc_config%opt_neb_ends)// &
+                              "'. Use frozen, perpendicular or free.")
+            end if
+            return
+         end if
+      end if
+
+      ! The path keywords describe a band, and a band needs two structures. A
+      ! deck that sets images or a spring without an endpoint has described
+      ! something it did not supply, and running the ordinary single-structure
+      ! optimization would silently do different work from the one asked for.
+      if (.not. allocated(driver_config%optimization%endpoint)) then
+         if (mqc_config%opt_n_images > 0 .or. allocated(mqc_config%opt_neb_ends) .or. &
+             mqc_config%opt_neb_spring >= 0.0_dp) then
+            if (present(error)) then
+               call error%set(ERROR_VALIDATION, &
+                              "keywords.optimization sets a path option (images, "// &
+                              "neb_spring or neb_endpoints) but no 'endpoint'. A "// &
+                              "chain-of-states run needs a second structure to run "// &
+                              "between; give the product geometry as "// &
+                              "keywords.optimization.endpoint.")
+            end if
+            return
+         end if
+      else
+         ! Two images are the endpoints and nothing in between, so there is no
+         ! band to relax. DL-FIND refuses it too, but from inside the engine and
+         ! with a message about its own variable.
+         if (mqc_config%opt_n_images > 0 .and. mqc_config%opt_n_images < MIN_NEB_IMAGES) then
+            if (present(error)) then
+               call error%set(ERROR_VALIDATION, &
+                              "keywords.optimization.images is "// &
+                              trim(int_to_text(mqc_config%opt_n_images))// &
+                              ". A path needs at least "// &
+                              trim(int_to_text(MIN_NEB_IMAGES))//": two of them are the "// &
+                              "endpoints, so fewer leaves nothing between them to relax.")
+            end if
+            return
+         end if
       end if
 
       ! A saddle is not something every algorithm can look for. Steepest

--- a/src/io/mqc_config_types.f90
+++ b/src/io/mqc_config_types.f90
@@ -418,6 +418,10 @@ module mqc_config_types
       logical :: opt_hess_end = .false.                !! Hessian at the converged geometry
       character(len=:), allocatable :: opt_hessian_update  !! none, powell, bofill, auto
       character(len=:), allocatable :: opt_target  !! minimum or saddle
+      character(len=:), allocatable :: opt_endpoint  !! xyz of the product, for NEB
+      character(len=:), allocatable :: opt_neb_ends  !! frozen, perpendicular, free
+      integer :: opt_n_images = 0                      !! Images along the path
+      real(dp) :: opt_neb_spring = -1.0_dp             !! <0 = engine default
       real(dp) :: opt_timestep = -1.0_dp               !! Damped dynamics step
       real(dp) :: opt_friction = -1.0_dp               !! Damped dynamics start friction
       real(dp) :: opt_friction_factor = -1.0_dp        !! Friction decay while descending

--- a/src/io/mqc_json_config_reader.f90
+++ b/src/io/mqc_json_config_reader.f90
@@ -422,6 +422,10 @@ contains
       call optional_string(json, "keywords.optimization.hessian_update", &
                            config%opt_hessian_update)
       call optional_string(json, "keywords.optimization.target", config%opt_target)
+      call optional_string(json, "keywords.optimization.endpoint", config%opt_endpoint)
+      call optional_string(json, "keywords.optimization.neb_endpoints", config%opt_neb_ends)
+      call optional_int(json, "keywords.optimization.images", config%opt_n_images)
+      call optional_real(json, "keywords.optimization.neb_spring", config%opt_neb_spring)
       call optional_real(json, "keywords.optimization.timestep", config%opt_timestep)
       call optional_real(json, "keywords.optimization.friction", config%opt_friction)
       call optional_real(json, "keywords.optimization.friction_factor", &

--- a/src/io/mqc_json_schema.f90
+++ b/src/io/mqc_json_schema.f90
@@ -35,11 +35,13 @@ module mqc_json_schema
 
    public :: ensure_valid_json  !! Reject a deck the schema does not describe
 
-   integer, parameter :: MAX_KEYS = 24
+   integer, parameter :: MAX_KEYS = 32
       !! Widest allow-list below; raising it is the only cost of a new key.
-      !! fragmentation_keys is the widest at 21 (its FMO inner-SCF controls
-      !! pushed it past 16, and bond_breaking/cap_scale past 18), so this keeps
-      !! a little headroom above that.
+      !! optimization_keys is now the widest: the transition-state work added
+      !! `target`, and the chain-of-states work `endpoint`, `neb_endpoints`,
+      !! `images` and `neb_spring`, which took it past fragmentation_keys (21,
+      !! pushed there by its FMO inner-SCF controls and bond_breaking/cap_scale).
+      !! This keeps headroom above that.
       !!
       !! `allow` checks this rather than trusting the comment. It used not to,
       !! and going one over wrote past `allowed` and corrupted whatever followed
@@ -511,6 +513,10 @@ contains
       call allow(keys, "hess_end")
       call allow(keys, "hessian_update")
       call allow(keys, "target")
+      call allow(keys, "endpoint")
+      call allow(keys, "neb_endpoints")
+      call allow(keys, "images")
+      call allow(keys, "neb_spring")
       call allow(keys, "frozen_atoms")
       call allow(keys, "constraints")
       call allow(keys, "timestep")

--- a/src/optimization/mqc_dlfind_bridge_stub.f90
+++ b/src/optimization/mqc_dlfind_bridge_stub.f90
@@ -26,7 +26,7 @@ contains
 
    subroutine dlfind_optimize(opt_settings, natoms, znuc, residues, coords, &
                               energy_gradient, step_taken, final_energy, error, &
-                              hessian)
+                              hessian, endpoint)
       !! No-op stand-in: optimizing a geometry needs the DL-FIND backend
       !!
       !! The argument list has to track the real bridge's exactly, including the
@@ -43,6 +43,7 @@ contains
       real(dp), intent(out) :: final_energy
       type(error_t), intent(inout) :: error
       procedure(hessian_i), optional :: hessian
+      real(dp), intent(in), optional :: endpoint(:, :)
 
       final_energy = 0.0_dp
       call error%set(ERROR_VALIDATION, &

--- a/src/optimization/mqc_geometry_optimizer.f90
+++ b/src/optimization/mqc_geometry_optimizer.f90
@@ -29,7 +29,7 @@ module mqc_geometry_optimizer
                                   OPT_COORDS_CARTESIAN, OPT_COORDS_UNKNOWN, OPT_ALGO_UNKNOWN, &
                                   coordinates_to_string, algorithm_to_string, &
                                   algorithm_needs_hessian
-   use mqc_physical_fragment, only: system_geometry_t, to_angstrom
+   use mqc_physical_fragment, only: system_geometry_t, to_angstrom, to_bohr
    use mqc_bond_perception, only: connected_components
    use mqc_config_adapter, only: driver_config_t
    use mqc_config_types, only: bond_t
@@ -140,6 +140,7 @@ contains
       integer :: probe_status
       real(dp) :: final_energy
       real(dp), allocatable :: coords(:, :)
+      real(dp), allocatable :: endpoint_geom(:, :)
       integer, allocatable :: atomic_numbers(:)
       integer, allocatable :: residues(:)
 
@@ -255,15 +256,22 @@ contains
          ! the same matrix and slower -- so the argument is omitted rather than
          ! passed and refused per geometry, which would spend a failed
          ! calculation to learn what is already known here.
+         ! `endpoint_geom` stays unallocated for an ordinary optimization, and an
+         ! unallocated allocatable is absent at an optional dummy -- so one pair
+         ! of call sites serves both the band and the single structure.
+         call load_endpoint(config%optimization%endpoint, atomic_numbers, endpoint_geom, error)
+         if (error%has_error()) return
+
          if (algorithm_needs_hessian(config%optimization%algorithm) .and. &
              is_restricted_hf(config)) then
             call dlfind_optimize(config%optimization, n_atoms, atomic_numbers, residues, &
                                  coords, evaluate_energy_gradient, record_step, &
-                                 final_energy, error, hessian=evaluate_hessian)
+                                 final_energy, error, hessian=evaluate_hessian, &
+                                 endpoint=endpoint_geom)
          else
             call dlfind_optimize(config%optimization, n_atoms, atomic_numbers, residues, &
                                  coords, evaluate_energy_gradient, record_step, &
-                                 final_energy, error)
+                                 final_energy, error, endpoint=endpoint_geom)
          end if
          call logger%info("  "//repeat("-", 69))
 
@@ -778,6 +786,66 @@ contains
       call logger%info(" ")
 
    end subroutine run_final_hessian
+
+   subroutine load_endpoint(path, atomic_numbers, endpoint, error)
+      !! Read the second structure of a chain-of-states run
+      !!
+      !! Unallocated on return when no endpoint was asked for, which is how the
+      !! caller passes "absent" to an optional dummy without branching.
+      !!
+      !! The two checks here are the ones that make a path meaningful. Atom
+      !! *count* is obvious. Atom *order* is not, and it is the one that bites:
+      !! DL-FIND interpolates image `i` between coordinate `i` of each
+      !! structure, so a product written with two atoms swapped describes a
+      !! reaction in which those atoms trade places, and the band relaxes to
+      !! something with no chemical meaning while converging perfectly happily.
+      use mqc_xyz_reader, only: read_xyz_file
+      use mqc_geometry, only: geometry_type
+      use mqc_elements, only: element_symbol_to_number
+      character(len=:), allocatable, intent(in) :: path
+      integer, intent(in) :: atomic_numbers(:)
+      real(dp), allocatable, intent(out) :: endpoint(:, :)
+      type(error_t), intent(inout) :: error
+
+      type(geometry_type) :: geom
+      type(error_t) :: read_error
+      integer :: i, z
+
+      if (.not. allocated(path)) return
+
+      call read_xyz_file(path, geom, read_error)
+      if (read_error%has_error()) then
+         call error%set(ERROR_VALIDATION, "keywords.optimization.endpoint could not be "// &
+                        "read: "//read_error%get_message())
+         return
+      end if
+
+      if (geom%natoms /= size(atomic_numbers)) then
+         call error%set(ERROR_VALIDATION, "keywords.optimization.endpoint has "// &
+                        trim(to_char(geom%natoms))//" atoms and the starting geometry has "// &
+                        trim(to_char(size(atomic_numbers)))// &
+                        ". A reaction path runs between two structures of the same system.")
+         return
+      end if
+
+      do i = 1, geom%natoms
+         z = element_symbol_to_number(trim(geom%elements(i)))
+         if (z /= atomic_numbers(i)) then
+            call error%set(ERROR_VALIDATION, "keywords.optimization.endpoint disagrees with "// &
+                           "the starting geometry at atom "//trim(to_char(i))//": "// &
+                           trim(element_number_to_symbol(atomic_numbers(i)))//" there, "// &
+                           trim(geom%elements(i))//" here. The images are interpolated atom "// &
+                           "by atom, so the two files have to list the same atoms in the "// &
+                           "same order.")
+            return
+         end if
+      end do
+
+      allocate (endpoint(3, geom%natoms))
+      do i = 1, geom%natoms
+         endpoint(:, i) = to_bohr(geom%coords(:, i))
+      end do
+   end subroutine load_endpoint
 
    subroutine report_reaction_mode(frequencies, cart_disp, sys_geom)
       !! Name the atoms the imaginary mode actually moves

--- a/src/optimization/mqc_optimizer_types.f90
+++ b/src/optimization/mqc_optimizer_types.f90
@@ -41,6 +41,8 @@ module mqc_optimizer_types
    public :: constraint_from_string, constraint_atom_count
    public :: OPT_TARGET_MINIMUM, OPT_TARGET_SADDLE
    public :: target_from_string, target_to_string, algorithm_finds_saddle
+   public :: NEB_ENDS_FROZEN, NEB_ENDS_PERPENDICULAR, NEB_ENDS_FREE, MIN_NEB_IMAGES
+   public :: neb_ends_from_string, neb_ends_to_string
    public :: algorithm_needs_hessian
 
    ! This program's own numbering rather than DL-FIND's, even though DL-FIND is
@@ -100,6 +102,20 @@ module mqc_optimizer_types
       !! means the search fell off the ridge into a basin; two or more means it
       !! is a higher-order stationary point and not a transition state.
 
+   ! How a chain-of-states run treats the two structures it was given. The
+   ! endpoints are usually already optimized minima, so freezing them is the
+   ! default: relaxing a minimum again costs images and moves nothing.
+   integer, parameter :: MIN_NEB_IMAGES = 3
+      !! DL-FIND's own floor. Two images are the two endpoints, so a band of
+      !! two has nothing between them to relax.
+   integer, parameter :: NEB_ENDS_FROZEN = 0
+   integer, parameter :: NEB_ENDS_PERPENDICULAR = 1
+      !! Endpoints move only perpendicular to their own tangent, which lets a
+      !! slightly-off endpoint settle onto the path without sliding along it.
+   integer, parameter :: NEB_ENDS_FREE = 2
+      !! Fully relaxed endpoints. For a pair of structures that are not yet
+      !! minima, at the cost of the path being free to shorten itself.
+
    ! How the engine carries curvature between steps once it has a Hessian.
    ! Only the algorithms that hold one pay attention to this.
    integer, parameter :: OPT_HESSIAN_UPDATE_ENGINE = -1  !! Leave DL-FIND's own choice
@@ -158,6 +174,18 @@ module mqc_optimizer_types
       integer :: target = OPT_TARGET_MINIMUM
          !! Whether this run is looking for a minimum or a first-order saddle.
          !! Independent of `algorithm` on purpose -- see `OPT_TARGET_SADDLE`.
+      character(len=:), allocatable :: endpoint
+         !! Path to a second geometry: the product, for a chain-of-states run.
+         !! Unallocated is the ordinary single-structure optimization, and is
+         !! what makes NEB opt-in rather than inferred.
+      integer :: n_images = 0
+         !! Images along the path, endpoints included. Zero means the engine's
+         !! own default. DL-FIND refuses fewer than three, since two images are
+         !! just the endpoints and there is no path between them to relax.
+      real(dp) :: neb_spring = -1.0_dp
+         !! Spring constant holding neighbouring images apart. Negative means
+         !! the engine default.
+      integer :: neb_ends = NEB_ENDS_FROZEN
       integer :: hessian_update = OPT_HESSIAN_UPDATE_ENGINE
          !! How curvature is carried between steps once a Hessian exists.
          !! Ignored by the algorithms that never build one.
@@ -372,6 +400,40 @@ contains
 
       needs = algorithm == OPT_ALGO_PRFO .or. algorithm == OPT_ALGO_NR
    end function algorithm_needs_hessian
+
+   pure function neb_ends_from_string(text) result(ends)
+      !! Parse how a deck wants the path endpoints treated
+      character(len=*), intent(in) :: text
+      integer :: ends
+
+      select case (lowercase(text))
+      case ("frozen", "fixed")
+         ends = NEB_ENDS_FROZEN
+      case ("perpendicular", "perp")
+         ends = NEB_ENDS_PERPENDICULAR
+      case ("free", "relaxed")
+         ends = NEB_ENDS_FREE
+      case default
+         ends = -2
+      end select
+   end function neb_ends_from_string
+
+   pure function neb_ends_to_string(ends) result(text)
+      !! Name an endpoint treatment, for the log
+      integer, intent(in) :: ends
+      character(len=:), allocatable :: text
+
+      select case (ends)
+      case (NEB_ENDS_FROZEN)
+         text = "frozen"
+      case (NEB_ENDS_PERPENDICULAR)
+         text = "perpendicular"
+      case (NEB_ENDS_FREE)
+         text = "free"
+      case default
+         text = "unknown"
+      end select
+   end function neb_ends_to_string
 
    pure function algorithm_finds_saddle(algorithm) result(can)
       !! Whether this algorithm can converge on a first-order saddle

--- a/test/test_mqc_optimizer_types.f90
+++ b/test/test_mqc_optimizer_types.f90
@@ -22,7 +22,10 @@ module test_mqc_optimizer_types
                                   constraint_from_string, constraint_atom_count, &
                                   target_from_string, target_to_string, &
                                   algorithm_finds_saddle, &
-                                  OPT_TARGET_MINIMUM, OPT_TARGET_SADDLE
+                                  OPT_TARGET_MINIMUM, OPT_TARGET_SADDLE, &
+                                  neb_ends_from_string, neb_ends_to_string, &
+                                  NEB_ENDS_FROZEN, NEB_ENDS_PERPENDICULAR, &
+                                  NEB_ENDS_FREE, MIN_NEB_IMAGES
    use mqc_calc_types, only: calc_type_from_string, calc_type_to_string, CALC_TYPE_OPTIMIZE
    use pic_types, only: dp
    implicit none
@@ -50,9 +53,59 @@ contains
                   new_unittest("target_parses", test_target_parses), &
                   new_unittest("target_roundtrip", test_target_roundtrip), &
                   new_unittest("target_defaults_to_minimum", test_target_default), &
-                  new_unittest("only_saddle_capable_algorithms", test_saddle_capable) &
+                  new_unittest("only_saddle_capable_algorithms", test_saddle_capable), &
+                  new_unittest("neb_endpoints_parse", test_neb_ends), &
+                  new_unittest("neb_defaults_are_off", test_neb_defaults) &
                   ]
    end subroutine collect_mqc_optimizer_types_tests
+
+   subroutine test_neb_ends(error)
+      !! How a deck spells the endpoint treatment
+      type(error_type), allocatable, intent(out) :: error
+
+      call check(error, neb_ends_from_string("frozen") == NEB_ENDS_FROZEN)
+      if (allocated(error)) return
+      call check(error, neb_ends_from_string("fixed") == NEB_ENDS_FROZEN)
+      if (allocated(error)) return
+      call check(error, neb_ends_from_string("perpendicular") == NEB_ENDS_PERPENDICULAR)
+      if (allocated(error)) return
+      call check(error, neb_ends_from_string("free") == NEB_ENDS_FREE)
+      if (allocated(error)) return
+      call check(error, neb_ends_from_string("FROZEN") == NEB_ENDS_FROZEN, &
+                 "endpoint spellings should be case-insensitive like their siblings")
+      if (allocated(error)) return
+      call check(error, neb_ends_from_string("banana") < NEB_ENDS_FROZEN, &
+                 "an unrecognised endpoint treatment must not fall back to a valid one")
+      if (allocated(error)) return
+      call check(error, neb_ends_from_string(neb_ends_to_string(NEB_ENDS_PERPENDICULAR)) == &
+                 NEB_ENDS_PERPENDICULAR, "the endpoint treatment should round-trip")
+   end subroutine test_neb_ends
+
+   subroutine test_neb_defaults(error)
+      !! A path is opt-in, and its floor is real
+      !!
+      !! The default matters more than it looks: every optimization in every
+      !! existing deck runs through these settings, and a non-zero image count
+      !! or an allocated endpoint would turn one of them into a band.
+      type(error_type), allocatable, intent(out) :: error
+      type(optimizer_settings_t) :: settings
+
+      call check(error,.not. allocated(settings%endpoint), &
+                 "an optimization is a single structure unless a deck says otherwise")
+      if (allocated(error)) return
+      call check(error, settings%n_images == 0, &
+                 "zero images means the engine default, not a band")
+      if (allocated(error)) return
+      call check(error, settings%neb_spring < 0.0_dp, &
+                 "a negative spring constant means the engine default")
+      if (allocated(error)) return
+      call check(error, settings%neb_ends == NEB_ENDS_FROZEN, &
+                 "endpoints supplied by a user are usually already minima")
+      if (allocated(error)) return
+      ! Two images are the two endpoints. DL-FIND refuses fewer than three from
+      ! inside the engine; this is the same floor, named where a deck is read.
+      call check(error, MIN_NEB_IMAGES == 3)
+   end subroutine test_neb_defaults
 
    subroutine test_target_parses(error)
       !! Every spelling a deck is likely to use, and one it is not


### PR DESCRIPTION
P-RFO converges on the saddle nearest where it starts, so the work is in the guess. Where reactant and product are both known the path between them supplies one, and DL-FIND has had improved-tangent NEB with a climbing image all along — the bridge never asked for it.

`keywords.optimization.endpoint` is a second geometry; giving one turns the run into a chain of states. `images`, `neb_spring` and `neb_endpoints` tune it. No new interop was needed: `cb_get_params` already declared `coords2`, `nframe`, `nimage` and `nebk`, and `nvarin2` was hardcoded to zero under a comment naming NEB as the reason the argument exists.

Three things about the encoding, none guessable: a band is selected through `icoord`, not `iopt` (unit place is the coordinate system, hundreds/tens are the band, so endpoint treatment is an offset onto a coordinate system); 190 is the quantum TS search, not NEB, which is why the offsets stop at 120; image `nimage` is reserved for the climbing image, so a seven-image band relaxes six.

Refused rather than run: path options without an endpoint, fewer than three images, and an endpoint whose atoms differ from the start geometry's — images are interpolated atom by atom, so a product with two atoms transposed describes a reaction where those atoms trade places, and the band relaxes to it happily.

**Verified**: ammonia inversion at HF/STO-3G, seven images — climbing image spawns at cycle 6 on image 4, converges to all four atoms at the same z (D3h planar TS), barrier 0.0164 Hartree = 10.3 kcal/mol.

The schema allow-list needed raising from 24 to 32; `optimization_keys` is now the widest in the file. It refused loudly rather than overflowing.

---

**Stack** (merge bottom-up):

1. #292 `feat/ts-search` — target: saddle, and read the result that way
2. #293 `feat/ts-neb` — NEB band with climbing image
3. #294 `feat/ts-dimer` — dimer method, Hessian-free
4. #295 `feat/ts-connect` — walk off the saddle both ways
5. #296 `feat/ts-mode-following` — zero modes, so P-RFO stops climbing rotations

This PR is #2 of the stack; it is based on the one below it, so its diff is only its own commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ER5Y9FP9PEWpXLVcy1atuu
