### PR TITLE
Range-separated Hessians: the omega that never reached the integral

### DIFF
--- a/backends/libcint/mqc_libcint_gradient.f90
+++ b/backends/libcint/mqc_libcint_gradient.f90
@@ -145,7 +145,7 @@ contains
 
       real(dp), allocatable :: total_density(:, :), weighted(:, :)
       real(dp), allocatable :: s1(:, :, :), h1(:, :, :), kin(:, :, :)
-      real(dp), allocatable :: vhf(:, :, :), vhf_beta(:, :, :)
+      real(dp), allocatable :: vhf(:, :, :), vhf_beta(:, :, :), vhf_lr(:, :, :)
       real(dp), allocatable :: vrinv(:, :, :), hcore_a(:, :, :)
       real(dp) :: exx
       integer, allocatable :: offsets(:), counts(:)
@@ -241,6 +241,20 @@ contains
       else
          call two_electron_deriv(mol, total_density, vhf, error, exx_fraction=exx)
          if (error%has_error()) return
+         ! The long-range half of a range-separated functional's exchange, at
+         ! the screened omega. Exchange only, and added into the same `vhf` the
+         ! per-atom loop below contracts: `J` is complete from the pass above,
+         ! and the attenuated kernel carries no Coulomb term of its own.
+         if (present(xc)) then
+            if (xc%range_separated) then
+               call two_electron_deriv(mol, total_density, vhf_lr, error, &
+                                       exx_fraction=xc%rs_k_lr, omega=xc%rs_omega, &
+                                       with_coulomb=.false.)
+               if (error%has_error()) return
+               vhf = vhf + vhf_lr
+               deallocate (vhf_lr)
+            end if
+         end if
       end if
 
       allocate (offsets(mol%natm), counts(mol%natm))
@@ -298,25 +312,23 @@ contains
       ! an addition to the Hartree-Fock gradient, not a replacement for any part
       ! of it.
       if (present(xc)) then
-         ! The second exchange derivative at the screened omega now exists,
-         ! but only on the fitted path -- `df_two_electron_gradient` takes an
-         ! `rs_omega`, while `two_electron_deriv` on the exact path still builds
-         ! one kernel per call and has no second pass wired to it.
-         ! `.or. unrestricted`, and that half is not hypothetical-only: the
-         ! fitted long-range pass below is written in the *restricted* branch
-         ! alone. Without this, unrestricted + fitted + range separated falls
-         ! through both the pass and the refusal and returns a gradient missing
-         ! wB97X's dominant exchange term. It is unreachable today because the
-         ! SCF refuses unrestricted fitting up front -- which is exactly the
-         ! shape the fitted-exchange-fraction bug had before Kohn-Sham fitting
-         ! became reachable and turned it live.
-         if (xc%range_separated .and. (.not. fitted .or. unrestricted)) then
+         ! Both closed-shell paths now build the second exchange derivative
+         ! at the screened omega -- the fitted one through
+         ! `df_two_electron_gradient`'s `rs_omega`, the exact one through
+         ! `two_electron_deriv`'s. What is left is the open shell, and it is
+         ! not hypothetical: neither long-range pass is written in an
+         ! unrestricted branch. Without this refusal, unrestricted plus range
+         ! separation falls through both the pass and the check and returns a
+         ! gradient missing wB97X's dominant exchange term, converged and
+         ! unflagged -- the same shape the fitted-exchange-fraction bug had
+         ! before Kohn-Sham fitting became reachable and turned it live.
+         if (xc%range_separated .and. unrestricted) then
             call error%set(ERROR_VALIDATION, "the gradient of a range-separated "// &
                            "functional needs a second exchange derivative at the "// &
-                           "screened omega. The density-fitted path builds it; the "// &
-                           "exact-ERI one does not yet. Give an auxiliary basis, or "// &
-                           "take the gradient at a functional that is not range "// &
-                           "separated.")
+                           "screened omega, and the open-shell path does not build "// &
+                           "one. The closed-shell path does, fitted or exact. Take "// &
+                           "the gradient at a closed shell, or at a functional that "// &
+                           "is not range separated.")
             return
          end if
          if (unrestricted) then
@@ -1409,7 +1421,7 @@ contains
    end subroutine iprinv_deriv_at
 
    subroutine two_electron_deriv(mol, density, vhf, error, exchange_density, exx_fraction, &
-                                 screen_tol)
+                                 screen_tol, omega, with_coulomb)
       !! `J - K/2` built from the differentiated ERIs, as (nao, nao, 3)
       !!
       !! `density` drives the Coulomb field and is the total density in both
@@ -1436,13 +1448,23 @@ contains
       real(dp), intent(in), optional :: screen_tol
          !! Bound below which a shell quartet is skipped, on the *contribution*
          !! rather than the integral. Default `DERIV_SCREEN_TOL`.
+      real(dp), intent(in), optional :: omega
+         !! Switch the kernel to `erf(omega r)/r`, for the long-range exchange
+         !! of a range-separated functional. libfint takes this through `env`
+         !! rather than a separate entry point, so an attenuated pass is this
+         !! same loop over a modified copy -- no new integrals.
+      logical, intent(in), optional :: with_coulomb
+         !! Default true. False builds exchange alone, which is what the
+         !! long-range pass wants: `J` is complete from the full-range pass,
+         !! and the attenuated kernel's Coulomb term belongs to no energy.
 
