### PR TITLE
Stop P-RFO from climbing a rotation

### DIFF
--- a/backends/dlfind/mqc_dlfind_bridge.f90
+++ b/backends/dlfind/mqc_dlfind_bridge.f90
@@ -503,6 +503,11 @@ contains
       ! against its serial stubs. Splitting the job again underneath would be
       ! two schedulers dividing the same ranks.
       ntasks = 1_c_int
+      if (settings%zero_modes >= 0) nzero = int(settings%zero_modes, c_int)
+      if (settings%soft_mode_threshold > 0.0_dp) then
+         soft = real(settings%soft_mode_threshold, c_double)
+      end if
+
       if (settings%connect) then
          task = DLF_TASK_TS_AND_DOWNHILL
          if (settings%connect_distort > 0.0_dp) then

--- a/mqc_docs/source/geometry_optimization.rst
+++ b/mqc_docs/source/geometry_optimization.rst
@@ -305,6 +305,13 @@ All optional. Everything under ``keywords.optimization``:
    * - ``dimer_rotation_tolerance``
      - engine
      - Stop rotating below this angle
+   * - ``zero_modes``
+     - engine
+     - Hessian eigenvalues to treat as zero rather than as vibrations. 6 in
+       Cartesians (5 if linear), 0 in internals. See :ref:`zero-modes`
+   * - ``soft_mode_threshold``
+     - engine
+     - Eigenvalues smaller than this are soft; P-RFO damps steps along them
    * - ``connect``
      - ``false``
      - After the saddle, relax downhill both ways and report the two minima.
@@ -390,6 +397,57 @@ around on anything but a small system.
 and an update thereafter, rather than a fresh one per step. ``bofill`` is the
 usual choice for a saddle point, because it does not assume the matrix is
 positive definite -- which at a transition state it is not.
+
+.. _zero-modes:
+
+Telling P-RFO which modes are not vibrations
+---------------------------------------------
+
+P-RFO maximises along the lowest Hessian eigenvalue. In Cartesian coordinates
+the lowest six modes are translations and rotations at roughly zero, and far
+from a saddle -- where there is no negative eigenvalue yet -- the lowest one is
+one of those. The search then climbs a rotation, and wanders.
+
+``zero_modes`` says how many of them there are, so they are recognised rather
+than followed::
+
+    "keywords": {
+      "optimization": {
+        "target": "saddle", "algorithm": "prfo",
+        "coordinates": "cartesian",
+        "zero_modes": 6
+      }
+    }
+
+Six for a non-linear molecule, five for a linear one, and **zero for internal
+coordinates**, which have no rotational or translational degrees of freedom to
+begin with. That is why the default is the engine's own rather than 6: a value
+right for Cartesians is wrong in DLC, where saddle searches are usually run.
+
+The difference this makes on the ``HCN`` to ``HNC`` saddle, Cartesian
+coordinates, same guess and same analytic Hessian::
+
+    no zero_modes     60 steps, did not converge
+    zero_modes: 6     13 steps, converged
+
+Both reach the same saddle when they reach one at all -- C-N 1.187, H-C 1.209,
+H-N 1.400 Angstrom, one imaginary frequency. Declaring the zero modes is the
+alternative to switching coordinate systems, and the warning a Cartesian saddle
+search prints is suppressed once you have.
+
+``soft_mode_threshold`` is the related knob for eigenvalues that are small but
+not meant to be zero: steps along them are damped rather than trusted.
+
+.. note::
+
+   Neither of these chooses *which* eigenvector to follow -- they only decide
+   which are ignored. Genuine mode following, where the search tracks a
+   particular mode by overlap from step to step, is not reachable. DL-FIND
+   implements it (``follow=2`` and ``follow=3`` in ``dlf_formstep.f90``) but
+   ``follow`` is a local variable hardcoded to zero, with the comment "get from
+   global eventually", and there is no field on its global state to read it
+   from. Exposing it means adding a parameter to DL-FIND's own C interface,
+   which is a change to the vendored dependency rather than to this program.
 
 .. _connect:
 
@@ -623,8 +681,9 @@ which is L-BFGS -- so a saddle search has to say which optimizer runs it.
    search that never mentioned coordinates gets. The warning says so, and says
    that the run will spend all of ``max_steps`` before giving up. It is a
    warning rather than a refusal because a Cartesian saddle search can be made
