### PR TITLE
Say what the saddle connects, by walking off it in both directions

### DIFF
--- a/backends/dlfind/mqc_dlfind_bridge.f90
+++ b/backends/dlfind/mqc_dlfind_bridge.f90
@@ -40,6 +40,7 @@ module mqc_dlfind_bridge
 
    public :: dlfind_available
    public :: dlfind_optimize
+   public :: dlfind_connected_minima
 
    ! DL-FIND's own numbering, which this file is the only place to know.
    ! `icoord`: mod 10 selects the coordinate system, and the tens and hundreds
@@ -64,6 +65,23 @@ module mqc_dlfind_bridge
    ! taken here because it is the one that respects the algorithm the deck
    ! chose.
    integer(c_int), parameter :: DLF_DIMER = 200
+
+   ! DL-FIND's task numbers. 1011 is "TS search, then find both downhill
+   ! structures": it runs the saddle search as configured, stores the geometry
+   ! and the imaginary mode, then displaces along that mode in each direction
+   ! and minimises, which is the practical answer to what the saddle connects.
+   ! DL-FIND has no IRC -- there is no `dlf_irc.f90` -- so this is the closest
+   ! thing to one it offers, and it answers the question an IRC is usually run
+   ! to answer.
+   integer(c_int), parameter :: DLF_TASK_TS_AND_DOWNHILL = 1011
+
+   ! Which structure `cb_put_coords` is being handed. 1 is an ordinary step, 2
+   ! the transition mode, 3 the transition structure, and 4 and 5 the two minima
+   ! reached by relaxing downhill from it.
+   integer(c_int), parameter :: DLF_PUT_STEP = 1
+   integer(c_int), parameter :: DLF_PUT_TS = 3
+   integer(c_int), parameter :: DLF_PUT_DOWNHILL_A = 4
+   integer(c_int), parameter :: DLF_PUT_DOWNHILL_B = 5
 
    integer(c_int), parameter :: DLF_NEB_ENDS_FREE = 100
    integer(c_int), parameter :: DLF_NEB_ENDS_PERPENDICULAR = 110
@@ -106,6 +124,15 @@ module mqc_dlfind_bridge
    integer, allocatable, save :: atomic_numbers(:)
    integer, allocatable, save :: atom_residues(:)
    real(dp), allocatable, save :: initial_coords(:, :)
+   real(dp), allocatable, save :: downhill_a(:, :), downhill_b(:, :)
+   real(dp), save :: energy_a = 0.0_dp, energy_b = 0.0_dp
+   real(dp), save :: saddle_energy = 0.0_dp
+   logical, save :: have_saddle = .false.
+      !! The transition structure's own energy. A `connect` run does not stop
+      !! there -- it carries on downhill twice -- so the energy the optimizer
+      !! finishes with belongs to the last minimum, not to the saddle.
+   logical, save :: have_downhill_a = .false., have_downhill_b = .false.
+      !! The two minima a `connect` run falls to, kept for the caller to report.
    real(dp), allocatable, save :: endpoint_coords(:, :)
       !! The second structure of a chain-of-states run, held here for the same
       !! reason the geometry is: `cb_get_params` is a C callback and takes no
@@ -265,6 +292,11 @@ contains
       ! Held for `cb_get_params`, and cleared when absent: this module's state is
       ! `save`, so a second optimization in the same process would otherwise
       ! inherit the previous run's path and quietly become a chain-of-states run.
+      have_downhill_a = .false.
+      have_downhill_b = .false.
+      have_saddle = .false.
+      if (allocated(downhill_a)) deallocate (downhill_a)
+      if (allocated(downhill_b)) deallocate (downhill_b)
       if (allocated(endpoint_coords)) deallocate (endpoint_coords)
       if (present(endpoint)) allocate (endpoint_coords(3, natoms), source=endpoint)
       allocate (latest_coords(3, natoms), source=coords)
@@ -471,6 +503,13 @@ contains
       ! against its serial stubs. Splitting the job again underneath would be
       ! two schedulers dividing the same ranks.
       ntasks = 1_c_int
+      if (settings%connect) then
+         task = DLF_TASK_TS_AND_DOWNHILL
+         if (settings%connect_distort > 0.0_dp) then
+            distort = real(settings%connect_distort, c_double)
+         end if
+      end if
+
       nframe = 0_c_int
       nmass = 0_c_int
       nweight = 0_c_int