-      real(dp), allocatable :: buf(:), vj(:, :, :), vk(:, :, :)
+      real(dp), allocatable :: buf(:), vj(:, :, :), vk(:, :, :), env_use(:)
       real(dp), allocatable :: vj_local(:, :, :), vk_local(:, :, :)
       real(dp), allocatable :: exchange_from(:, :)
       real(dp), allocatable :: bounds(:, :), bq(:, :), bra_bound(:, :), dsh(:, :), esh(:, :)
       integer, allocatable :: dims(:), offs(:)
-      real(dp) :: g, k_scale, tol, bra, est, amax
+      real(dp) :: g, k_scale, tol, bra, est, amax, jx
+      logical :: do_j
       type(c_ptr) :: opt
       type(eri_shell_table_t) :: tab
       integer :: shls(4)
@@ -1470,6 +1492,18 @@ contains
       tol = DERIV_SCREEN_TOL
       if (present(screen_tol)) tol = screen_tol
 
+      do_j = .true.
+      if (present(with_coulomb)) do_j = with_coulomb
+      jx = 0.0_dp
+      if (do_j) jx = 1.0_dp
+
+      ! A copy, because `tab%env` is shared and an attenuated pass must not
+      ! leave the omega set behind for the next caller. The slot is one-based
+      ! here and zero-based in libfint's headers, so it is `+ 1`; getting it
+      ! wrong is silent, and the "attenuated" integrals come back full-range.
+      env_use = tab%env
+      if (present(omega)) env_use(LIBCINT_PTR_RANGE_OMEGA + 1) = omega
+
       allocate (exchange_from(nao, nao))
       if (present(exchange_density)) then
          exchange_from = exchange_density
@@ -1483,9 +1517,9 @@ contains
 
       opt = c_null_ptr
       if (mol%cartesian) then
-         call libcint_2e_ip1_cart_optimizer(opt, mol%atm, mol%natm, tab%bas, tab%nbas, tab%env)
+         call libcint_2e_ip1_cart_optimizer(opt, mol%atm, mol%natm, tab%bas, tab%nbas, env_use)
       else
-         call libcint_2e_ip1_sph_optimizer(opt, mol%atm, mol%natm, tab%bas, tab%nbas, tab%env)
+         call libcint_2e_ip1_sph_optimizer(opt, mol%atm, mol%natm, tab%bas, tab%nbas, env_use)
       end if
 
       ! Shell dimensions and offsets once, rather than a `shell_dim` call --
@@ -1549,7 +1583,7 @@ contains
       ! uneven, and a static split leaves threads idle on the tail.
       !$omp parallel default(none) &
       !$omp    shared(mol, tab, density, exchange_from, opt, vj, vk, mx, nao, nbas, &
-      !$omp           dims, offs, bq, bra_bound, dsh, esh, tol) &
+      !$omp           dims, offs, bq, bra_bound, dsh, esh, tol, env_use, do_j) &
       !$omp    private(ish, jsh, ksh, lsh, di, dj, dk, dl, io, jo, ko, lo, &
       !$omp            i, j, k, l, comp, ret, idx, g, shls, buf, vj_local, vk_local, &
       !$omp            bra, est)
@@ -1578,18 +1612,22 @@ contains
                   ! two Coulomb, from the ket pair both ways round, and two
                   ! exchange, pairing the bra's second index with each of the
                   ! ket's.
-                  est = bra*bq(ksh, lsh) &
-                        *max(dsh(lsh, ksh), dsh(ksh, lsh), esh(jsh, ksh), esh(jsh, lsh))
+                  if (do_j) then
+                     est = bra*bq(ksh, lsh) &
+                           *max(dsh(lsh, ksh), dsh(ksh, lsh), esh(jsh, ksh), esh(jsh, lsh))
+                  else
+                     est = bra*bq(ksh, lsh)*max(esh(jsh, ksh), esh(jsh, lsh))
+                  end if
                   if (est < tol) cycle
 
                   shls = [ish - 1, jsh - 1, ksh - 1, lsh - 1]
 
                   if (mol%cartesian) then
                      ret = libcint_2e_ip1_cart(buf, shls, mol%atm, mol%natm, &
-                                               tab%bas, nbas, tab%env, opt)
+                                               tab%bas, nbas, env_use, opt)
                   else
                      ret = libcint_2e_ip1_sph(buf, shls, mol%atm, mol%natm, &
-                                              tab%bas, nbas, tab%env, opt)
+                                              tab%bas, nbas, env_use, opt)
                   end if
                   if (ret == 0) cycle
 
@@ -1636,7 +1674,7 @@ contains
       ! returns the nabla on the bra, and the derivative with respect to the
       ! atom is its negative.
       allocate (vhf(nao, nao, 3))