-   to work, from a guess close enough that the reaction mode is already the
-   lowest eigenvalue, where a downhill algorithm cannot.
+   to work -- declare the zero modes, as below, or start from a guess close
+   enough that the reaction mode is already the lowest eigenvalue -- where a
+   downhill algorithm cannot. Declaring them also silences this warning.
 
 .. _opt-constraints:
 

--- a/src/io/mqc_config_adapter.f90
+++ b/src/io/mqc_config_adapter.f90
@@ -543,6 +543,8 @@ contains
          end if
       end if
 
+      driver_config%optimization%zero_modes = mqc_config%opt_zero_modes
+      driver_config%optimization%soft_mode_threshold = mqc_config%opt_soft_modes
       driver_config%optimization%connect = mqc_config%opt_connect
       driver_config%optimization%connect_distort = mqc_config%opt_connect_distort
 
@@ -629,7 +631,8 @@ contains
          ! lands here, which is why the warning says what it will cost rather
          ! than only what it is.
          if (driver_config%optimization%coordinates == OPT_COORDS_CARTESIAN .and. &
-             driver_config%optimization%saddle_method == SADDLE_METHOD_PRFO) then
+             driver_config%optimization%saddle_method == SADDLE_METHOD_PRFO .and. &
+             driver_config%optimization%zero_modes < 0) then
             if (allocated(mqc_config%opt_coordinates)) then
                call logger%warning("  keywords.optimization: a saddle search in Cartesian "// &
                                    "coordinates follows a rotation, not the reaction mode.")
@@ -641,8 +644,10 @@ contains
             call logger%warning("     Expect it to wander for all "// &
                                 to_char(driver_config%optimization%max_steps)// &
                                 " steps without converging.")
-            call logger%warning("     Use coordinates 'dlc' (or 'hdlc' for a cluster) "// &
-                                "unless you have a reason not to.")
+            call logger%warning("     Use coordinates 'dlc' (or 'hdlc' for a cluster), or "// &
+                                "set zero_modes to 6 (5 if linear) so the")
+            call logger%warning("     translations and rotations are recognised as zero "// &
+                                "rather than followed.")
          end if
       end if
 

--- a/src/io/mqc_config_types.f90
+++ b/src/io/mqc_config_types.f90
@@ -426,6 +426,8 @@ module mqc_config_types
       real(dp) :: opt_dimer_separation = -1.0_dp       !! <0 = engine default
       integer :: opt_dimer_max_rotations = -1          !! <0 = engine default
       real(dp) :: opt_dimer_rot_tol = -1.0_dp          !! <0 = engine default
+      integer :: opt_zero_modes = -1                   !! <0 = engine default
+      real(dp) :: opt_soft_modes = -1.0_dp             !! <0 = engine default
       logical :: opt_connect = .false.                 !! Relax downhill from the saddle
       real(dp) :: opt_connect_distort = -1.0_dp        !! <0 = engine default
       real(dp) :: opt_timestep = -1.0_dp               !! Damped dynamics step

--- a/src/io/mqc_json_config_reader.f90
+++ b/src/io/mqc_json_config_reader.f90
@@ -434,6 +434,9 @@ contains
                         config%opt_dimer_max_rotations)
       call optional_real(json, "keywords.optimization.dimer_rotation_tolerance", &
                          config%opt_dimer_rot_tol)
+      call optional_int(json, "keywords.optimization.zero_modes", config%opt_zero_modes)
+      call optional_real(json, "keywords.optimization.soft_mode_threshold", &
+                         config%opt_soft_modes)
       call optional_logical(json, "keywords.optimization.connect", config%opt_connect)
       call optional_real(json, "keywords.optimization.connect_distort", &
                          config%opt_connect_distort)

--- a/src/io/mqc_json_schema.f90
+++ b/src/io/mqc_json_schema.f90
@@ -522,6 +522,8 @@ contains
       call allow(keys, "dimer_separation")
       call allow(keys, "dimer_max_rotations")
       call allow(keys, "dimer_rotation_tolerance")
+      call allow(keys, "zero_modes")
+      call allow(keys, "soft_mode_threshold")
       call allow(keys, "connect")
       call allow(keys, "connect_distort")
       call allow(keys, "frozen_atoms")

--- a/src/optimization/mqc_optimizer_types.f90
+++ b/src/optimization/mqc_optimizer_types.f90
@@ -209,6 +209,16 @@ module mqc_optimizer_types
       real(dp) :: dimer_rotation_tolerance = -1.0_dp
          !! Stop rotating once the angle falls below this. Negative is the
          !! engine default.
