### PR TITLE
Let a deck reach the Kohn-Sham Hessian

### DIFF
--- a/backends/libcint/mqc_libcint_bridge.f90
+++ b/backends/libcint/mqc_libcint_bridge.f90
@@ -36,7 +36,7 @@ module mqc_libcint_bridge
    use mqc_libcint_xc, only: xc_context_t, xc_context_create, xc_available
    use mqc_libcint_pcm, only: pcm_context_t
    use mqc_libcint_gradient, only: libcint_scf_gradient
-   use mqc_libcint_hessian, only: rhf_hessian, hessian_to_matrix
+   use mqc_libcint_hessian, only: rhf_hessian, ks_hessian, hessian_to_matrix
    use mqc_libcint_mp2_gradient, only: libcint_mp2_gradient
    use mqc_libcint_ri_mp2_gradient, only: libcint_ri_mp2_gradient
    use mqc_libcint_mp2, only: mp2_result_t, run_libcint_mp2, run_libcint_ri_mp2, &
@@ -1319,16 +1319,23 @@ contains
 
       ! ---- the analytic Hessian, where it applies ---------------------------
       !
-      ! Restricted Hartree-Fock over exact integrals and nothing else. Every
-      ! other case here reaches this same line and every one of them must fall
-      ! through: an unrestricted reference has two densities where `rhf_hessian`
-      ! assumes one carrying its factor of two; a fitted SCF converged a
-      ! different energy from the one these derivatives belong to; a functional
-      ! adds an exchange-correlation second derivative that does not exist on
-      ! this side; and a correlated method's Hessian needs its own response
-      ! entirely. None of those would fail loudly -- each would return a
-      ! plausible, converged, wrong matrix -- so the guard is a list of
-      ! positives rather than a list of refusals.
+      ! A restricted reference over exact integrals, Hartree-Fock or Kohn-Sham.
+      ! Every other case here reaches this same line and every one of them must
+      ! fall through: an unrestricted reference has two densities where these
+      ! assume one carrying its factor of two; a fitted SCF converged a
+      ! different energy from the one these derivatives belong to; and a
+      ! correlated method's Hessian needs its own response entirely. None of
+      ! those would fail loudly -- each would return a plausible, converged,
+      ! wrong matrix -- so the guard is a list of positives rather than a list
+      ! of refusals.
+      !
+      ! **A functional carrying VV10 falls through as well.** `ks_hessian`
+      ! refuses it, and a refusal reaching the error branch below would abort
+      ! the run rather than fall back, which is the opposite of what a
+      ! `-V` functional wants: its Hessian is available, just not from here.
+      ! Tested on the condition rather than on the refusal so that the
+      ! fallback is chosen deliberately instead of arrived at by way of an
+      ! error.
       !
       ! Hydrogen caps are excluded for a different reason: the shapes match and
       ! the numbers would be right, but a capped fragment's second derivatives
@@ -1338,18 +1345,25 @@ contains
       ! A solvated SCF also falls through: these second derivatives are the
       ! gas-phase operator's, and the finite-difference fallback is *correct*
       ! for the continuum -- each displaced energy rebuilds its own cavity.
-      if (do_hessian .and. .not. unrestricted .and. .not. kohn_sham &
+      if (do_hessian .and. .not. unrestricted &
           .and. .not. settings%density_fitting .and. .not. settings%run_mp2 &
           .and. .not. settings%run_cc .and. .not. settings%pcm%enabled &
-          .and. fragment%n_caps == 0) then
+          .and. fragment%n_caps == 0 &
+          .and. .not. (kohn_sham .and. xc%nlc_b > 0.0_dp)) then
          block
             real(dp), allocatable :: hess4(:, :, :, :)
             type(timer_type) :: hess_clock
 
             call logger%info("  computing the analytic Hessian")
             call hess_clock%start()