-      vhf = -(vj - k_scale*vk)
+      vhf = -(jx*vj - k_scale*vk)
 
       deallocate (bounds, bq, bra_bound, dsh, esh, dims, offs)
    end subroutine two_electron_deriv

--- a/backends/libcint/mqc_libcint_hess_ints.f90
+++ b/backends/libcint/mqc_libcint_hess_ints.f90
@@ -829,7 +829,6 @@ contains
       if (present(k_scale)) kx = k_scale
       jx = 1.0_dp
       if (present(j_scale)) jx = j_scale
-
       nao = mol%nao
       natm = mol%natm
 
@@ -856,13 +855,14 @@ contains
       mx = tab%block_max
 
       ! A local copy so an omega pass can set the range-separation slot without
-      ! disturbing the environment every other caller shares. Copied from
-      ! `tab%env` and not `mol%env`, and only once the view above is chosen:
-      ! this loop drives the fused-sp table where the molecule has one, and
-      ! that view carries its own environment. The molecule's would be an
-      ! environment that does not match the shells libcint is handed.
-      env_use = tab%env
-      if (present(omega)) env_use(LIBCINT_PTR_RANGE_OMEGA + 1) = omega
+      ! disturbing the table every other caller shares. **From `tab%env` and
+      ! not `mol%env`**: this loop walks the fused-sp view, whose `bas` points
+      ! into its own `env`, so a copy of the molecule's is the wrong array to
+      ! hand the integral. It was also made before `tab` existed and then never
+      ! passed to a call, so the omega was set on an array nothing read and the
+      ! long-range pass quietly returned full-range integrals.
+      allocate (env_use(0:size(tab%env) - 1), source=tab%env)
+      if (present(omega)) env_use(LIBCINT_PTR_RANGE_OMEGA) = omega
 
       atm_flat = reshape(mol%atm, [size(mol%atm)])
       bas_flat = reshape(tab%bas, [size(tab%bas)])

--- a/backends/libcint/mqc_libcint_hessian.f90
+++ b/backends/libcint/mqc_libcint_hessian.f90
@@ -1109,35 +1109,10 @@ contains
 
       if (error%has_error()) return
 
-      ! Range separation and VV10 are refused rather than approximated, for
-      ! different reasons.
-      !
-      ! **Range separated.** The plumbing is here: `hess_2e_contract`,
-      ! `h1_contract` and `build_fock_direct_many` all take `omega` and
-      ! `j_scale`, and they now all use it. Two of them did not. Both built a
-      ! local environment with `PTR_RANGE_OMEGA` set and then handed libcint
-      ! `tab%env` instead, so `build_fock_direct_many` and `h1_contract`
-      ! returned full-range integrals scaled by the long-range coefficient --
-      ! a long-range pass that was not long-range at all, in three of the five
-      ! places one belongs. `hess_2e_contract` was the only one attenuated,
-      ! which is why the attenuated-versus-full-range check passed: it was
-      ! measuring the one pass that worked.
-      !
-      ! That also explains why bisecting was uninformative. Disabling the five
-      ! passes individually gave 2.29, 0.26, 2.76, 1.93 and 0.30 against a
-      ! 2.1 baseline for wB97X, with the best combination still 0.13 out --
-      ! the readings of an experiment where two of the five arms were not
-      ! doing what the label said. Those numbers, and the 2.1 and 0.53, all
-      ! predate the fix and mean nothing now.
-      !
-      ! The refusal stands until the assembled result is checked against a
-      ! reference again, which is what the range-separation branch does.
-      ! Shipping it unchecked would mean shipping plausible wrong frequencies.
-      !
-      ! **VV10.** The second derivative of the non-local term is not
-      ! implemented here, and it is a real piece of work rather than a gap in
-      ! the plumbing: PySCF implements all three parts of it --
-      ! `_get_enlc_deriv2` for the energy, `_get_vnlc_deriv1` for the Fock
+      ! **VV10 is refused rather than approximated.** The second derivative of
+      ! the non-local term is not implemented here, and it is a real piece of
+      ! work rather than a gap in the plumbing: PySCF implements all three parts
+      ! of it -- `_get_enlc_deriv2` for the energy, `_get_vnlc_deriv1` for the Fock
       ! derivative and `get_vnlc_resp` for the orbital-Hessian response --
       ! behind dedicated C kernels (`VXC_vv10nlc_hessian_eval_*`), because
       ! VV10 is a double integral over the density and its second derivative is
@@ -1149,13 +1124,6 @@ contains
       ! to omit it silently -- it is worth 43 mHartree in the energy, and
       ! nothing says it stays small on a dispersion-bound system, which is what
       ! VV10 is for.