@@ -527,6 +566,13 @@ contains
       ! dlf_put_coords. Without it the optimization runs to convergence and
       ! hands back nothing, which is the one failure that looks like success.
       printf = 1_c_int
+      ! A `connect` run needs 4. DL-FIND hands back the transition structure and
+      ! the two minima it relaxed to only from inside `printf >= 4` blocks --
+      ! the same blocks that write TS.xyz and minimum_+.xyz -- so at the default
+      ! the downhill runs happen, report themselves as finished, and are never
+      ! passed to the caller. It costs a handful of files in the working
+      ! directory, which is a fair price for the answer being reachable.
+      if (settings%connect) printf = 4_c_int
 
       ! Curvature settings, which only P-RFO and Newton-Raphson read. Asking
       ! for the external Hessian is safe whether or not one can be produced:
@@ -607,7 +653,29 @@ contains
       integer(c_int), intent(in), value :: iam  !! Task id; only the first reports
 
       if (iam /= 0_c_int) return
-      if (switch /= 1_c_int .and. switch /= 3_c_int) return
+      ! The two downhill minima arrive here and nowhere else, so they are kept
+      ! rather than filtered out with everything that is not a step.
+      if (nvar == 3*n_atoms) then
+         if (switch == DLF_PUT_DOWNHILL_A) then
+            if (.not. allocated(downhill_a)) allocate (downhill_a(3, n_atoms))
+            downhill_a = reshape(coords, [3, n_atoms])
+            energy_a = energy
+            have_downhill_a = .true.
+            return
+         end if
+         if (switch == DLF_PUT_DOWNHILL_B) then
+            if (.not. allocated(downhill_b)) allocate (downhill_b(3, n_atoms))
+            downhill_b = reshape(coords, [3, n_atoms])
+            energy_b = energy
+            have_downhill_b = .true.
+            return
+         end if
+      end if
+      if (switch == DLF_PUT_TS .and. nvar == 3*n_atoms) then
+         saddle_energy = energy
+         have_saddle = .true.
+      end if
+      if (switch /= DLF_PUT_STEP .and. switch /= DLF_PUT_TS) return
       if (nvar /= 3*n_atoms) return
 
       latest_coords = reshape(real(coords, dp), [3, n_atoms])
@@ -758,6 +826,23 @@ contains
       end select
       if (present(band)) icoord = icoord + band
    end function dlfind_coordinates
+
+   subroutine dlfind_connected_minima(a, energy_first, b, energy_second, found, e_saddle)
+      !! The two minima a `connect` run relaxed to, if it ran and reached them
+      real(dp), allocatable, intent(out) :: a(:, :), b(:, :)
+      real(dp), intent(out) :: energy_first, energy_second
+      logical, intent(out) :: found
+      real(dp), intent(out) :: e_saddle
+         !! The saddle's own energy, which is not the one the run finishes with.
+
+      e_saddle = saddle_energy
+      found = have_downhill_a .and. have_downhill_b .and. have_saddle
+      energy_first = energy_a
+      energy_second = energy_b
+      if (.not. found) return
+      a = downhill_a
+      b = downhill_b
+   end subroutine dlfind_connected_minima
 
    pure function dlfind_neb_band(ends) result(band)
       !! This program's endpoint treatment, as DL-FIND's `icoord` offset

--- a/mqc_docs/source/geometry_optimization.rst
+++ b/mqc_docs/source/geometry_optimization.rst
@@ -305,6 +305,13 @@ All optional. Everything under ``keywords.optimization``:
    * - ``dimer_rotation_tolerance``
      - engine
      - Stop rotating below this angle
+   * - ``connect``
+     - ``false``
+     - After the saddle, relax downhill both ways and report the two minima.
+       See :ref:`connect`
+   * - ``connect_distort``
+     - engine
+     - How far to displace along the imaginary mode before relaxing
    * - ``frozen_atoms``
      - none
      - 0-based indices held at their input position. See :ref:`opt-constraints`
@@ -383,6 +390,59 @@ around on anything but a small system.
 and an update thereafter, rather than a fresh one per step. ``bofill`` is the
 usual choice for a saddle point, because it does not assume the matrix is
 positive definite -- which at a transition state it is not.