-            call rhf_hessian(mol, fragment%element_numbers, scf%density, scf%orbitals, &
-                             scf%orbital_energies, scf%n_occupied, hess4, error)
+            if (kohn_sham) then
+               call ks_hessian(mol, fragment%element_numbers, scf%density, scf%orbitals, &
+                               scf%orbital_energies, scf%n_occupied, xc, xc%exx_fraction, &
+                               hess4, error)
+            else
+               call rhf_hessian(mol, fragment%element_numbers, scf%density, scf%orbitals, &
+                                scf%orbital_energies, scf%n_occupied, hess4, error)
+            end if
             if (error%has_error()) then
                call result%error%set(ERROR_VALIDATION, "Hessian: "//error%get_message())
                result%has_error = .true.

--- a/backends/libcint/mqc_libcint_bridge.f90
+++ b/backends/libcint/mqc_libcint_bridge.f90
@@ -1345,10 +1345,22 @@ contains
       ! A solvated SCF also falls through: these second derivatives are the
       ! gas-phase operator's, and the finite-difference fallback is *correct*
       ! for the continuum -- each displaced energy rebuilds its own cavity.
+      ! The double hybrid is on this list for the same reason VV10 is, and
+      ! `settings%run_mp2` does not stand in for it: a double hybrid's PT2
+      ! correlation is driven from `xc%pt2_fraction` further down and never
+      ! sets that flag. None of the second derivatives below carries it, so
+      ! `b2plyp` taken analytically returns its underlying hybrid's Hessian --
+      ! a Frobenius norm of 2.146683 against a true 2.120638 on water at
+      ! STO-3G, printed beside the double hybrid's own "PT2 x 0.270" energy
+      ! line with nothing to say the Hessian excludes what the energy includes.
+      ! That is the failure the *gradient* guard above this one already
+      ! prevents, where the hybrid's number came back against the double
+      ! hybrid's energy, right in shape and wrong by a third.
       if (do_hessian .and. .not. unrestricted &
           .and. .not. settings%density_fitting .and. .not. settings%run_mp2 &
           .and. .not. settings%run_cc .and. .not. settings%pcm%enabled &
           .and. fragment%n_caps == 0 &
+          .and. .not. (kohn_sham .and. xc%pt2_fraction /= 0.0_dp) &
           .and. .not. (kohn_sham .and. xc%nlc_b > 0.0_dp)) then
          block
             real(dp), allocatable :: hess4(:, :, :, :)

--- a/mqc_docs/source/analytic_hessians.rst
+++ b/mqc_docs/source/analytic_hessians.rst
@@ -182,10 +182,34 @@ there is no way to say whether a fitted one is converged or merely fast.
 **PCM.** A continuum's contribution to a second derivative is not implemented,
 and its interaction with the response terms has not been worked out.
 
-.. note::
+How a deck reaches it
+=====================
 
-   None of this is reachable from a deck yet. ``driver: Hessian`` still takes
-   the semi-numerical path for every method, and the analytic Kohn-Sham
-   Hessian is available only to callers inside the program. Wiring it up is a
-   small change; it is deliberately not made while the coverage above has holes
-   a keyword would not name.
+It does not ask. ``driver: Hessian`` requests the analytic Hessian, the backend
+takes it where the table above says yes, and everything else falls back to
+central differences of analytic gradients without saying so as an error --
+declining is not failing, because a Hessian has a second way to get one that is
+correct and merely slower. A run that took the analytic path logs
+``computing the analytic Hessian`` at verbose level, which is the only way to
+tell from the outside.
+
+There is no keyword to force either path. A deck that wants the fallback can
+have it by asking for something the analytic path declines -- density fitting,
+say -- but that is a side effect rather than a control, and if a real need for
+one appears it should be a keyword rather than a trick.
+
+Accuracy on larger bases
+========================
+
+The 1e-8 figures above are water at STO-3G, and they do not hold everywhere.
+Against PySCF, a functional agrees to 1e-9 relative at STO-3G, 8e-6 at 6-31G
+and 2e-5 at cc-pVDZ, while Hartree-Fock stays at 1e-8 on all three. The
+residual is the two codes' quadrature rather than the derivatives: it moves
+with the grid level and vanishes at STO-3G, where the density is compact enough
+that where the points sit stops mattering.
+
+In frequency terms the worst of it is 0.16 cm-1 on a mode at 3894 cm-1. That is
+below anything the underlying model resolves, but it is not the agreement the
+STO-3G numbers suggest, and it has not been chased further. ``check_hessian.py``
+in the validation suite carries both figures, one tolerance per case, rather
+than loosening every case to the worst one.

--- a/mqc_docs/source/capabilities.rst
+++ b/mqc_docs/source/capabilities.rst
@@ -455,14 +455,15 @@ Hessian Calculations
 There are two, and the backend picks -- a request that cannot be honoured
 analytically is not refused, it falls back.
 
-- **Analytic**, for a restricted Hartree-Fock reference: second derivatives
-  without displacing anything, built in the pieces the standard decomposition
-  uses (nuclear repulsion, the per-atom perturbation, the coupled-perturbed
-  solve, the explicit second-derivative assembly) so it can be compared with
-  PySCF's ``hessian.rhf`` stage by stage rather than only at the end. Taken
-  whenever the calculation is restricted, not Kohn-Sham, not density fitted, has
-  no MP2 or coupled-cluster correlation, no continuum solvent and no hydrogen
-  caps.
+- **Analytic**, for a restricted Hartree-Fock or Kohn-Sham reference: second
+  derivatives without displacing anything, built in the pieces the standard
+  decomposition uses (nuclear repulsion, the per-atom perturbation, the
+  coupled-perturbed solve, the explicit second-derivative assembly) so it can be
+  compared with PySCF's ``hessian.rhf`` and ``hessian.rks`` stage by stage
+  rather than only at the end. Taken whenever the calculation is restricted, not
+  density fitted, has no VV10 non-local correlation, no MP2 or coupled-cluster
+  correlation, no continuum solvent and no hydrogen caps. See
+  :doc:`analytic_hessians` for which functionals qualify.
 - **Semi-numerical** otherwise: central differences of *analytic gradients*,
   ``H[i,j] = (g_j(x_i + h) - g_j(x_i - h)) / 2h``. Only one derivative is taken
   numerically, which keeps most of the digits that differencing energies twice
@@ -780,9 +781,10 @@ Current Limitations
    Hartree-Fock, LDA, GGA, meta-GGA, hybrids and range-separated hybrids are
    covered, and ``b97m-v`` and any open shell are not. What is not covered
    falls back to the semi-numerical path rather than failing. The grid response
-   is omitted, as it is in the reference this is checked against. See
-   :doc:`analytic_hessians`, and note that none of it is reachable from a deck
-   yet
+   is omitted, as it is in the reference this is checked against. Agreement
+   with PySCF is 1e-8 at STO-3G and loosens to 2e-5 on cc-pVDZ for a
+   functional, which is quadrature rather than the derivatives -- worth 0.16
+   cm-1 at worst. See :doc:`analytic_hessians`
 9. **SCF convergence aids**: DIIS and level shifting, and no damping, Fermi
    smearing or second-order fallback. The shift is tapered off before
    convergence, so what it costs is iterations and not the orbital energies --

--- a/src/methods/mqc_method_dft.F90
+++ b/src/methods/mqc_method_dft.F90
@@ -144,12 +144,16 @@ contains
       call dft_run(this, fragment, result, want_gradient=.false.)
    end subroutine dft_calc_energy
 
-   subroutine dft_run(this, fragment, result, want_gradient)
+   subroutine dft_run(this, fragment, result, want_gradient, want_hessian)
       !! Run a density-fitted Kohn-Sham calculation through cuEST
       class(dft_method_t), intent(in) :: this
       type(physical_fragment_t), intent(in) :: fragment
       type(calculation_result_t), intent(inout) :: result
       logical, intent(in) :: want_gradient
+      logical, intent(in), optional :: want_hessian
+         !! Only the CPU backend has an analytic Hessian, and only for some of
+         !! what reaches it. Passed along rather than decided here: which cases
+         !! qualify is a fact about that backend.
 
       type(cuest_scf_settings_t) :: settings
       type(error_t) :: backend_error
@@ -251,12 +255,12 @@ contains
          end if
          call run_cuest_scf(settings, fragment, result, want_gradient)
       case (BACKEND_LIBCINT)
-         call run_libcint_hf(settings, fragment, result, want_gradient)
+         call run_libcint_hf(settings, fragment, result, want_gradient, want_hessian)
       case default
 #ifdef MQC_WITH_CUEST
          call run_cuest_scf(settings, fragment, result, want_gradient)
 #else
-         call run_libcint_hf(settings, fragment, result, want_gradient)
+         call run_libcint_hf(settings, fragment, result, want_gradient, want_hessian)
 #endif
       end select
    end subroutine dft_run
@@ -271,11 +275,31 @@ contains
    end subroutine dft_calc_gradient
 
    subroutine dft_calc_hessian(this, fragment, result)
-      !! Hessian by central differences of the analytic gradients
+      !! The analytic Hessian where there is one, central differences otherwise
+      !!
+      !! The same shape as `hf_calc_hessian`, and for the same reason: whether
+      !! an analytic Hessian applies depends on what the backend knows -- which
+      !! rung the functional sits on, whether it carries VV10, whether the SCF
+      !! converged restricted and unfitted -- and not on anything visible here.
+      !! The request goes down and `has_hessian` comes back: true means it was
+      !! computed, false with no error means it was declined and finite
+      !! differences take over.
+      !!
+      !! Declining is not failing. A backend that cannot honour a *gradient*
+      !! refuses loudly, because there is no other way to get one; a Hessian
+      !! has a second way that is correct and merely slower.
       class(dft_method_t), intent(in) :: this
       type(physical_fragment_t), intent(in) :: fragment
       type(calculation_result_t), intent(out) :: result
 
+      call dft_run(this, fragment, result, want_gradient=.true., want_hessian=.true.)
+      if (result%has_error) return
+      if (result%has_hessian) return
+
+      ! Declined. Nothing computed above is reusable -- the finite-difference
+      ! path runs its own reference point -- so this starts over rather than
+      ! trying to keep the SCF that just ran.
+      call result%destroy()
       call finite_difference_hessian(this, fragment, result, verbose=this%options%verbose)
    end subroutine dft_calc_hessian
 

--- a/validation/check_hessian.py
+++ b/validation/check_hessian.py
@@ -57,8 +57,53 @@ DIMER = [("O", (-0.0702, -0.0227, 0.0)),
          ("H", (3.0208, -0.3971, -0.7602)),
          ("H", (3.0208, -0.3971, 0.7602))]
 
-CASES = [("water", WATER, ["sto-3g", "6-31g", "cc-pvdz"]),
-         ("dimer", DIMER, ["sto-3g", "6-31g"])]
+# `None` is Hartree-Fock; anything else is a functional, run restricted and
+# unfitted, which is what the analytic path covers. One per rung, plus both
+# range-separated forms -- their long-range exchange is a second pass at a
+# screened omega in five separate places, and a pass that silently ran
+# full-range is the bug this is here to catch again.
+# name, geometry, bases, functional, tolerance scale.
+#
+# `None` is Hartree-Fock; anything else is a functional, run restricted and
+# unfitted, which is what the analytic path covers. One per rung, plus both
+# range-separated forms -- their long-range exchange is a second pass at a
+# screened omega in five separate places, and a pass that silently ran
+# full-range is the bug this is here to catch again.
+#
+# **The scale is the honest part.** A quadrature functional does not reach the
+# agreement an exact-integral one does, and the gap grows with the basis: on
+# water, DFT matches PySCF to 1e-9 relative at STO-3G, 8e-6 at 6-31G and 2e-5
+# at cc-pVDZ, where Hartree-Fock holds 1e-8 on all three. That residual is the
+# two codes' grids, not the derivatives -- it moves when the grid level moves
+# and it is absent at STO-3G, where the density is compact enough that where
+# the points sit stops mattering. In frequency terms the worst of it is 0.16
+# cm-1 on a 3894 cm-1 mode. It has not been chased below that, so rather than
+# loosen every case to the worst one, each case carries the tolerance its own
+# size earns: STO-3G stays at the tight one for every functional, and only the
+# larger bases are given room.
+#
+# 6-31G* is deliberately absent. mqc reads it with Cartesian d functions, which
+# is the Pople convention and correct, while `mol.cart = False` below asks
+# PySCF for spherical -- 19 functions against 18, which is a different basis
+# and not a disagreement about Hessians.
+CASES = [("water", WATER, ["sto-3g", "6-31g", "cc-pvdz"], None, 1),
+         ("dimer", DIMER, ["sto-3g", "6-31g"], None, 1),
+         ("water", WATER, ["sto-3g"], "pbe", 1),
+         ("water", WATER, ["sto-3g"], "b3lyp", 1),
+         ("water", WATER, ["sto-3g"], "tpss", 1),
+         ("water", WATER, ["sto-3g"], "cam-b3lyp", 1),
+         ("water", WATER, ["sto-3g"], "wb97x", 1),
+         ("water", WATER, ["6-31g"], "pbe", 50),
+         ("water", WATER, ["6-31g"], "b3lyp", 50),
+         ("water", WATER, ["cc-pvdz"], "pbe", 50),
+         ("water", WATER, ["cc-pvdz"], "b3lyp", 50)]
+
+# Both sides quadrature on this. It has to be one number, not each code's
+# default, or the comparison measures the grids rather than the derivatives.
+GRID_LEVEL = 3
+
+# PySCF spells two of these without the hyphen.
+PYSCF_XC = {"cam-b3lyp": "camb3lyp"}
 
 # A thousandth of a wavenumber on modes of a few thousand, and a part in a
 # million on the norm. Both are far below the accuracy of the model itself and
@@ -68,17 +113,25 @@ FREQ_TOL = 1.0e-2      # cm-1
 NORM_REL_TOL = 1.0e-6
 
 
-def run_mqc(binary, atoms, basis, workdir):
+def run_mqc(binary, atoms, basis, workdir, functional=None):
     """One `driver: Hessian` deck through mqc; returns frequencies and the norm."""
     xyz = workdir / "geom.xyz"
     lines = [str(len(atoms)), ""]
     lines += [f"{s}  {c[0]:.10f} {c[1]:.10f} {c[2]:.10f}" for s, c in atoms]
     xyz.write_text("\n".join(lines) + "\n")
 
+    if functional is None:
+        model = {"method": "HF", "basis": basis}
+        keywords = {}
+    else:
+        model = {"method": "dft", "basis": basis, "functional": functional}
+        keywords = {"dft": {"grid_level": GRID_LEVEL}}
+
     deck = workdir / "case.json"
     deck.write_text(json.dumps({
         "schema": {"name": "case", "version": "1.0"},
-        "model": {"method": "HF", "basis": basis},
+        "model": model,
+        "keywords": keywords,
         "driver": "Hessian",
         "molecules": [{"xyz": "geom.xyz",
                        "molecular_charge": 0,
@@ -88,14 +141,15 @@ def run_mqc(binary, atoms, basis, workdir):
     proc = subprocess.run([str(binary), "case.json"], cwd=workdir,
                           capture_output=True, text=True)
     out = workdir / "output_case.json"
+    label = basis if functional is None else f"{functional}/{basis}"
     if proc.returncode != 0 or not out.exists():
-        raise SystemExit(f"mqc failed on {basis}:\n{proc.stdout[-2000:]}")
+        raise SystemExit(f"mqc failed on {label}:\n{proc.stdout[-2000:]}")
 
     # The analytic path announces itself; without that line this compared the
     # finite-difference Hessian to PySCF and would have passed while testing
     # nothing that this script exists to test.
     if "computing the analytic Hessian" not in proc.stdout:
-        raise SystemExit(f"{basis}: mqc fell back to finite differences, so there "
+        raise SystemExit(f"{label}: mqc fell back to finite differences, so there "
                          f"is no analytic Hessian here to check")
 
     data = json.load(open(out))
@@ -104,8 +158,8 @@ def run_mqc(binary, atoms, basis, workdir):
             block["hessian_frobenius_norm"])
 
 
-def run_pyscf(atoms, basis):
-    from pyscf import gto, scf
+def run_pyscf(atoms, basis, functional=None):
+    from pyscf import dft, gto, scf
     from pyscf.hessian import thermo
 
     mol = gto.Mole()
@@ -116,7 +170,12 @@ def run_pyscf(atoms, basis):
     mol.verbose = 0
     mol.build()
 
-    mf = scf.RHF(mol)
+    if functional is None:
+        mf = scf.RHF(mol)
+    else:
+        mf = dft.RKS(mol)
+        mf.xc = PYSCF_XC.get(functional, functional)
+        mf.grids.level = GRID_LEVEL
     mf.conv_tol = 1e-13
     mf.kernel()
 
@@ -139,14 +198,17 @@ def main():
         return 1
 
     failures = 0
-    for name, atoms, bases in CASES:
+    for name, atoms, bases, functional, scale in CASES:
         for basis in bases:
+            freq_tol = FREQ_TOL * scale
+            norm_tol = NORM_REL_TOL * scale
             with tempfile.TemporaryDirectory() as tmp:
-                ours_freq, ours_norm = run_mqc(binary, atoms, basis, pathlib.Path(tmp))
-            theirs_freq, theirs_norm = run_pyscf(atoms, basis)
+                ours_freq, ours_norm = run_mqc(binary, atoms, basis,
+                                               pathlib.Path(tmp), functional)
+            theirs_freq, theirs_norm = run_pyscf(atoms, basis, functional)
 
             dn = abs(ours_norm - theirs_norm) / theirs_norm
-            ok = dn <= NORM_REL_TOL
+            ok = dn <= norm_tol
             note = ""
 
             if np.iscomplexobj(theirs_freq) and np.abs(theirs_freq.imag).max() > 0:
@@ -158,18 +220,19 @@ def main():
                 real = np.real(theirs_freq)
                 k = len(real)
                 df = np.abs(np.sort(ours_freq)[-k:] - np.sort(real))
-                ok = ok and df.max() <= FREQ_TOL
+                ok = ok and df.max() <= freq_tol
 
-            head = f"  {'ok  ' if ok else 'FAIL'} {name:6s} {basis:10s} "
+            method = "hf" if functional is None else functional
+            head = f"  {'ok  ' if ok else 'FAIL'} {name:6s} {method:10s} {basis:10s} "
             if df is None:
-                print(head + f"|dnorm|/norm {dn:8.2e} (<= {NORM_REL_TOL:.0e}){note}")
+                print(head + f"|dnorm|/norm {dn:8.2e} (<= {norm_tol:.0e}){note}")
             else:
                 print(head + f"{k} modes  max |dnu| {df.max():8.2e} cm-1 "
-                             f"(<= {FREQ_TOL:.0e})  |dnorm|/norm {dn:8.2e} "
-                             f"(<= {NORM_REL_TOL:.0e})")
+                             f"(<= {freq_tol:.0e})  |dnorm|/norm {dn:8.2e} "
+                             f"(<= {norm_tol:.0e})")
             if not ok:
                 failures += 1
-                if df is not None and df.max() > FREQ_TOL:
+                if df is not None and df.max() > freq_tol:
                     worst = int(np.argmax(df))
                     print(f"       mode {worst}: {np.sort(ours_freq)[-k:][worst]:.4f} vs "
                           f"{np.sort(np.real(theirs_freq))[worst]:.4f} cm-1")
@@ -178,7 +241,7 @@ def main():
     if failures:
         print(f"[hessian] {failures} case(s) disagree with PySCF")
         return 1
-    print("[hessian] the analytic RHF Hessian matches PySCF's on every case")
+    print("[hessian] the analytic Hessian matches PySCF's on every case")
     return 0
 
 


### PR DESCRIPTION
`ks_hessian` has been correct and unreachable. `dft_calc_hessian` called `finite_difference_hessian` unconditionally and never passed `want_hessian` down, so the gate in the bridge was dead code for every functional — a deck asking for `driver: Hessian` on PBE got 6N+1 gradient evaluations while the analytic path sat one call away.

The fix gives DFT the shape Hartree-Fock already had: the request goes down and `has_hessian` comes back, true meaning it was computed and false with no error meaning it was declined. Declining is not failing, which is why it is not an error — a Hessian has a second way to get one that is correct and merely slower. The bridge's gate loses `.not. kohn_sham` and gains a VV10 exclusion, placed on the condition rather than on `ks_hessian`'s refusal because a refusal reaching the error branch aborts the run instead of falling back.

On water/STO-3G, PBE now takes the analytic path and lands within 0.11 cm-1 of the semi-numerical frequencies it replaces — the omitted grid response and the displacement error, as expected.

`check_hessian.py` grows the functionals: one per rung plus both range-separated forms. It already asserted that mqc announces the analytic path, which makes it the regression guard for this wiring as well as for the numbers.

Two things the comparison turned up, neither a bug here:

* 6-31G* is left out. mqc reads it with Cartesian d functions, the Pople convention and correct, while the script asks PySCF for spherical — 19 functions against 18. That is a different basis, not a disagreement about Hessians. (The next PR gives a deck the say.)
* Agreement with PySCF is 1e-9 relative at STO-3G but 8e-6 at 6-31G and 2e-5 at cc-pVDZ, where Hartree-Fock holds 1e-8 throughout. It moves with the grid level and is absent at STO-3G, so it is quadrature rather than the derivatives — 0.16 cm-1 at worst on a 3894 cm-1 mode. Each case carries the tolerance its own size earns rather than loosening every case to the worst one, and the docs say so.

---

**Stack** (merge bottom-up):

1. #302 `feat/dft-hessian` — XC second derivatives, LDA through meta-GGA
2. #303 `feat/rsh-hessian` — range-separated exchange in the Hessian
3. #304 `feat/hessian-wiring` — a deck can reach the analytic path
4. #305 `feat/model-cartesian` — model.cartesian, the angular form a deck asks for
5. #306 `feat/vv10-gradient` — the VV10 gradient
6. #307 `feat/vv10-hessian` — the VV10 Hessian
7. #308 `feat/mp2-frozen-core` — frozen-core MP2 and RI-MP2 gradients

This PR is #3 of the stack; it is based on the one below it, so its diff is only its own commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012hZrt2ZvTQGGsrczouFRv3
