### PR TITLE
Call cuEST's VV10

### DIFF
--- a/backends/cuest/backend/mqc_cuest_functionals.f90
+++ b/backends/cuest/backend/mqc_cuest_functionals.f90
@@ -37,32 +37,6 @@ module mqc_cuest_functionals
 
 contains
 
-   subroutine vv10_unsupported(name, error)
-      !! Refuse a `-V` functional on this backend
-      !!
-      !! **cuEST can do this and mqc does not ask it to.** The library exposes
-      !! `CUEST_XCINTPLAN_IS_VV10`, the `VV10_B`/`VV10_C`/`VV10_SCALE`
-      !! attributes and a separate `cuestNonlocalXCPotential*Compute` entry
-      !! point; this backend sets the exchange scales and nothing else, and
-      !! never calls that routine. The semilocal half alone converges and
-      !! prints a number 43 mHa wrong on water -- so before this refusal, a GPU
-      !! run of wb97x-v produced a confident wrong answer where the CPU path
-      !! produced an error.
-      !!
-      !! Refused by name rather than by querying IS_VV10, which would be the
-      !! better test and would cover functionals cuEST adds later, because it
-      !! has to hold on a machine with no GPU to check it on. Wiring the
-      !! nonlocal compute is the real fix and needs a card.
-      character(len=*), intent(in) :: name
-      type(error_t), intent(out) :: error
-
-      call error%set(ERROR_VALIDATION, "'"//name//"' carries a non-local correlation "// &
-                     "term (VV10). cuEST implements it, but this backend does not yet "// &
-                     "enable it, and the semilocal part alone is a different functional "// &
-                     "-- 43 mHa on water. Refused rather than evaluated without it; the "// &
-                     "CPU path runs this functional.")
-   end subroutine vv10_unsupported
-
    subroutine functional_name_to_id(name, functional_id, error)
       !! Translate a functional name into the cuEST XC plan identifier
       !!
@@ -100,18 +74,15 @@ contains
       case ("svwn5", "lda", "svwn")
          functional_id = CUEST_XCINTPLAN_PARAMETERS_FUNCTIONAL_SVWN5
       case ("b97m-v", "b97mv")
-         call vv10_unsupported("b97m-v", error)
-         return
+         functional_id = CUEST_XCINTPLAN_PARAMETERS_FUNCTIONAL_B97MV
       case ("lc-wpbe", "lcwpbe")
          functional_id = CUEST_XCINTPLAN_PARAMETERS_FUNCTIONAL_LCWPBE
       case ("wb97x")
          functional_id = CUEST_XCINTPLAN_PARAMETERS_FUNCTIONAL_WB97X
       case ("wb97x-v", "wb97xv")
-         call vv10_unsupported("wb97x-v", error)
-         return
+         functional_id = CUEST_XCINTPLAN_PARAMETERS_FUNCTIONAL_WB97XV
       case ("wb97m-v", "wb97mv")
-         call vv10_unsupported("wb97m-v", error)
-         return
+         functional_id = CUEST_XCINTPLAN_PARAMETERS_FUNCTIONAL_WB97MV
       case ("lc-wpbeh", "lcwpbeh")
          functional_id = CUEST_XCINTPLAN_PARAMETERS_FUNCTIONAL_LCWPBEH
       case ("cam-b3lyp", "camb3lyp")

--- a/backends/cuest/backend/mqc_cuest_gradient.f90
+++ b/backends/cuest/backend/mqc_cuest_gradient.f90
@@ -32,7 +32,7 @@ module mqc_cuest_gradient
    use pic_types, only: dp
    use mqc_nuclear_repulsion, only: add_nuclear_repulsion_gradient
    use pic_blas_interfaces, only: pic_gemm
-   use mqc_error, only: error_t
+   use mqc_error, only: error_t, ERROR_VALIDATION
    use mqc_cuest_integrals, only: cuest_system_t
    use mqc_cuest_scf, only: scf_result_t
    implicit none