+      integer :: zero_modes = -1
+         !! How many Hessian eigenvalues to treat as zero rather than as
+         !! vibrations. Negative is the engine default. Six for a non-linear
+         !! molecule in Cartesian coordinates -- three translations and three
+         !! rotations -- and five for a linear one. Internal coordinates have
+         !! none, which is why this is off by default.
+      real(dp) :: soft_mode_threshold = -1.0_dp
+         !! Eigenvalues smaller than this in magnitude are soft: P-RFO steps
+         !! along them are damped rather than trusted. Negative is the engine
+         !! default.
       logical :: connect = .false.
          !! After the saddle is found, follow its imaginary mode downhill in
          !! both directions and report the two minima it falls to. One

--- a/test/test_mqc_optimizer_types.f90
+++ b/test/test_mqc_optimizer_types.f90
@@ -59,9 +59,26 @@ contains
                   new_unittest("neb_endpoints_parse", test_neb_ends), &
                   new_unittest("neb_defaults_are_off", test_neb_defaults), &
                   new_unittest("saddle_method_parses", test_saddle_method), &
-                  new_unittest("connect_defaults_off", test_connect_defaults) &
+                  new_unittest("connect_defaults_off", test_connect_defaults), &
+                  new_unittest("mode_handling_defaults", test_mode_handling) &
                   ]
    end subroutine collect_mqc_optimizer_types_tests
+
+   subroutine test_mode_handling(error)
+      !! Zero and soft modes default to the engine's own choice
+      !!
+      !! Negative rather than a number, because the right value depends on the
+      !! coordinate system: six for a non-linear molecule in Cartesians, five
+      !! for a linear one, none at all in internal coordinates. A default of 6
+      !! would be wrong in DLC, which is where saddle searches are usually run.
+      type(error_type), allocatable, intent(out) :: error
+      type(optimizer_settings_t) :: settings
+
+      call check(error, settings%zero_modes < 0, &
+                 "the zero-mode count must default to the engine's, not to six")
+      if (allocated(error)) return
+      call check(error, settings%soft_mode_threshold < 0.0_dp)
+   end subroutine test_mode_handling
 
    subroutine test_connect_defaults(error)
       !! Following a saddle downhill is opt-in


### PR DESCRIPTION
Phase 0 of this work found that a Cartesian saddle search does not converge: 60 steps and no answer on HCN/HNC, against four in DLC from the same guess and Hessian. The cause is that P-RFO maximises along the lowest Hessian eigenvalue, and in Cartesians the lowest six modes are translations and rotations. Far from a saddle there is no negative eigenvalue yet, so the lowest is a rotation, and the search climbs it.

`zero_modes` says how many there are. Declaring them turns the same Cartesian run from 60 steps and no convergence into 13 steps and the saddle — C-N 1.187, H-C 1.209, H-N 1.400 Å, one imaginary frequency, the same structure DLC finds. `soft_mode_threshold` is the related knob for eigenvalues that are small without being meant as zero.

The default is the engine's own rather than 6, because the right value is a property of the coordinate system: six for a non-linear molecule in Cartesians, five for a linear one, none at all in internals, which is where saddle searches are usually run. The Cartesian warning added earlier now names this as the alternative to switching coordinates, and is suppressed once a deck has declared them.

What this is not: mode following. These decide which modes are ignored, not which eigenvector is tracked. Genuine mode following is implemented in DL-FIND (`follow=2`/`follow=3` in `dlf_formstep.f90`) and is unreachable — `follow` is a local variable hardcoded to zero under the comment "get from global eventually - IMPROVE", with no field on the global state to read it from and no parameter in the C interface to carry it. Reaching it means changing the vendored dependency's own API. The documentation says so, with the file and variable, so the next person does not rediscover it.

---

**Stack** (merge bottom-up):

1. #292 `feat/ts-search` — target: saddle, and read the result that way
2. #293 `feat/ts-neb` — NEB band with climbing image
3. #294 `feat/ts-dimer` — dimer method, Hessian-free
4. #295 `feat/ts-connect` — walk off the saddle both ways
5. #296 `feat/ts-mode-following` — zero modes, so P-RFO stops climbing rotations

This PR is #5 of the stack; it is based on the one below it, so its diff is only its own commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ER5Y9FP9PEWpXLVcy1atuu