+
+.. _connect:
+
+What does the saddle connect?
+------------------------------
+
+One imaginary frequency proves a first-order saddle. It does not prove the
+saddle joins the two minima anybody had in mind, and a transition state between
+the wrong pair is a barrier height that looks entirely reasonable and describes
+a different reaction.
+
+``connect`` settles it. After the saddle converges, the geometry is displaced
+along the imaginary mode in each direction and relaxed, and the two minima it
+falls into are reported::
+
+    "keywords": {
+      "optimization": {
+        "target": "saddle",
+        "saddle_method": "dimer",
+        "endpoint": "product.xyz",
+        "connect": true
+      }
+    }
+
+giving::
+
+    the saddle relaxes to two minima:
+       forward       -55.455419758873 Hartree
+       backward      -55.455419796039 Hartree
+       barrier from each side:      11.141081 and      11.141104 kcal/mol
+    written to connected_forward.xyz and connected_backward.xyz
+
+Open those two files. If they are the reactant and product you meant, the saddle
+is the right one; if either is something else, it is not, whatever its frequency
+said.
+
+This is not an intrinsic reaction coordinate. The path taken downhill is an
+ordinary minimisation path rather than the mass-weighted steepest-descent one,
+so the *route* is not the reaction coordinate -- but the endpoints are the same,
+and the endpoints are the question being asked. A true IRC is not available:
+DL-FIND does not implement one.
+
+``connect_distort`` is how far the geometry is displaced along the mode before
+relaxing. Too small and both sides fall back to the saddle; too large and they
+can skip past the adjacent minima entirely.
+
+.. note::
+
+   ``connect`` and ``hess_end`` are refused together. A connect run does not
+   finish at the saddle -- it finishes at the second of the two minima -- so a
+   final Hessian would describe that structure and report, correctly and
+   uselessly, that it has no imaginary frequencies. Run the saddle search with
+   ``hess_end`` first, then connect from the geometry it found.
 
 .. _dimer:
 

--- a/src/io/mqc_config_adapter.f90
+++ b/src/io/mqc_config_adapter.f90
@@ -543,6 +543,42 @@ contains
          end if
       end if
 
+      driver_config%optimization%connect = mqc_config%opt_connect
+      driver_config%optimization%connect_distort = mqc_config%opt_connect_distort
+
+      ! Following a saddle downhill needs a saddle to follow. Asked for
+      ! alongside a minimisation it describes something that cannot happen, and
+      ! running the minimisation and ignoring the request would report success
+      ! for half of what the deck asked.
+      if (mqc_config%opt_connect .and. &
+          driver_config%optimization%target /= OPT_TARGET_SADDLE) then
+         if (present(error)) then
+            call error%set(ERROR_VALIDATION, &
+                           "keywords.optimization.connect asks for the minima on either "// &
+                           "side of a transition state, but target is 'minimum'. Set "// &
+                           "target to 'saddle'.")
+         end if
+         return
+      end if
+
+      ! A connect run does not stop at the saddle -- it carries on downhill
+      ! twice -- so the geometry it finishes with is the second minimum. A
+      ! Hessian there describes that minimum and reports, correctly and
+      ! uselessly, that it has no imaginary frequencies. Refused rather than
+      ! run, because the output would read as the saddle having been checked
+      ! and failed.
+      if (mqc_config%opt_connect .and. mqc_config%opt_hess_end) then
+         if (present(error)) then
+            call error%set(ERROR_VALIDATION, &
+                           "keywords.optimization sets both connect and hess_end. A "// &
+                           "connect run ends at one of the minima rather than at the "// &
+                           "saddle, so the final Hessian would describe the wrong "// &
+                           "structure. Run the saddle search with hess_end first, then "// &
+                           "connect from the geometry it found.")
+         end if
+         return
+      end if
+
       ! A saddle is not something every algorithm can look for. Steepest
       ! descent and the quasi-Newton minimisers go downhill by construction and
       ! will report a minimum however the target is spelled, so asking them for

--- a/src/io/mqc_config_types.f90
+++ b/src/io/mqc_config_types.f90
@@ -426,6 +426,8 @@ module mqc_config_types
       real(dp) :: opt_dimer_separation = -1.0_dp       !! <0 = engine default
       integer :: opt_dimer_max_rotations = -1          !! <0 = engine default
       real(dp) :: opt_dimer_rot_tol = -1.0_dp          !! <0 = engine default
+      logical :: opt_connect = .false.                 !! Relax downhill from the saddle
+      real(dp) :: opt_connect_distort = -1.0_dp        !! <0 = engine default
       real(dp) :: opt_timestep = -1.0_dp               !! Damped dynamics step
       real(dp) :: opt_friction = -1.0_dp               !! Damped dynamics start friction
       real(dp) :: opt_friction_factor = -1.0_dp        !! Friction decay while descending