@@ -100,6 +100,21 @@ contains
       real(dp), allocatable :: term(:, :), weighted(:, :), half_density(:, :)
       real(dp), allocatable :: weighted_beta(:, :)
       integer :: n_atoms, n_ao
+
+      ! A VV10 gradient is not the semilocal gradient. cuestXCDerivativeRKSCompute
+      ! returns the derivative of the semilocal part; the non-local term has its
+      ! own entry point, cuestNonlocalXCDerivativeRKSCompute, which this does not
+      ! call. Refused rather than omitted, because omitting it survives every
+      ! check a user can make -- the SCF converges, the energy is right, and the
+      ! forces are quietly wrong, so an optimisation walks to the wrong minimum.
+      ! This is the same refusal the CPU path makes, for the same reason.
+      if (system%has_nlc) then
+         call error%set(ERROR_VALIDATION, "this functional carries a non-local "// &
+                        "correlation term (VV10), whose contribution to the nuclear "// &
+                        "gradient is not implemented on the GPU path. Refused rather "// &
+                        "than returning a gradient missing it.")
+         return
+      end if
 
       n_atoms = size(atomic_numbers)
       n_ao = size(scf%density, 1)

--- a/backends/cuest/backend/mqc_cuest_integrals.f90
+++ b/backends/cuest/backend/mqc_cuest_integrals.f90
@@ -107,8 +107,23 @@ module mqc_cuest_integrals
                     CUEST_MOLECULARGRID_PARAMETERS, CUEST_XCINTPLAN_PARAMETERS, &
                     CUEST_XCPOTENTIALRKSCOMPUTE_PARAMETERS, &
                     CUEST_XCINTPLAN, CUEST_XCINTPLAN_EXCHANGE_SCALE, &
-                    CUEST_XCINTPLAN_LRC_EXCHANGE_SCALE, CUEST_XCINTPLAN_LRC_OMEGA
-   use cuest_helpers, only: cuest_query_i64, cuest_query_f64, cuest_param_set_f64, &
+                    CUEST_XCINTPLAN_LRC_EXCHANGE_SCALE, CUEST_XCINTPLAN_LRC_OMEGA, &
+                    CUEST_XCINTPLAN_IS_VV10, CUEST_XCINTPLAN_VV10_B, &
+                    CUEST_XCINTPLAN_VV10_C, CUEST_XCINTPLAN_VV10_SCALE, &
+                    CUEST_NONLOCALXCPOTENTIALRKSCOMPUTE_PARAMETERS, &
+                    CUEST_NONLOCALXCPOTENTIALUKSCOMPUTE_PARAMETERS, &
+                    CUEST_NONLOCALXCPOTENTIALRKSCOMPUTE_PARAMETERS_VV10_B, &
+                    CUEST_NONLOCALXCPOTENTIALRKSCOMPUTE_PARAMETERS_VV10_C, &
+                    CUEST_NONLOCALXCPOTENTIALRKSCOMPUTE_PARAMETERS_VV10_SCALE, &
+                    CUEST_NONLOCALXCPOTENTIALUKSCOMPUTE_PARAMETERS_VV10_B, &
+                    CUEST_NONLOCALXCPOTENTIALUKSCOMPUTE_PARAMETERS_VV10_C, &
+                    CUEST_NONLOCALXCPOTENTIALUKSCOMPUTE_PARAMETERS_VV10_SCALE, &
+                    cuestNonlocalXCPotentialRKSCompute, &
+                    cuestNonlocalXCPotentialRKSComputeWorkspaceQuery, &
+                    cuestNonlocalXCPotentialUKSCompute, &
+                    cuestNonlocalXCPotentialUKSComputeWorkspaceQuery
+   use cuest_helpers, only: cuest_query_i64, cuest_query_i32, cuest_query_f64, &
+                            cuest_param_set_f64, &
                             cuest_param_set_i64, cuest_results_query_f64, &
                             cuest_results_query_i64
    implicit none