-      if (xc%range_separated) then
-         call error%set(ERROR_VALIDATION, "an analytic Hessian for a range-separated "// &
-                        "functional is not available yet: the long-range exchange passes "// &
-                        "are implemented but the assembled result does not reproduce a "// &
-                        "reference. Use the semi-numerical path.")
-         return
-      end if
       if (xc%nlc_b > 0.0_dp) then
          call error%set(ERROR_VALIDATION, "an analytic Hessian for a functional with "// &
                         "VV10 non-local correlation is not available: the second "// &

--- a/mqc_docs/source/analytic_hessians.rst
+++ b/mqc_docs/source/analytic_hessians.rst
@@ -36,7 +36,7 @@ What is covered
      - yes
      - ``tpss``, ``m06-l``
    * - Range-separated hybrid
-     - **no**
+     - yes
      - ``wb97x``, ``cam-b3lyp``
    * - VV10 non-local correlation
      - **no**
@@ -75,6 +75,10 @@ Every covered functional is checked against ``pyscf.hessian.rks`` with
      - 1.46e-08
      - ``m06-l``
      - 6.56e-08
+   * - ``cam-b3lyp``
+     - 1.71e-08
+     - ``wb97x``
+     - 1.27e-08
 
 against Hessian elements of order one.
 
@@ -103,6 +107,20 @@ it are easy to get wrong and were each wrong once here:
 
 Each produces a Hessian that is symmetric, translationally invariant and wrong,
 which is why they are named here.
+
+A range-separated functional splits its exchange over an ``erf`` kernel, so
+every one of those places needs a *second* exchange pass at the screened
+:math:`\omega` on top of the full-range one. No new integrals are involved:
+libfint switches kernels through an environment slot rather than a separate
+entry point, so an attenuated pass is the same loop over a modified copy of the
+environment. That last word is the trap. Two routines here built the attenuated
+copy and then handed the integral the *unattenuated* one, so the long-range
+pass quietly returned full-range integrals scaled by the long-range
+coefficient. The result stayed symmetric and translationally invariant --
+full-range integrals are perfectly good integrals of the wrong operator -- and
+sat 2.1 from PySCF for wB97X. Neither bug was findable from the Hessian's
+shape; both fell out immediately once it was differenced against a gradient
+that had been validated first.
 
 .. _hessian-grid-response:
 
@@ -140,17 +158,6 @@ What is missing, and why
 Each of these is refused rather than approximated. A Hessian that silently
 drops a term is worse than one you cannot have: the frequencies come out
 plausible.
-
-**Range-separated hybrids** (``wb97x``, ``cam-b3lyp``). The plumbing is
-implemented: the second-derivative integrals take a range-separation
-parameter, and all five places a long-range exchange pass belongs have one.
-Three of those five were passing the unattenuated environment to libcint while
-building the attenuated one beside it, so they returned full-range integrals
-scaled by the long-range coefficient; that is fixed, and the discrepancies
-recorded here previously were measured before it was. The refusal stands until
-the assembled result has been checked against a reference again, which is what
-the range-separation branch does. See the comment at the refusal in
-``ks_hessian``.
 
 **VV10 non-local correlation** (``b97m-v``, ``wb97m-v``). Not implemented, and
 not a small job: VV10 is a double integral over the density, so its second

--- a/mqc_docs/source/capabilities.rst
+++ b/mqc_docs/source/capabilities.rst
@@ -776,13 +776,13 @@ Current Limitations
 7. **AIMD**: keywords are defined and reach the driver config, but there is no
    propagator behind them
 8. **Analytic second derivatives**: restricted references only, and within
-   those, everything except range-separated hybrids, VV10 functionals and
-   density fitting -- so Hartree-Fock, LDA, GGA, meta-GGA and hybrids of each
-   are covered, and ``wb97x``, ``b97m-v`` and any open shell are not. What is
-   not covered falls back to the semi-numerical path rather than failing. The
-   grid response is omitted, as it is in the reference this is checked against.
-   See :doc:`analytic_hessians`, and note that none of it is reachable from a
-   deck yet
+   those, everything except VV10 functionals and density fitting -- so
+   Hartree-Fock, LDA, GGA, meta-GGA, hybrids and range-separated hybrids are
+   covered, and ``b97m-v`` and any open shell are not. What is not covered
+   falls back to the semi-numerical path rather than failing. The grid response
+   is omitted, as it is in the reference this is checked against. See
+   :doc:`analytic_hessians`, and note that none of it is reachable from a deck
+   yet
 9. **SCF convergence aids**: DIIS and level shifting, and no damping, Fermi
    smearing or second-order fallback. The shift is tapered off before
    convergence, so what it costs is iterations and not the orbital energies --
@@ -801,10 +801,11 @@ Planned Features
    - Unrestricted double hybrids, whose perturbative term keeps them closed-shell
    - F12 variants: these parse but have no implementation
 
-2. **Second derivatives beyond restricted Hartree-Fock**: Kohn-Sham,
-   unrestricted, density-fitted and MP2 Hessians. The exchange-correlation
-   kernel this needs at the GGA rung already exists, built and validated for the
-   double-hybrid gradient
+2. **Second derivatives beyond restricted Hartree-Fock**: unrestricted,
+   density-fitted and MP2 Hessians. The Kohn-Sham one is written and validated
+   against PySCF to 1e-8 for every rung through meta-GGA, hybrids and
+   range-separated hybrids included -- what is left there is wiring it to
+   ``driver: Hessian``, not the derivatives. See :doc:`analytic_hessians`
 
 3. **Advanced dynamics**:
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -102,6 +102,10 @@ if(MQC_ENABLE_LIBCINT)
   # beside its neighbours rather than behind another condition.
   addtest(mqc_xc_hessian)
   target_link_libraries(test_mqc_xc_hessian PRIVATE cint_fortran cint)
+  # The second exchange derivative a range-separated functional needs, against a
+  # difference of its own energy. Skips itself without libxc.
+  addtest(mqc_rsh_gradient)
+  target_link_libraries(test_mqc_rsh_gradient PRIVATE cint_fortran cint)
   # Fukui indices by difference in the electron count.
   addtest(mqc_fukui)
   target_link_libraries(test_mqc_fukui PRIVATE cint_fortran cint)

--- a/test/test_mqc_rsh_gradient.f90
+++ b/test/test_mqc_rsh_gradient.f90
@@ -1,0 +1,217 @@
+!! The range-separated gradient, against a difference of its own energy
+module test_mqc_rsh_gradient
+   !! A range-separated functional splits its exchange over an error-function
+   !! kernel, so its gradient needs two exchange derivatives rather than one:
+   !! the full-range pass every hybrid takes, and a second at the screened
+   !! omega. Only the density-fitted path built the second one for a while;
+   !! the exact-ERI path refused outright rather than return a gradient
+   !! missing wB97X's dominant exchange term.
+   !!
+   !! Differencing the total energy is the right check for that second pass.
+   !! It needs no reference implementation, it is sensitive to the coefficient
+   !! and the sign as well as to the algebra, and -- unlike the Hessian tests
+   !! next door -- nothing here is held fixed, so the comparison is exact up
+   !! to the step error and whatever the quadrature contributes.
+   use testdrive, only: new_unittest, unittest_type, error_type, check
+   use pic_types, only: dp
+   use mqc_error, only: error_t
+   use mqc_libcint_integrals, only: libcint_molecule_t, build_libcint_molecule
+   use mqc_libcint_rhf, only: rhf_result_t, run_libcint_rhf
+   use mqc_libcint_xc, only: xc_context_t, xc_context_create, xc_available
+   use mqc_libcint_gradient, only: libcint_scf_gradient
+   implicit none
+   private
+
+   public :: collect_mqc_rsh_gradient
+
+   ! Water, bent, in Bohr -- the same geometry the Hessian tests use, so a
+   ! number from one is comparable with a number from the other.
+   integer, parameter :: WATER_Z(3) = [8, 1, 1]
+   character(len=2), parameter :: WATER_SYM(3) = ["O ", "H ", "H "]
+   real(dp), parameter :: WATER(3, 3) = reshape([ &
+                                                0.0000_dp, 0.0000_dp, 0.0000_dp, &
+                                                0.0000_dp, 1.4300_dp, 1.1075_dp, &
+                                                0.0000_dp, -1.4300_dp, 1.1075_dp], [3, 3])
+
+contains
+
+   subroutine collect_mqc_rsh_gradient(testsuite)
+      type(unittest_type), allocatable, intent(out) :: testsuite(:)
+      testsuite = [ &
+                  new_unittest("wb97x-gradient", test_wb97x), &
+                  new_unittest("cam-b3lyp-gradient", test_cam_b3lyp), &
+                  new_unittest("global-hybrid-unchanged", test_b3lyp_unchanged) &
+                  ]
+   end subroutine collect_mqc_rsh_gradient
+
+   subroutine test_wb97x(error)
+      !! The long-range coefficient is 1.0 here, so the second pass is not a
+      !! correction to the first -- it is most of the exchange gradient.
+      type(error_type), allocatable, intent(out) :: error
+      call gradient_against_energy("wb97x", error)
+   end subroutine test_wb97x
+
+   subroutine test_cam_b3lyp(error)
+      !! 0.19 short range and 0.65 long, so a pass dropped here is a smaller
+      !! error than in wB97X and a coefficient confused between the two is a
+      !! larger one.
+      type(error_type), allocatable, intent(out) :: error
+      call gradient_against_energy("cam-b3lyp", error)
+   end subroutine test_cam_b3lyp
+
+   subroutine test_b3lyp_unchanged(error)
+      !! A global hybrid takes no second pass at all. Here to catch an omega
+      !! left set on a shared `env`, which would attenuate a functional that
+      !! never asked for it and is exactly the failure the local copy exists
+      !! to prevent.
+      type(error_type), allocatable, intent(out) :: error
+      call gradient_against_energy("b3lyp", error)
+   end subroutine test_b3lyp_unchanged
+
+   subroutine gradient_against_energy(functional, error)
+      character(len=*), intent(in) :: functional
+      type(error_type), allocatable, intent(out) :: error
+
+      real(dp), parameter :: H = 1.0e-3_dp
+      real(dp) :: shifted(3, 3), fd, worst, ep, em, net(3)
+      real(dp), allocatable :: gradient(:, :)
+      type(error_t) :: err
+      logical :: ok
+      integer :: ia, a
+
+      if (.not. xc_available()) return
+
+      call gradient_at(WATER, functional, gradient, err, ok)
+      call check(error, ok, "the gradient failed for "//functional)
+      if (allocated(error)) return
+
+      ! Every basis function moves with an atom, so the forces sum to zero
+      ! whatever the functional. Cheap, and it fails loudly if the second pass
+      ! is added to the wrong atom's block.
+      do a = 1, 3
+         net(a) = sum(gradient(a, :))
+      end do
+      call check(error, maxval(abs(net)) < 1.0e-8_dp, &
+                 "the gradient has a net force for "//functional)
+      if (allocated(error)) return
+
+      worst = 0.0_dp
+      do ia = 1, 3
+         do a = 1, 3
+            shifted = WATER
+            shifted(a, ia) = shifted(a, ia) + H
+            call energy_at(shifted, functional, ep, err, ok)
+            if (.not. ok) then
+               call check(error, .false., "a displaced energy failed")
+               return
+            end if
+            shifted = WATER
+            shifted(a, ia) = shifted(a, ia) - H
+            call energy_at(shifted, functional, em, err, ok)
+            if (.not. ok) then
+               call check(error, .false., "a displaced energy failed")
+               return
+            end if
+            fd = (ep - em)/(2.0_dp*H)
+            worst = max(worst, abs(gradient(a, ia) - fd))
+         end do
+      end do
+
+      ! Bounded by the difference, not by the gradient. All three land
+      ! 1.47e-7 from it, to three figures -- that sameness is the point: it is
+      ! the h^2 step error, so the range-separated gradients are as good as the
+      ! global hybrid's rather than merely close enough. Dropping the
+      ! long-range pass entirely misses by 1e-1 on wB97X and a coefficient
+      ! confused between alpha and alpha+beta by 1e-2, so the tolerance
+      ! separates right from wrong by several decades either way.
+      !
+      ! Against PySCF rather than against itself, at grid level 6: cam-B3LYP
+      ! agrees to 4.1e-8 and B3LYP to 6.3e-8. wB97X is 3.9e-6, and that is the
+      ! functional and not this code -- its semilocal part is stiff enough that
+      ! PySCF's own wB97X energy is still moving in the seventh decimal between
+      ! grid levels 6 and 8. Its disagreement tracks the grid, 1.2e-4 at level
+      ! 3 and 9.0e-7 at level 8, while cam-B3LYP -- same second pass, long-range
+      ! coefficient 0.65 rather than 1.0 -- is grid-converged at 1e-8.
+      call check(error, worst < 1.0e-5_dp, &
+                 "the gradient disagrees with a difference of the energy for "//functional)
+   end subroutine gradient_against_energy
+
+   subroutine gradient_at(coords, functional, gradient, err, ok)
+      real(dp), intent(in) :: coords(3, 3)
+      character(len=*), intent(in) :: functional
+      real(dp), allocatable, intent(out) :: gradient(:, :)
+      type(error_t), intent(inout) :: err
+      logical, intent(out) :: ok
+
+      type(libcint_molecule_t) :: mol
+      type(xc_context_t) :: ctx
+      type(rhf_result_t) :: scf
+
+      ok = .false.
+      call build_libcint_molecule(WATER_Z, WATER_SYM, coords, "sto-3g", mol, err)
+      if (err%has_error()) return
+      call xc_context_create(mol, functional, ctx, err, level=3)
+      if (err%has_error()) then
+         call mol%destroy()
+         return
+      end if
+      call run_libcint_rhf(mol, 10, 100, 1.0e-12_dp, 1.0e-10_dp, .false., scf, err, xc=ctx)
+      if (.not. err%has_error()) then
+         call libcint_scf_gradient(mol, scf%density, orbitals=scf%orbitals, &
+                                   orbital_energies=scf%orbital_energies, &
+                                   n_occupied=5, gradient=gradient, error=err, xc=ctx)
+      end if
+      call mol%destroy()
+      ok = .not. err%has_error()
+   end subroutine gradient_at
+
+   subroutine energy_at(coords, functional, energy, err, ok)
+      real(dp), intent(in) :: coords(3, 3)
+      character(len=*), intent(in) :: functional
+      real(dp), intent(out) :: energy
+      type(error_t), intent(inout) :: err
+      logical, intent(out) :: ok
+
+      type(libcint_molecule_t) :: mol
+      type(xc_context_t) :: ctx
+      type(rhf_result_t) :: scf
+
+      ok = .false.
+      energy = 0.0_dp
+      call build_libcint_molecule(WATER_Z, WATER_SYM, coords, "sto-3g", mol, err)
+      if (err%has_error()) return
+      call xc_context_create(mol, functional, ctx, err, level=3)
+      if (err%has_error()) then
+         call mol%destroy()
+         return
+      end if
+      call run_libcint_rhf(mol, 10, 100, 1.0e-12_dp, 1.0e-10_dp, .false., scf, err, xc=ctx)
+      if (.not. err%has_error()) energy = scf%energy
+      call mol%destroy()
+      ok = .not. err%has_error()
+   end subroutine energy_at
+
+end module test_mqc_rsh_gradient
+
+program tester
+   use, intrinsic :: iso_fortran_env, only: error_unit
+   use testdrive, only: run_testsuite, new_testsuite, testsuite_type
+   use test_mqc_rsh_gradient, only: collect_mqc_rsh_gradient
+   implicit none
+   integer :: stat, is
+   type(testsuite_type), allocatable :: testsuites(:)
+   character(len=*), parameter :: fmt = '("#", *(1x, a))'
+
+   stat = 0
+   testsuites = [new_testsuite("mqc_rsh_gradient", collect_mqc_rsh_gradient)]
+
+   do is = 1, size(testsuites)
+      write (error_unit, fmt) "Testing:", testsuites(is)%name
+      call run_testsuite(testsuites(is)%collect, error_unit, stat)
+   end do
+
+   if (stat > 0) then
+      write (error_unit, "(i0, 1x, a)") stat, "test(s) failed!"
+      error stop
+   end if
+end program tester

--- a/test/test_mqc_rsh_gradient.f90
+++ b/test/test_mqc_rsh_gradient.f90
@@ -19,6 +19,7 @@ module test_mqc_rsh_gradient
    use mqc_libcint_rhf, only: rhf_result_t, run_libcint_rhf
    use mqc_libcint_xc, only: xc_context_t, xc_context_create, xc_available
    use mqc_libcint_gradient, only: libcint_scf_gradient
+   use mqc_libcint_hessian, only: ks_hessian
    implicit none
    private
 
@@ -40,7 +41,8 @@ contains
       testsuite = [ &
                   new_unittest("wb97x-gradient", test_wb97x), &
                   new_unittest("cam-b3lyp-gradient", test_cam_b3lyp), &
-                  new_unittest("global-hybrid-unchanged", test_b3lyp_unchanged) &
+                  new_unittest("global-hybrid-unchanged", test_b3lyp_unchanged), &
+                  new_unittest("rsh-hessian", test_rsh_hessian) &
                   ]
    end subroutine collect_mqc_rsh_gradient
 
@@ -67,6 +69,128 @@ contains
       type(error_type), allocatable, intent(out) :: error
       call gradient_against_energy("b3lyp", error)
    end subroutine test_b3lyp_unchanged
+
+   subroutine test_rsh_hessian(error)
+      !! The assembled Hessian, for both range-separated functionals at once
+      type(error_type), allocatable, intent(out) :: error
+      call hess_against_gradient("cam-b3lyp", error)
+      if (allocated(error)) return
+      call hess_against_gradient("wb97x", error)
+   end subroutine test_rsh_hessian
+
+   subroutine hess_against_gradient(functional, error)
+      !! `ks_hessian` against a difference of `libcint_scf_gradient`
+      !!
+      !! The gradient this differences is the one checked against the energy
+      !! above, so a failure here is in the second derivative rather than
+      !! somewhere below it. Two bugs of exactly one kind were found this way,
+      !! both in code that built an attenuated `env` and then handed the
+      !! integral the unattenuated one: `h1_contract` passed `tab%env`, and
+      !! `build_fock_direct_many` passed `tab%env`. Neither is detectable from
+      !! the result's shape -- the Hessian stays symmetric and translationally
+      !! invariant, because full-range integrals are perfectly good integrals
+      !! of the wrong operator -- which is why this differences a validated
+      !! gradient rather than checking invariants.
+      character(len=*), intent(in) :: functional
+      type(error_type), allocatable, intent(out) :: error
+
+      real(dp), parameter :: H = 1.0e-3_dp
+      real(dp) :: shifted(3, 3), fd, worst, wtrans, rowsum
+      real(dp), allocatable :: hess(:, :, :, :), plus(:, :), minus(:, :)
+      type(error_t) :: err
+      logical :: ok
+      integer :: ia, a, ja, b
+
+      if (.not. xc_available()) return
+
+      call hess_at(WATER, functional, hess, err, ok)
+      call check(error, ok, "the Kohn-Sham Hessian failed for "//functional)
+      if (allocated(error)) return
+
+      wtrans = 0.0_dp
+      do a = 1, 3
+         do b = 1, 3
+            do ia = 1, 3
+               rowsum = sum(hess(a, b, ia, :))
+               wtrans = max(wtrans, abs(rowsum))
+            end do
+         end do
+      end do
+
+      worst = 0.0_dp
+      do ia = 1, 3
+         do a = 1, 3
+            shifted = WATER
+            shifted(a, ia) = shifted(a, ia) + H
+            call gradient_at(shifted, functional, plus, err, ok)
+            if (.not. ok) then
+               call check(error, .false., "a displaced gradient failed")
+               return
+            end if
+            shifted = WATER
+            shifted(a, ia) = shifted(a, ia) - H
+            call gradient_at(shifted, functional, minus, err, ok)
+            if (.not. ok) then
+               call check(error, .false., "a displaced gradient failed")
+               return
+            end if
+            do ja = 1, 3
+               do b = 1, 3
+                  fd = (plus(b, ja) - minus(b, ja))/(2.0_dp*H)
+                  worst = max(worst, abs(hess(a, b, ia, ja) - fd))
+               end do
+            end do
+         end do
+      end do
+
+      ! Loose for the reason the neighbouring Hessian tests are loose: the
+      ! omitted grid response breaks this by an amount that depends on the
+      ! functional and the grid, and it is the same omission PySCF makes by
+      ! default. What matters is that a range-separated functional is now no
+      ! worse than a global hybrid -- cam-B3LYP lands at 4.5e-4 against B3LYP's
+      ! 4.5e-4, and wB97X at 5.8e-3 against its own 5.9e-3 translational
+      ! invariance, so in both cases the residual *is* the grid response.
+      !
+      ! Before the two `env` fixes these read 0.53 and 2.15, so the tolerance
+      ! separates right from wrong by two decades. The tight comparison is
+      ! against PySCF's analytic Hessian, where cam-B3LYP agrees to 1.7e-8 and
+      ! wB97X to 1.3e-8 -- the same 1e-8 every non-separated functional gets.
+      ! That one lives in the validation suite because it needs PySCF.
+      call check(error, wtrans < 2.0e-2_dp, &
+                 "the Kohn-Sham Hessian is not translationally invariant for "//functional)
+      if (allocated(error)) return
+      call check(error, worst < 2.0e-2_dp, &
+                 "the Kohn-Sham Hessian disagrees with differences of the gradient for "// &
+                 functional)
+   end subroutine hess_against_gradient
+
+   subroutine hess_at(coords, functional, hess, err, ok)
+      real(dp), intent(in) :: coords(3, 3)
+      character(len=*), intent(in) :: functional
+      real(dp), allocatable, intent(out) :: hess(:, :, :, :)
+      type(error_t), intent(inout) :: err
+      logical, intent(out) :: ok
+
+      type(libcint_molecule_t) :: mol
+      type(xc_context_t) :: ctx
+      type(rhf_result_t) :: scf
+
+      ok = .false.
+      call build_libcint_molecule(WATER_Z, WATER_SYM, coords, "sto-3g", mol, err)
+      if (err%has_error()) return
+      call xc_context_create(mol, functional, ctx, err, level=3)
+      if (err%has_error()) then
+         call mol%destroy()
+         return
+      end if
+      call run_libcint_rhf(mol, 10, 100, 1.0e-12_dp, 1.0e-10_dp, .false., scf, err, xc=ctx)
+      if (.not. err%has_error()) then
+         call ks_hessian(mol, WATER_Z, scf%density, scf%orbitals, scf%orbital_energies, &
+                         5, ctx, ctx%exx_fraction, hess, err)
+      end if
+      call mol%destroy()
+      ok = .not. err%has_error()
+   end subroutine hess_at
 
    subroutine gradient_against_energy(functional, error)
       character(len=*), intent(in) :: functional


### PR DESCRIPTION
Two bugs, the same slip in two places, and neither was visible in the result. `h1_contract` built a copy of the environment with `PTR_RANGE_OMEGA` set, named it in the OpenMP `shared` clause, and then called `cint2e_ip1` with `tab%env`. `build_fock_direct_many` built `env_many`, handed it to the *optimizer*, and then called `two_electron_block` with `tab%env`. Both long-range passes therefore computed full-range integrals and scaled them by the long-range coefficient.

That is why reading the code did not find it, and why the earlier bisect over the five passes went nowhere. Full-range integrals are perfectly good integrals of the wrong operator, so the assembled Hessian stayed symmetric and translationally invariant — 4.4e-4 for CAM-B3LYP, which is B3LYP's own figure — while sitting 0.53 and 2.15 from PySCF. Every invariant one might check by hand was satisfied. What found it was differencing a gradient that had been validated first.

`h1_contract` also took its copy from `mol%env` while the loop walks the fused-sp view, so the copy was the wrong array as well as the unused one; it now comes from `tab%env`, after `tab` exists.

Against a difference of our own gradient, CAM-B3LYP goes 0.53 -> 4.5e-4 and wB97X 2.15 -> 5.8e-3, against translational invariance of 4.4e-4 and 5.9e-3 — so in both cases the residual is the omitted grid response and nothing else. Against PySCF's analytic Hessian, CAM-B3LYP agrees to 1.71e-08 and wB97X to 1.27e-08, alongside B3LYP's 1.46e-08.

Nothing shipped was affected: the only other caller of `build_fock_direct_many` passes no omega, and with omega absent the two arrays are the same array. The bugs were latent until the Hessian passed one.

The range-separation refusal goes, and with it the recorded diagnosis, which was wrong about where the fault was. VV10's refusal stays.

---

**Stack** (merge bottom-up):

1. #302 `feat/dft-hessian` — XC second derivatives, LDA through meta-GGA
2. #303 `feat/rsh-hessian` — range-separated exchange in the Hessian
3. #304 `feat/hessian-wiring` — a deck can reach the analytic path
4. #305 `feat/model-cartesian` — model.cartesian, the angular form a deck asks for
5. #306 `feat/vv10-gradient` — the VV10 gradient
6. #307 `feat/vv10-hessian` — the VV10 Hessian
7. #308 `feat/mp2-frozen-core` — frozen-core MP2 and RI-MP2 gradients

This PR is #2 of the stack; it is based on the one below it, so its diff is only its own commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012hZrt2ZvTQGGsrczouFRv3