--- a/src/io/mqc_json_config_reader.f90
+++ b/src/io/mqc_json_config_reader.f90
@@ -434,6 +434,9 @@ contains
                         config%opt_dimer_max_rotations)
       call optional_real(json, "keywords.optimization.dimer_rotation_tolerance", &
                          config%opt_dimer_rot_tol)
+      call optional_logical(json, "keywords.optimization.connect", config%opt_connect)
+      call optional_real(json, "keywords.optimization.connect_distort", &
+                         config%opt_connect_distort)
       call optional_real(json, "keywords.optimization.timestep", config%opt_timestep)
       call optional_real(json, "keywords.optimization.friction", config%opt_friction)
       call optional_real(json, "keywords.optimization.friction_factor", &

--- a/src/io/mqc_json_schema.f90
+++ b/src/io/mqc_json_schema.f90
@@ -35,11 +35,12 @@ module mqc_json_schema
 
    public :: ensure_valid_json  !! Reject a deck the schema does not describe
 
-   integer, parameter :: MAX_KEYS = 32
+   integer, parameter :: MAX_KEYS = 40
       !! Widest allow-list below; raising it is the only cost of a new key.
       !! optimization_keys is now the widest: the transition-state work added
       !! `target`, and the chain-of-states work `endpoint`, `neb_endpoints`,
-      !! `images` and `neb_spring`, which took it past fragmentation_keys (21,
+      !! `images`, `neb_spring`, the dimer controls and `connect`, which took it
+      !! past fragmentation_keys (21,
       !! pushed there by its FMO inner-SCF controls and bond_breaking/cap_scale).
       !! This keeps headroom above that.
       !!
@@ -521,6 +522,8 @@ contains
       call allow(keys, "dimer_separation")
       call allow(keys, "dimer_max_rotations")
       call allow(keys, "dimer_rotation_tolerance")
+      call allow(keys, "connect")
+      call allow(keys, "connect_distort")
       call allow(keys, "frozen_atoms")
       call allow(keys, "constraints")
       call allow(keys, "timestep")

--- a/src/optimization/mqc_dlfind_bridge_stub.f90
+++ b/src/optimization/mqc_dlfind_bridge_stub.f90
@@ -15,6 +15,7 @@ module mqc_dlfind_bridge
 
    public :: dlfind_available
    public :: dlfind_optimize
+   public :: dlfind_connected_minima
 
 contains
 
@@ -23,6 +24,22 @@ contains
       logical :: available
       available = .false.
    end function dlfind_available
+
+   subroutine dlfind_connected_minima(a, energy_first, b, energy_second, found, e_saddle)
+      !! Nothing ran, so nothing was connected
+      real(dp), allocatable, intent(out) :: a(:, :), b(:, :)
+      real(dp), intent(out) :: energy_first, energy_second
+      logical, intent(out) :: found
+      real(dp), intent(out) :: e_saddle
+
+      found = .false.
+      e_saddle = 0.0_dp
+      energy_first = 0.0_dp
+      energy_second = 0.0_dp
+      if (.false.) then
+         allocate (a(0, 0), b(0, 0))
+      end if
+   end subroutine dlfind_connected_minima
 
    subroutine dlfind_optimize(opt_settings, natoms, znuc, residues, coords, &
                               energy_gradient, step_taken, final_energy, error, &

--- a/src/optimization/mqc_geometry_optimizer.f90
+++ b/src/optimization/mqc_geometry_optimizer.f90
@@ -39,7 +39,9 @@ module mqc_geometry_optimizer
    use mqc_method_types, only: method_type_to_string, METHOD_TYPE_GFN1, METHOD_TYPE_GFN2
    use mqc_error, only: error_t, ERROR_GENERIC, ERROR_VALIDATION
    use mqc_elements, only: element_number_to_symbol
-   use mqc_dlfind_bridge, only: dlfind_available, dlfind_optimize
+   use mqc_physical_constants, only: HARTREE_TO_KCALMOL
+   use mqc_dlfind_bridge, only: dlfind_available, dlfind_optimize, &
+                                dlfind_connected_minima
    use mqc_optimization_output, only: optimization_record_t, write_optimization_json, &
                                       write_trajectory_xyz
    use mqc_frag_utils, only: generate_mbe_term_list
@@ -297,6 +299,9 @@ contains
             ! optimizer was still moving away from describes that point and
             ! not the minimum, and reporting it beside a "did not converge"
             ! line invites it to be read as the minimum's.
+            if (config%optimization%connect .and. converged .and. .not. error%has_error()) then
+               call report_connected_minima(sys_geom)
+            end if
             if (config%optimization%hess_end .and. converged .and. .not. error%has_error()) then
                call run_final_hessian(sys_geom, config%optimization%target)
             end if
@@ -786,6 +791,68 @@ contains
       call logger%info(" ")
 
    end subroutine run_final_hessian
+
+   subroutine report_connected_minima(sys_geom)
+      !! The two minima the saddle falls to, and the barrier from each side
+      !!
+      !! One imaginary frequency proves a first-order saddle. It does not prove
+      !! the saddle joins the two structures anybody had in mind, and a
+      !! transition state between the wrong pair of minima is a number that
+      !! looks entirely reasonable and describes a different reaction.
+      !!
+      !! Displacing along the imaginary mode and relaxing in each direction is
+      !! what settles it. It is not an intrinsic reaction coordinate -- the path
+      !! taken downhill is a minimisation path rather than the steepest-descent
+      !! one -- but the endpoints are the same, and the endpoints are the
+      !! question.
+      type(system_geometry_t), intent(in) :: sys_geom
+
+      real(dp), allocatable :: side_a(:, :), side_b(:, :)
+      real(dp) :: e_a, e_b, saddle_energy
+      logical :: found
+      character(len=LINE_LEN) :: line
+
+      call dlfind_connected_minima(side_a, e_a, side_b, e_b, found, saddle_energy)
+      if (.not. found) then
+         call logger%warning("  the downhill runs did not reach two minima, so what this "// &
+                             "saddle connects is unknown")
+         return
+      end if
+
+      call logger%info("  the saddle relaxes to two minima:")
+      write (line, "(a,f20.12,a)") "     forward   ", e_a, " Hartree"
+      call logger%info(trim(line))
+      write (line, "(a,f20.12,a)") "     backward  ", e_b, " Hartree"
+      call logger%info(trim(line))
+      write (line, "(a,f14.6,a,f14.6,a)") "     barrier from each side: ", &
+         (saddle_energy - e_a)*HARTREE_TO_KCALMOL, " and ", &
+         (saddle_energy - e_b)*HARTREE_TO_KCALMOL, " kcal/mol"
+      call logger%info(trim(line))
+      call write_side_xyz("connected_forward.xyz", sys_geom, side_a, e_a)
+      call write_side_xyz("connected_backward.xyz", sys_geom, side_b, e_b)
+      call logger%info("  written to connected_forward.xyz and connected_backward.xyz")
+      call logger%info(" ")
+   end subroutine report_connected_minima
+
+   subroutine write_side_xyz(filename, sys_geom, coords, energy)
+      !! One connected minimum, in Angstroms, for whatever opens it next
+      character(len=*), intent(in) :: filename
+      type(system_geometry_t), intent(in) :: sys_geom
+      real(dp), intent(in) :: coords(:, :)
+      real(dp), intent(in) :: energy
+
+      integer :: unit, stat, i
+
+      open (newunit=unit, file=filename, status="replace", action="write", iostat=stat)
+      if (stat /= 0) return
+      write (unit, "(i0)") size(sys_geom%element_numbers)
+      write (unit, "(a,f20.12,a)") "metalquicha connected minimum, E = ", energy, " Hartree"
+      do i = 1, size(sys_geom%element_numbers)
+         write (unit, "(a4,3f20.12)") element_number_to_symbol(sys_geom%element_numbers(i)), &
+            to_angstrom(coords(1, i)), to_angstrom(coords(2, i)), to_angstrom(coords(3, i))
+      end do
+      close (unit)
+   end subroutine write_side_xyz
 
    subroutine load_endpoint(path, atomic_numbers, endpoint, error)
       !! Read the second structure of a chain-of-states run

--- a/src/optimization/mqc_optimizer_types.f90
+++ b/src/optimization/mqc_optimizer_types.f90
@@ -209,6 +209,16 @@ module mqc_optimizer_types
       real(dp) :: dimer_rotation_tolerance = -1.0_dp
          !! Stop rotating once the angle falls below this. Negative is the
          !! engine default.
+      logical :: connect = .false.
+         !! After the saddle is found, follow its imaginary mode downhill in
+         !! both directions and report the two minima it falls to. One
+         !! imaginary frequency proves a first-order saddle; it does not prove
+         !! the saddle joins the two structures anybody had in mind, and this
+         !! is the check that settles it.
+      real(dp) :: connect_distort = -1.0_dp
+         !! How far to displace along the imaginary mode before relaxing.
+         !! Negative is the engine default. Too small and both sides fall back
+         !! to the saddle; too large and they skip past the adjacent minima.
       integer :: hessian_update = OPT_HESSIAN_UPDATE_ENGINE
          !! How curvature is carried between steps once a Hessian exists.
          !! Ignored by the algorithms that never build one.

--- a/test/test_mqc_optimizer_types.f90
+++ b/test/test_mqc_optimizer_types.f90
@@ -58,9 +58,26 @@ contains
                   new_unittest("only_saddle_capable_algorithms", test_saddle_capable), &
                   new_unittest("neb_endpoints_parse", test_neb_ends), &
                   new_unittest("neb_defaults_are_off", test_neb_defaults), &
-                  new_unittest("saddle_method_parses", test_saddle_method) &
+                  new_unittest("saddle_method_parses", test_saddle_method), &
+                  new_unittest("connect_defaults_off", test_connect_defaults) &
                   ]
    end subroutine collect_mqc_optimizer_types_tests
+
+   subroutine test_connect_defaults(error)
+      !! Following a saddle downhill is opt-in
+      !!
+      !! It has to be: a connect run does not stop at the saddle, it carries on
+      !! into two minimisations, so turning it on by accident changes both what
+      !! the run costs and which geometry it finishes on.
+      type(error_type), allocatable, intent(out) :: error
+      type(optimizer_settings_t) :: settings
+
+      call check(error,.not. settings%connect, &
+                 "an optimization must not follow anything downhill unless asked")
+      if (allocated(error)) return
+      call check(error, settings%connect_distort < 0.0_dp, &
+                 "a negative displacement means the engine default")
+   end subroutine test_connect_defaults
 
    subroutine test_saddle_method(error)
       !! How a deck spells the way a saddle is hunted


### PR DESCRIPTION
One imaginary frequency proves a first-order saddle. It does not prove the saddle joins the two minima anybody had in mind, and a transition state between the wrong pair is a barrier height that looks entirely reasonable and describes a different reaction.

`keywords.optimization.connect` displaces along the imaginary mode in each direction after convergence, relaxes, and reports the two minima with the barrier from each side. This is DL-FIND's task 1011. It is not an IRC — the route downhill is an ordinary minimisation path, not the mass-weighted steepest-descent one — but the endpoints are the same, and the endpoints are the question. A true IRC is not on offer: DL-FIND has no `dlf_irc.f90`.

Three things found by running it:

* DL-FIND hands the transition structure and the two minima back only from inside `printf >= 4` blocks. At the default the downhill runs happen, announce themselves finished, and are never passed to the caller.
* The energy the optimizer finishes with belongs to the second minimum, not the saddle — a connect run does not stop there. The saddle's energy is taken from the `switch == 3` callback instead. Without that the barrier prints as zero, plausible for a symmetric reaction and wrong for every other one.
* `connect` with `hess_end` is refused. The final Hessian would describe the second minimum and correctly report no imaginary frequencies, which reads as the saddle having been checked and failed.

The stub grew `dlfind_connected_minima` and the `endpoint` argument it was owed two commits ago. A build with `MQC_ENABLE_DLFIND=OFF` did not compile between those two commits; it does now, and both configurations are built from here on.

**Verified**: ammonia inversion at HF/STO-3G — the dimer finds the planar saddle, relaxing off it both ways gives minima at -55.4554197589 and -55.4554197960 Hartree (same to eight decimals, as a mirror-image inversion must), barrier 11.1410 / 11.1411 kcal/mol from either side.

---

**Stack** (merge bottom-up):

1. #292 `feat/ts-search` — target: saddle, and read the result that way
2. #293 `feat/ts-neb` — NEB band with climbing image
3. #294 `feat/ts-dimer` — dimer method, Hessian-free
4. #295 `feat/ts-connect` — walk off the saddle both ways
5. #296 `feat/ts-mode-following` — zero modes, so P-RFO stops climbing rotations

This PR is #4 of the stack; it is based on the one below it, so its diff is only its own commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ER5Y9FP9PEWpXLVcy1atuu