@@ -196,6 +211,20 @@ module mqc_cuest_integrals
       real(dp) :: lrc_omega = 0.0_dp
          !! Range-separation parameter
 
+      logical :: has_nlc = .false.
+         !! Whether the functional carries VV10 non-local correlation.
+         !!
+         !! Queried from the plan rather than matched against a list of names,
+         !! so a `-V` functional cuEST adds later is covered without a change
+         !! here. It also means the check cannot drift out of step with what
+         !! the plan was actually built for.
+      real(dp) :: nlc_b = 0.0_dp
+      real(dp) :: nlc_c = 0.0_dp
+         !! VV10's own two parameters, as the plan reports them
+      real(dp) :: nlc_scale = 0.0_dp
+         !! How much of the non-local term the functional wants. Queried and
+         !! passed through rather than assumed to be 1.
+
       logical :: has_xc = .false.
          !! Whether an XC plan exists, i.e. this is DFT rather than HF
       logical :: needs_exchange = .true.
@@ -272,6 +301,8 @@ module mqc_cuest_integrals
       procedure :: coulomb_device => system_coulomb_device
       procedure :: exchange_device => system_exchange_device
       procedure :: xc_device => system_xc_device
+      procedure :: nlc_device => system_nlc_device
+      procedure :: nlc_uks_device => system_nlc_uks_device
       procedure :: pcm_device => system_pcm_device
       procedure :: build_pcm => build_pcm_plan
       procedure :: xc_uks_device => system_xc_uks_device
@@ -887,6 +918,7 @@ contains
       type(c_ptr) :: grid_params, plan_params
       real(dp), allocatable, target :: xyz(:)
       integer(c_int) :: status
+      integer(c_int) :: is_vv10
 
       ! ---- per-atom grids ---------------------------------------------------
       call build_atom_grids(this%handle, atomic_numbers, n_radial, n_angular, &
@@ -969,6 +1001,27 @@ contains
       call cuest_status_check(cuest_query_f64(this%handle, CUEST_XCINTPLAN, this%xc_plan, &
                                               CUEST_XCINTPLAN_LRC_OMEGA, this%lrc_omega), &
                               "query XC plan range-separation parameter", error)
+
+      ! ---- and whether it carries VV10 --------------------------------------
+      ! Asked of the plan, not of the name the deck used. `is_vv10` is the
+      ! plan's own answer, so a functional cuEST adds later is handled here
+      ! without a list to keep in step.
+      is_vv10 = 0
+      call cuest_status_check(cuest_query_i32(this%handle, CUEST_XCINTPLAN, this%xc_plan, &
+                                              CUEST_XCINTPLAN_IS_VV10, is_vv10), &
+                              "query XC plan VV10 flag", error)
+      this%has_nlc = (is_vv10 /= 0)
+      if (this%has_nlc) then
+         call cuest_status_check(cuest_query_f64(this%handle, CUEST_XCINTPLAN, this%xc_plan, &
+                                                 CUEST_XCINTPLAN_VV10_B, this%nlc_b), &
+                                 "query XC plan VV10 b", error)
+         call cuest_status_check(cuest_query_f64(this%handle, CUEST_XCINTPLAN, this%xc_plan, &
+                                                 CUEST_XCINTPLAN_VV10_C, this%nlc_c), &
+                                 "query XC plan VV10 c", error)
+         call cuest_status_check(cuest_query_f64(this%handle, CUEST_XCINTPLAN, this%xc_plan, &
+                                                 CUEST_XCINTPLAN_VV10_SCALE, this%nlc_scale), &
+                                 "query XC plan VV10 scale", error)
+      end if
    end subroutine build_xc_plan
 
    subroutine build_pcm_plan(this, atomic_numbers, pcm, error)
@@ -1419,6 +1472,185 @@ contains
 
       if (.not. error%has_error()) xc_energy = energy
    end subroutine system_xc_device
+
+   subroutine system_nlc_device(this, d_c_occ, d_out, nlc_energy, error)
+      !! VV10 non-local correlation, RKS, device in and device out
+      !!
+      !! **Adds into `d_out`.** `system_xc_device` has already written the
+      !! semilocal potential there, and this is a second contribution to the
+      !! same matrix rather than a replacement for it -- cuEST keeps the two
+      !! behind separate entry points because the non-local term is a double
+      !! integral over the density rather than a functional of it at a point.
+      !!
+      !! The accumulation goes through a scratch matrix and a daxpy rather than
+      !! handing cuEST `d_out` directly, because whether the routine adds to its
+      !! output or overwrites it is not something this code can assume. Writing
+      !! into a buffer of our own and adding it is correct either way, and costs
+      !! one n_ao^2 allocation per call.
+      class(cuest_system_t), intent(inout) :: this
+      type(c_ptr), intent(in) :: d_c_occ   !! Occupied MOs, (n_ao, n_occ) on device
+      type(c_ptr), intent(in) :: d_out     !! Vxc, (n_ao, n_ao) on device, added to
+      real(dp), intent(out) :: nlc_energy  !! E_nl, Hartree
+      type(error_t), intent(inout) :: error
+
+      type(cuestWorkspaceDescriptor_t) :: temporary_desc, variable_buffer
+      type(cuestWorkspace_t) :: temporary_ws
+      type(c_ptr) :: params, d_v_nl
+      integer(c_int) :: status
+      real(dp), target :: energy
+
+      nlc_energy = 0.0_dp
+      if (error%has_error() .or. .not. this%has_xc .or. .not. this%has_nlc) return
+
+      d_v_nl = c_null_ptr
+      call device_alloc(d_v_nl, this%n_ao*this%n_ao, "VV10 potential matrix", error)
+      if (error%has_error()) return
+
+      params = c_null_ptr
+      call cuest_status_check(cuestParametersCreate(CUEST_NONLOCALXCPOTENTIALRKSCOMPUTE_PARAMETERS, &
+                                                    params), &
+                              "cuestParametersCreate(RKS VV10 potential)", error)
+
+      ! The plan knows b, c and the scale; they are handed to the compute call
+      ! rather than re-derived, so the two cannot disagree about the functional.
+      if (.not. error%has_error()) then
+         call cuest_status_check(cuest_param_set_f64(CUEST_NONLOCALXCPOTENTIALRKSCOMPUTE_PARAMETERS, &
+                                                     params, CUEST_NONLOCALXCPOTENTIALRKSCOMPUTE_PARAMETERS_VV10_B, &
+                                                     this%nlc_b), "set VV10 b (RKS)", error)
+      end if
+      if (.not. error%has_error()) then
+         call cuest_status_check(cuest_param_set_f64(CUEST_NONLOCALXCPOTENTIALRKSCOMPUTE_PARAMETERS, &
+                                                     params, CUEST_NONLOCALXCPOTENTIALRKSCOMPUTE_PARAMETERS_VV10_C, &
+                                                     this%nlc_c), "set VV10 c (RKS)", error)
+      end if
+      if (.not. error%has_error()) then
+         call cuest_status_check(cuest_param_set_f64(CUEST_NONLOCALXCPOTENTIALRKSCOMPUTE_PARAMETERS, &
+                                                     params, CUEST_NONLOCALXCPOTENTIALRKSCOMPUTE_PARAMETERS_VV10_SCALE, &
+                                                     this%nlc_scale), "set VV10 scale (RKS)", error)
+      end if
+
+      variable_buffer%hostBufferSizeInBytes = 0_c_size_t
+      variable_buffer%deviceBufferSizeInBytes = DF_EXCHANGE_BUFFER_BYTES
+
+      energy = 0.0_dp
+      if (.not. error%has_error()) then
+         call cuest_status_check(cuestNonlocalXCPotentialRKSComputeWorkspaceQuery( &
+                                 this%handle, this%xc_plan, params, variable_buffer, &
+                                 temporary_desc, this%n_occ, d_c_occ, c_loc(energy), d_v_nl), &
+                                 "cuestNonlocalXCPotentialRKSComputeWorkspaceQuery", error)
+      end if
+      if (.not. error%has_error()) call workspace_alloc(temporary_ws, temporary_desc, error)
+      if (.not. error%has_error()) then
+         call cuest_status_check(cuestNonlocalXCPotentialRKSCompute( &
+                                 this%handle, this%xc_plan, params, variable_buffer, &
+                                 temporary_ws, this%n_occ, d_c_occ, c_loc(energy), d_v_nl), &
+                                 "cuestNonlocalXCPotentialRKSCompute", error)
+      end if
+      if (.not. error%has_error()) then
+         call cublas_status_check(cublasDaxpy(this%cublas, int(this%n_ao*this%n_ao, c_int), &
+                                              1.0_dp, d_v_nl, 1, d_out, 1), &
+                                  "cublasDaxpy(+VV10)", error)
+      end if
+
+      call workspace_free(temporary_ws)
+      status = cuestParametersDestroy(CUEST_NONLOCALXCPOTENTIALRKSCOMPUTE_PARAMETERS, params)
+      call cuest_status_check(status, "cuestParametersDestroy(RKS VV10 potential)", error)
+      call device_free(d_v_nl)
+
+      if (.not. error%has_error()) nlc_energy = energy
+   end subroutine system_nlc_device
+
+   subroutine system_nlc_uks_device(this, d_c_alpha, d_c_beta, n_occ_beta, &
+                                    d_out_alpha, d_out_beta, nlc_energy, error)
+      !! VV10 non-local correlation, UKS
+      !!
+      !! One call for both spins: VV10 is built from the total density and has
+      !! no spin dependence, so cuEST returns a single potential matrix and a
+      !! single energy. That matrix is added to **both** channels and the energy
+      !! is counted **once** -- the same arrangement the CPU path uses.
+      class(cuest_system_t), intent(inout) :: this
+      type(c_ptr), intent(in) :: d_c_alpha, d_c_beta
+      integer, intent(in) :: n_occ_beta               !! Beta columns, at least 1
+      type(c_ptr), intent(in) :: d_out_alpha, d_out_beta
+      real(dp), intent(out) :: nlc_energy
+      type(error_t), intent(inout) :: error
+
+      type(cuestWorkspaceDescriptor_t) :: temporary_desc, variable_buffer
+      type(cuestWorkspace_t) :: temporary_ws
+      type(c_ptr) :: params, d_v_nl
+      integer(c_int) :: status
+      integer(c_int64_t) :: beta_occupancy
+      real(dp), target :: energy
+
+      nlc_energy = 0.0_dp
+      if (error%has_error() .or. .not. this%has_xc .or. .not. this%has_nlc) return
+
+      ! cuEST requires numOccupiedBeta > 0 even where the molecule has no beta
+      ! electrons; the caller guarantees that column is zeroed, exactly as it
+      ! does for the semilocal path above.
+      beta_occupancy = max(int(n_occ_beta, c_int64_t), 1_c_int64_t)
+
+      d_v_nl = c_null_ptr
+      call device_alloc(d_v_nl, this%n_ao*this%n_ao, "VV10 potential matrix (UKS)", error)
+      if (error%has_error()) return
+
+      params = c_null_ptr
+      call cuest_status_check(cuestParametersCreate(CUEST_NONLOCALXCPOTENTIALUKSCOMPUTE_PARAMETERS, &
+                                                    params), &
+                              "cuestParametersCreate(UKS VV10 potential)", error)
+      if (.not. error%has_error()) then
+         call cuest_status_check(cuest_param_set_f64(CUEST_NONLOCALXCPOTENTIALUKSCOMPUTE_PARAMETERS, &
+                                                     params, CUEST_NONLOCALXCPOTENTIALUKSCOMPUTE_PARAMETERS_VV10_B, &
+                                                     this%nlc_b), "set VV10 b (UKS)", error)
+      end if
+      if (.not. error%has_error()) then
+         call cuest_status_check(cuest_param_set_f64(CUEST_NONLOCALXCPOTENTIALUKSCOMPUTE_PARAMETERS, &
+                                                     params, CUEST_NONLOCALXCPOTENTIALUKSCOMPUTE_PARAMETERS_VV10_C, &
+                                                     this%nlc_c), "set VV10 c (UKS)", error)
+      end if
+      if (.not. error%has_error()) then
+         call cuest_status_check(cuest_param_set_f64(CUEST_NONLOCALXCPOTENTIALUKSCOMPUTE_PARAMETERS, &
+                                                     params, CUEST_NONLOCALXCPOTENTIALUKSCOMPUTE_PARAMETERS_VV10_SCALE, &
+                                                     this%nlc_scale), "set VV10 scale (UKS)", error)
+      end if
+
+      variable_buffer%hostBufferSizeInBytes = 0_c_size_t
+      variable_buffer%deviceBufferSizeInBytes = DF_EXCHANGE_BUFFER_BYTES
+
+      energy = 0.0_dp
+      if (.not. error%has_error()) then
+         call cuest_status_check(cuestNonlocalXCPotentialUKSComputeWorkspaceQuery( &
+                                 this%handle, this%xc_plan, params, variable_buffer, &
+                                 temporary_desc, this%n_occ, beta_occupancy, d_c_alpha, d_c_beta, &
+                                 c_loc(energy), d_v_nl), &
+                                 "cuestNonlocalXCPotentialUKSComputeWorkspaceQuery", error)
+      end if
+      if (.not. error%has_error()) call workspace_alloc(temporary_ws, temporary_desc, error)
+      if (.not. error%has_error()) then
+         call cuest_status_check(cuestNonlocalXCPotentialUKSCompute( &
+                                 this%handle, this%xc_plan, params, variable_buffer, &
+                                 temporary_ws, this%n_occ, beta_occupancy, d_c_alpha, d_c_beta, &
+                                 c_loc(energy), d_v_nl), &
+                                 "cuestNonlocalXCPotentialUKSCompute", error)
+      end if
+      if (.not. error%has_error()) then
+         call cublas_status_check(cublasDaxpy(this%cublas, int(this%n_ao*this%n_ao, c_int), &
+                                              1.0_dp, d_v_nl, 1, d_out_alpha, 1), &
+                                  "cublasDaxpy(+VV10 alpha)", error)
+      end if
+      if (.not. error%has_error()) then
+         call cublas_status_check(cublasDaxpy(this%cublas, int(this%n_ao*this%n_ao, c_int), &
+                                              1.0_dp, d_v_nl, 1, d_out_beta, 1), &
+                                  "cublasDaxpy(+VV10 beta)", error)
+      end if
+
+      call workspace_free(temporary_ws)
+      status = cuestParametersDestroy(CUEST_NONLOCALXCPOTENTIALUKSCOMPUTE_PARAMETERS, params)
+      call cuest_status_check(status, "cuestParametersDestroy(UKS VV10 potential)", error)
+      call device_free(d_v_nl)
+
+      if (.not. error%has_error()) nlc_energy = energy
+   end subroutine system_nlc_uks_device
 
    subroutine system_compute_xc(this, c_occ, xc_energy, xc_potential, error)
       !! Exchange-correlation energy and potential from host MO coefficients

--- a/backends/cuest/backend/mqc_cuest_scf.f90
+++ b/backends/cuest/backend/mqc_cuest_scf.f90
@@ -312,7 +312,7 @@ contains
       type(diis_device_t) :: diis
       integer :: n_ao, n_mo, n_occ, iteration
       real(dp) :: electronic_energy, previous_energy, energy_change, error_norm
-      real(dp) :: xc_energy, pcm_energy, trace_h, trace_j, trace_k
+      real(dp) :: xc_energy, nlc_energy, pcm_energy, trace_h, trace_j, trace_k
       logical :: diis_ok
 
       character(len=MAX_LINE_LENGTH) :: line
@@ -377,6 +377,7 @@ contains
       call build_density_closed_shell(occupied, n_occ, density)
 
       xc_energy = 0.0_dp
+      nlc_energy = 0.0_dp
       pcm_energy = 0.0_dp
       if (use_diis) then
          ! The error vectors live in the orthogonal basis, the Fock matrices in the AO basis.
@@ -453,6 +454,14 @@ contains
          end if
 
          call system%xc_device(system%d_c_occ, system%d_xc, xc_energy, error)
+
+         ! VV10, for a `-V` functional. A second entry point in cuEST, so a
+         ! second call here: it adds its potential into the same matrix and its
+         ! energy into the same total, which is what keeps the Fock assembly and
+         ! the energy expression below unchanged. `nlc_device` returns zero and
+         ! touches nothing when the functional has no non-local term.
+         call system%nlc_device(system%d_c_occ, system%d_xc, nlc_energy, error)
+         xc_energy = xc_energy + nlc_energy
 
          ! The continuum. Solved from the current total density, so it belongs
          ! here beside the other density-dependent terms; the potential it leaves
@@ -685,6 +694,7 @@ contains
       integer :: n_ao, n_mo, n_alpha, n_beta, iteration
       integer :: n_fock_spin, n_err_spin
       real(dp) :: electronic_energy, previous_energy, energy_change, error_norm, xc_energy
+      real(dp) :: nlc_energy
       real(dp) :: pcm_energy
       real(dp) :: trace_h, trace_j, trace_ka, trace_kb
       logical :: diis_ok, occupations_ok, beta_exchange
@@ -771,6 +781,7 @@ contains
       end if
       d_error_beta = device_offset(system%d_error, int(n_err_spin, c_int64_t))
       xc_energy = 0.0_dp
+      nlc_energy = 0.0_dp
       pcm_energy = 0.0_dp
       previous_energy = 0.0_dp
       result%converged = .false.
@@ -839,6 +850,12 @@ contains
 
          call system%xc_uks_device(system%d_c_occ, system%d_c_occ_beta, max(n_beta, 1), &
                                    system%d_xc, system%d_xc_beta, xc_energy, error)
+
+         ! VV10 sees the total density only, so one call serves both spins: the
+         ! same matrix is added to each channel and the energy counted once.
+         call system%nlc_uks_device(system%d_c_occ, system%d_c_occ_beta, max(n_beta, 1), &
+                                    system%d_xc, system%d_xc_beta, nlc_energy, error)
+         xc_energy = xc_energy + nlc_energy
 
          ! The continuum sees the total density, so there is one solve and one
          ! potential for both spins -- `assemble_fock` adds it to each channel.

--- a/mqc_docs/source/capabilities.rst
+++ b/mqc_docs/source/capabilities.rst
@@ -267,7 +267,9 @@ What has a gradient on the CPU backend, at a glance:
      - yes
      - ωB97X-V, ωB97M-V, B97M-V. Self-consistent, restricted and unrestricted,
        on a separate grid set by ``keywords.dft.nlc_grid_level``. **Energy only:
-       the nuclear gradient is refused.** CPU backend only
+       the nuclear gradient is refused**, on both backends. The GPU path calls
+       cuEST's own non-local entry points and is compiled but not yet run
+       against the library
    * - Kohn-Sham: range-separated hybrid
      - yes
      - **Needs an auxiliary basis.** The exact-ERI path builds no second

--- a/mqc_docs/source/input_files.rst
+++ b/mqc_docs/source/input_files.rst
@@ -566,10 +566,18 @@ the term converges quickly, so there is rarely a reason to go past 2.
 
 .. note::
 
-   This is the CPU path. The GPU backend refuses ``-V`` functionals by name:
-   cuEST exposes the entry points for it, and this backend does not yet call
-   them, so evaluating the semilocal half alone would return a converged and
-   quietly wrong energy.
+   The GPU path calls cuEST's own ``cuestNonlocalXCPotential{RKS,UKS}Compute``
+   for this term, rather than reimplementing it. Whether the functional carries
+   VV10 is asked of the XC plan (``CUEST_XCINTPLAN_IS_VV10``) rather than
+   matched against a list of names, so ``nlc_grid_level`` does not apply there:
+   cuEST chooses its own quadrature for the non-local term.
+
+   .. warning::
+
+      The GPU wiring compiles and is type-checked against cuEST's headers, but
+      **has not been run against the library**, which needs an sm_80 card. Until
+      it has, check a ``-V`` energy on the GPU against the CPU path before
+      trusting it. The GPU gradient is refused, as on CPU.
 
 Driver Section
 --------------


### PR DESCRIPTION
The GPU path refused the `-V` functionals because this backend never called cuEST's non-local entry points, and the semilocal half alone is a different functional by 43 mHa. cuEST has had the entry points all along and the bindings in backends/cuest/bindings/ already declared all four.

What now happens:

- functional_name_to_id maps wb97x-v, wb97m-v and b97m-v to the cuEST identifiers instead of refusing; vv10_unsupported is gone.
- build_xc_plan asks the plan CUEST_XCINTPLAN_IS_VV10 and, when set, reads VV10_B, VV10_C and VV10_SCALE from it. Asked of the plan rather than matched against names, which is what the old refusal's own comment said the better test would be -- a `-V` functional cuEST adds later is covered without a change here.
- system_nlc_device and system_nlc_uks_device call cuestNonlocalXCPotential{RKS,UKS}Compute and add the result into the same matrix and the same energy the semilocal term uses, so the Fock assembly and the energy expression are untouched. UKS calls it once: VV10 sees the total density, so one matrix is added to both channels and the energy counted once, as on CPU.
- The gradient is refused when the plan says VV10, matching the CPU path. cuestXCDerivativeRKSCompute returns the semilocal derivative only -- the non-local term has its own entry point, which this does not call -- and a gradient quietly missing it walks an optimisation to the wrong minimum.

The potential is accumulated through a scratch matrix and a daxpy rather than handing cuEST the shared output buffer directly. Whether that routine adds to its output or overwrites it is not something I can check from here, and going through a buffer of our own is correct either way, for one n_ao^2 allocation per call.

**Not run.** MQC_ENABLE_CUEST needs CUEST_ROOT and an sm_80, so this is compiled and type-checked but not executed. The docs say so, and say to check a `-V` energy against the CPU path before trusting it.

Which is why the second half of this: tools/check_cuest_compiles.sh, and a CI job that runs it. Nothing in the tree compiled backends/cuest/ at all -- the option is off by default and needs hardware, so on every CI runner and most dev boxes that directory was never handed to a compiler. It could break and nobody would find out until someone with a card built it. The bindings are plain bind(C) interfaces, so the library is needed to link but not to compile, and gfortran will type-check every call against them. It caught one real bug while I wrote this, an integer kind mismatch at the C boundary that a reviewer would not have seen.

Verified: the check passes on the exact configuration the CI job uses (libcint, tblite, libxc and testing all off), fails as it should when a call is deliberately broken, and the CPU build and its tests are unaffected. Sphinx builds clean.