### PR TITLE
model.cartesian: ask for the angular form rather than inherit it

### DIFF
--- a/backends/libcint/mqc_libcint_bridge.f90
+++ b/backends/libcint/mqc_libcint_bridge.f90
@@ -757,7 +757,8 @@ contains
       ! difference meaningful.
       call build_libcint_molecule(fragment%element_numbers, symbols, &
                                   fragment%coordinates, trim(settings%basis_set), &
-                                  mol, error, ghost=ghost_of(fragment))
+                                  mol, error, ghost=ghost_of(fragment), &
+                                  force_cartesian=settings%cartesian)
       if (error%has_error()) then
          call result%error%set(ERROR_VALIDATION, error%get_message())
          result%has_error = .true.
@@ -927,7 +928,8 @@ contains
          ! molecule from the one being fitted.
          call build_libcint_molecule(fragment%element_numbers, symbols, &
                                      fragment%coordinates, trim(settings%aux_basis_set), &
-                                     aux, error, ghost=ghost_of(fragment))
+                                     aux, error, ghost=ghost_of(fragment), &
+                                     force_cartesian=settings%cartesian)
          if (error%has_error()) then
             call result%error%set(ERROR_VALIDATION, "auxiliary basis '"// &
                                   trim(settings%aux_basis_set)//"': "//error%get_message())
@@ -2064,7 +2066,8 @@ contains
 
       call build_libcint_molecule(fragment%element_numbers, symbols, &
                                   fragment%coordinates, trim(settings%basis_set), &
-                                  mol, error, ghost=ghost_of(fragment))
+                                  mol, error, ghost=ghost_of(fragment), &
+                                  force_cartesian=settings%cartesian)
       if (error%has_error()) then
          call result%error%set(ERROR_VALIDATION, error%get_message())
          result%has_error = .true.
@@ -2487,7 +2490,8 @@ contains
 
       call build_libcint_molecule(fragment%element_numbers, symbols, &
                                   fragment%coordinates, name, aux, error, &
-                                  ghost=ghost_of(fragment))
+                                  ghost=ghost_of(fragment), &
+                                  force_cartesian=settings%cartesian)
    end subroutine correlation_aux_basis
 
    pure function core_orbital_count(atomic_numbers) result(n_core)

--- a/mqc_docs/source/input_files.rst
+++ b/mqc_docs/source/input_files.rst
@@ -241,6 +241,29 @@ the RI error it is meant to be. Naming an auxiliary basis does **not** by itself
 density-fit the reference -- that is ``keywords.scf.density_fitting``, asked for
 rather than inferred.
 
+``cartesian`` reads the basis in Cartesian form whatever its file declares --
+6d rather than 5d, 10f rather than 7f. It defaults to false, meaning the file
+decides, and it is a no-op for a basis with no shell above p, where the two
+forms are the same functions.
+
+It is not a preference. For a shell above p the two forms span different
+spaces, so this changes the answer rather than its representation: water at
+cc-pVDZ/B3LYP goes from 24 basis functions and -76.420342 Hartree to 25 and
+-76.421536. Both are correct, and they are correct for different models.
+
+It exists because the convention is not something a basis set *name* settles.
+BSE is inconsistent about it -- 6-31G* is marked Cartesian and cc-pVDZ
+spherical -- and GAMESS assumes Cartesian for the Pople sets throughout, so
+reproducing a GAMESS number, or comparing against a program whose default runs
+the other way, needs a way to say which was meant. Without it the run still
+succeeds and still converges; it just answers a different question than the one
+being compared against.
+
+An auxiliary basis follows the orbital basis rather than its own file: a
+three-centre integral is built in one angular form, so a spherical fitting
+basis over a Cartesian orbital basis is not a mixture the integrals can
+express.
+
 Kohn-Sham DFT, on the CPU through libcint and libxc:
 
 - ``DFT`` (also ``KS``, ``Kohn-Sham``) selects the method; **which** functional is
@@ -1357,7 +1380,8 @@ is direct -- each ``%section`` becomes an object of the same name:
      - JSON
    * - ``%schema`` / ``name``, ``version``
      - ``"schema": {"name": ..., "version": ...}``
-   * - ``%model`` / ``method``, ``basis``, ``aux_basis``, ``functional``
+   * - ``%model`` / ``method``, ``basis``, ``aux_basis``, ``functional``,
+       ``cartesian``
      - ``"model": {...}``, same keys
    * - ``%driver`` / ``type = Energy``
      - ``"driver": "Energy"``

--- a/mqc_docs/source/input_files.rst
+++ b/mqc_docs/source/input_files.rst
@@ -264,6 +264,14 @@ three-centre integral is built in one angular form, so a spherical fitting
 basis over a Cartesian orbital basis is not a mixture the integrals can
 express.
 
+It is a CPU-path keyword. cuEST builds its AO shells spherical whatever the
+basis says, so asking for both is refused rather than quietly answered in the
+other form -- ``backend: cuest`` with ``cartesian`` on is an error, and so is
+leaving the backend at ``auto`` on a build that resolves it to the GPU. Ask for
+``backend: libcint``, which honours the file and this keyword both. A basis
+whose *file* is Cartesian, such as 6-31G*, was already refused on the GPU path
+for the same reason.
+
 Kohn-Sham DFT, on the CPU through libcint and libxc:
 
 - ``DFT`` (also ``KS``, ``Kohn-Sham``) selects the method; **which** functional is

--- a/src/core/mqc_fingerprint.f90
+++ b/src/core/mqc_fingerprint.f90
@@ -170,6 +170,14 @@ contains
          ! HF, DFT and anything else built on the SCF.
          call h%text(trim(config%basis_set))
          call h%flag(config%use_spherical)
+         ! The angular form the deck asked for, which `use_spherical` above is
+         ! not: that one is hardcoded true and is the flag cuEST builds its AO
+         ! shells with, so it hashes the same for every run. `scf%cartesian` is
+         ! the one that changes the answer -- above p the two forms span
+         ! different spaces, so water at cc-pVDZ is 24 functions and -76.420342
+         ! one way and 25 and -76.421536 the other. Two runs differing only in
+         ! this are two different energies and must not share a fingerprint.
+         call h%flag(config%scf%cartesian)
          call h%text(trim(config%scf%aux_basis_set))
          ! Whether it was asked for, not only what it is. A double hybrid fits
          ! its perturbative term when a deck names an auxiliary basis and not

--- a/src/io/mqc_config_adapter.f90
+++ b/src/io/mqc_config_adapter.f90
@@ -124,6 +124,7 @@ contains
       if (allocated(mqc_config%basis)) then
          driver_config%method_config%basis_set = mqc_config%basis
       end if
+      driver_config%method_config%scf%cartesian = mqc_config%cartesian
       if (allocated(mqc_config%aux_basis)) then
          driver_config%method_config%scf%aux_basis_set = mqc_config%aux_basis
          driver_config%method_config%scf%aux_basis_named = .true.

--- a/src/io/mqc_config_types.f90
+++ b/src/io/mqc_config_types.f90
@@ -171,6 +171,16 @@ module mqc_config_types
       integer(int32) :: method = METHOD_TYPE_GFN2
       character(len=:), allocatable :: basis
       character(len=:), allocatable :: aux_basis
+      logical :: cartesian = .false.
+         !! Read the basis in Cartesian form whatever its file declares.
+         !!
+         !! Not a preference: for a basis with a shell above p the two forms
+         !! span different spaces and give different energies, so this changes
+         !! the model rather than its representation. It exists because BSE is
+         !! inconsistent about the Pople sets -- 6-31G* is marked Cartesian and
+         !! cc-pVDZ spherical -- and because GAMESS assumes Cartesian for the
+         !! Pople sets throughout, so reproducing a GAMESS number needs a way
+         !! to say so. Defaults false, which honours the file.
       character(len=:), allocatable :: functional
       character(len=:), allocatable :: scf_guess
          !! Initial guess name from `keywords.scf.guess`.

--- a/src/io/mqc_json_config_reader.f90
+++ b/src/io/mqc_json_config_reader.f90
@@ -196,6 +196,7 @@ contains
       config%mcscf_optimize_orbitals = .not. method_is_casci(text)
       call optional_string(json, "model.basis", config%basis)
       call optional_string(json, "model.aux_basis", config%aux_basis)
+      call optional_logical(json, "model.cartesian", config%cartesian)
       call optional_string(json, "model.functional", config%functional)
 
       ! ---- properties ------------------------------------------------------

--- a/src/io/mqc_json_schema.f90
+++ b/src/io/mqc_json_schema.f90
@@ -199,6 +199,7 @@ contains
       call allow(keys, "basis")
       call allow(keys, "aux_basis")
       call allow(keys, "functional")
+      call allow(keys, "cartesian")
       call require(keys, "method")
    end function model_keys
 

--- a/src/methods/mqc_cuest_iface.f90
+++ b/src/methods/mqc_cuest_iface.f90
@@ -36,6 +36,9 @@ module mqc_cuest_iface
       !! Method-independent description of one cuEST SCF calculation
       character(len=32) :: basis_set = "sto-3g"
          !! Orbital basis set name
+      logical :: cartesian = .false.
+         !! Read the basis in Cartesian form whatever its file declares; see
+         !! `mqc_config_t`. Only the libcint path acts on it.
       character(len=32) :: aux_basis_set = "def2-universal-jkfit"
       logical :: density_fitting = .false.
       ! Post-Hartree-Fock. Kept beside the SCF settings rather than inside

--- a/src/methods/mqc_method_config.f90
+++ b/src/methods/mqc_method_config.f90
@@ -25,6 +25,10 @@ module mqc_method_config
    !============================================================================
    type :: scf_config_t
       !! Shared SCF settings for HF and DFT methods
+      logical :: cartesian = .false.
+         !! `model.cartesian`; see `mqc_config_t`. Carried here rather than
+         !! beside the basis name because it reaches the backend by the same
+         !! route the rest of the SCF settings do.
       integer :: max_iter = 100
          !! Maximum SCF iterations
       real(dp) :: energy_convergence = 1.0e-8_dp

--- a/src/methods/mqc_method_dft.F90
+++ b/src/methods/mqc_method_dft.F90
@@ -88,6 +88,8 @@ module mqc_method_dft
       ! Density fitting
       logical :: use_density_fitting = .false.
          !! Use RI-J approximation
+      logical :: cartesian = .false.
+         !! `model.cartesian`; see `mqc_config_t`.
       character(len=32) :: aux_basis_set = "def2-universal-jkfit"
          !! Auxiliary (JKFIT) basis. Required by the cuEST backend.
       logical :: aux_basis_named = .false.
@@ -170,6 +172,7 @@ contains
       end if
 
       settings%basis_set = this%options%basis_set
+      settings%cartesian = this%options%cartesian
       settings%aux_basis_set = this%options%aux_basis_set
       settings%aux_basis_named = this%options%aux_basis_named
       settings%functional = this%options%functional

--- a/src/methods/mqc_method_dft.F90
+++ b/src/methods/mqc_method_dft.F90
@@ -248,6 +248,16 @@ contains
       ! said `cuest` and got libcint would report a provenance that was not true.
       select case (settings%backend)
       case (BACKEND_CUEST)
+         if (settings%cartesian) then
+            call result%error%set(ERROR_VALIDATION, "backend 'cuest' was asked for, but "// &
+                                  "'model.cartesian' is on and the GPU path builds its "// &
+                                  "AO shells spherical whatever the basis says. Running "// &
+                                  "it would answer with a different basis than the deck "// &
+                                  "asked for and say nothing. Ask for backend 'libcint', "// &
+                                  "or drop 'model.cartesian'.")
+            result%has_error = .true.
+            return
+         end if
          if (settings%run_mp2 .or. settings%run_cc) then
             call result%error%set(ERROR_VALIDATION, "backend 'cuest' was asked for, but "// &
                                   "MP2 and coupled cluster have no GPU implementation "// &
@@ -261,6 +271,15 @@ contains
          call run_libcint_hf(settings, fragment, result, want_gradient, want_hessian)
       case default
 #ifdef MQC_WITH_CUEST
+         if (settings%cartesian) then
+            call result%error%set(ERROR_VALIDATION, "'model.cartesian' is on and this "// &
+                                  "build resolves 'auto' to the GPU backend, which "// &
+                                  "builds its AO shells spherical whatever the basis "// &
+                                  "says. Ask for backend 'libcint', or drop "// &
+                                  "'model.cartesian'.")
+            result%has_error = .true.
+            return
+         end if
          call run_cuest_scf(settings, fragment, result, want_gradient)
 #else
          call run_libcint_hf(settings, fragment, result, want_gradient, want_hessian)

--- a/src/methods/mqc_method_factory.F90
+++ b/src/methods/mqc_method_factory.F90
@@ -219,6 +219,7 @@ contains
          m%options%scs_os = config%corr%scs_os
       end if
 
+      m%options%cartesian = config%scf%cartesian
       m%options%aux_basis_set = config%scf%aux_basis_set
       m%options%aux_basis_named = config%scf%aux_basis_named
       m%options%density_fitting = config%scf%density_fitting
@@ -292,6 +293,7 @@ contains
          m%options%aux_basis_set = config%dft%aux_basis_set
          m%options%aux_basis_named = .true.
       else
+         m%options%cartesian = config%scf%cartesian
          m%options%aux_basis_set = config%scf%aux_basis_set
          m%options%aux_basis_named = config%scf%aux_basis_named
       end if

--- a/src/methods/mqc_method_hf.F90
+++ b/src/methods/mqc_method_hf.F90
@@ -38,6 +38,8 @@ module mqc_method_hf
          !! was read, validated, and then silently dropped for every one of them.
       character(len=32) :: basis_set = "sto-3g"
          !! Orbital basis set name
+      logical :: cartesian = .false.
+         !! `model.cartesian`; see `mqc_config_t`.
       character(len=32) :: aux_basis_set = "def2-universal-jkfit"
          !! Auxiliary (JKFIT) basis for the density-fitted J and K
       logical :: aux_basis_named = .false.
@@ -153,6 +155,7 @@ contains
          this%options%properties%bonding_restrict_localization
       settings%bonding_no_sharing_ci = this%options%properties%bonding_no_sharing_ci
       settings%basis_set = this%options%basis_set
+      settings%cartesian = this%options%cartesian
       settings%aux_basis_set = this%options%aux_basis_set
       settings%aux_basis_named = this%options%aux_basis_named
       settings%density_fitting = this%options%density_fitting

--- a/src/methods/mqc_method_hf.F90
+++ b/src/methods/mqc_method_hf.F90
@@ -209,6 +209,16 @@ contains
       ! said `cuest` and got libcint would report a provenance that was not true.
       select case (settings%backend)
       case (BACKEND_CUEST)
+         if (settings%cartesian) then
+            call result%error%set(ERROR_VALIDATION, "backend 'cuest' was asked for, but "// &
+                                  "'model.cartesian' is on and the GPU path builds its "// &
+                                  "AO shells spherical whatever the basis says. Running "// &
+                                  "it would answer with a different basis than the deck "// &
+                                  "asked for and say nothing. Ask for backend 'libcint', "// &
+                                  "or drop 'model.cartesian'.")
+            result%has_error = .true.
+            return
+         end if
          if (settings%run_mp2 .or. settings%run_cc) then
             call result%error%set(ERROR_VALIDATION, "backend 'cuest' was asked for, but "// &
                                   "MP2 and coupled cluster have no GPU implementation "// &
@@ -222,6 +232,15 @@ contains
          call run_libcint_hf(settings, fragment, result, want_gradient, want_hessian)
       case default
 #ifdef MQC_WITH_CUEST
+         if (settings%cartesian) then
+            call result%error%set(ERROR_VALIDATION, "'model.cartesian' is on and this "// &
+                                  "build resolves 'auto' to the GPU backend, which "// &
+                                  "builds its AO shells spherical whatever the basis "// &
+                                  "says. Ask for backend 'libcint', or drop "// &
+                                  "'model.cartesian'.")
+            result%has_error = .true.
+            return
+         end if
          call run_cuest_scf(settings, fragment, result, want_gradient)
 #else
          call run_libcint_hf(settings, fragment, result, want_gradient, want_hessian)

--- a/test/test_mqc_config_adapter.f90
+++ b/test/test_mqc_config_adapter.f90
@@ -25,7 +25,9 @@ contains
                   new_unittest("driver_nodes_per_group", test_driver_nodes_per_group), &
                   new_unittest("saddle_target_reaches_driver", test_saddle_target), &
                   new_unittest("saddle_needs_a_saddle_algorithm", test_saddle_algorithm), &
-                  new_unittest("unknown_target_refused", test_unknown_target) &
+                  new_unittest("unknown_target_refused", test_unknown_target), &
+                  new_unittest("driver_cartesian", test_driver_cartesian), &
+                  new_unittest("driver_cartesian_default", test_driver_cartesian_default) &
                   ]
    end subroutine collect_mqc_config_adapter_tests
 
@@ -145,6 +147,45 @@ contains
 
       call check(error, driver_config%nodes_per_group, 0, "nodes_per_group should default to 0")
    end subroutine test_driver_global_groups
+
+   subroutine test_driver_cartesian(error)
+      !! `model.cartesian` reaches the SCF settings the backend reads
+      !!
+      !! Worth a test of its own because the consequence of it *not* arriving
+      !! is silent: the run succeeds, converges and reports an energy in the
+      !! basis the file declared rather than the one the deck asked for. For a
+      !! shell above p those are different spaces, so it is a different answer
+      !! and not a different spelling of one.
+      type(error_type), allocatable, intent(out) :: error
+      type(mqc_config_t) :: config
+      type(driver_config_t) :: driver_config
+
+      config%method = METHOD_TYPE_GFN2
+      config%calc_type = CALC_TYPE_ENERGY
+      config%nfrag = 0
+      config%cartesian = .true.
+
+      call config_to_driver(config, driver_config)
+
+      call check(error, driver_config%method_config%scf%cartesian, &
+                 "model.cartesian should reach the SCF config")
+   end subroutine test_driver_cartesian
+
+   subroutine test_driver_cartesian_default(error)
+      !! Absent, it is false, so a deck that says nothing honours the file
+      type(error_type), allocatable, intent(out) :: error
+      type(mqc_config_t) :: config
+      type(driver_config_t) :: driver_config
+
+      config%method = METHOD_TYPE_GFN2
+      config%calc_type = CALC_TYPE_ENERGY
+      config%nfrag = 0
+
+      call config_to_driver(config, driver_config)
+
+      call check(error,.not. driver_config%method_config%scf%cartesian, &
+                 "cartesian should default to false")
+   end subroutine test_driver_cartesian_default
 
    subroutine test_driver_nodes_per_group(error)
       !! Test nodes_per_group is copied into driver_config

--- a/test/test_mqc_fingerprint.f90
+++ b/test/test_mqc_fingerprint.f90
@@ -43,7 +43,8 @@ contains
                   new_unittest("functional_moves_it", test_functional), &
                   new_unittest("scf_threshold_moves_it", test_threshold), &
                   new_unittest("driver_moves_it", test_driver), &
-                  new_unittest("verbosity_does_not", test_verbosity) &
+                  new_unittest("verbosity_does_not", test_verbosity), &
+                  new_unittest("angular_form_moves_it", test_cartesian) &
                   ]
    end subroutine collect_mqc_fingerprint
 
@@ -191,6 +192,25 @@ contains
       b%basis_set = "def2-tzvp"
       call differ(error, sys, sys, a, b, "changing the basis")
    end subroutine test_basis
+
+   subroutine test_cartesian(error)
+      !! `model.cartesian` is a different model, not a different spelling
+      !!
+      !! Above p the Cartesian and spherical forms span different spaces, so
+      !! water at cc-pVDZ is 24 functions and -76.420342 one way and 25 and
+      !! -76.421536 the other. Nothing else in the deck distinguishes them --
+      !! same basis name, same functional, same thresholds -- so without this
+      !! in the hash two genuinely different energies share a fingerprint,
+      !! which is the shape a caching bug takes.
+      type(error_type), allocatable, intent(out) :: error
+      type(system_geometry_t) :: sys
+      type(method_config_t) :: a, b
+
+      call water_dimer(sys)
+      call dft(a); call dft(b)
+      b%scf%cartesian = .true.
+      call differ(error, sys, sys, a, b, "forcing a Cartesian basis")
+   end subroutine test_cartesian
 
    subroutine test_functional(error)
       !! The one with no other symptom


### PR DESCRIPTION
`force_cartesian` already ran the whole way from `build_libcint_molecule` to `mol%build`, and EFP already passed it, because GAMESS assumes Cartesian for the Pople sets. Nothing exposed it to a deck, so the convention was whatever the basis file happened to declare.

That is not something a basis set *name* settles. BSE is inconsistent about it — 6-31G* is marked Cartesian and cc-pVDZ spherical — and a program being compared against may well default the other way. Without a way to say which was meant, the run still succeeds and still converges; it answers a different question than the one being compared against, and nothing in the output says so.

`model.cartesian` follows `model.aux_basis` exactly: parsed in the config reader, through the adapter into `scf_config_t`, through the factory into each method's options, into `cuest_scf_settings_t`, and out at the bridge's molecule builds. It also needed adding to the schema's `model_keys`, the strict whitelist that caught the omission immediately and is the reason the keyword could not be half-wired. An auxiliary basis follows the orbital basis rather than its own file — a three-centre integral is built in one angular form, so a spherical fitting basis over a Cartesian orbital basis is not a mixture the integrals can express.

The angular form joins the fingerprint, so two models are two fingerprints rather than one cache entry answering both.

cuEST builds its AO shells spherical whatever the basis says — `use_spherical` is hardcoded there — so `model.cartesian` on the GPU path is refused rather than silently answered in the other space.

Checked against PySCF's `mol.cart` on water/cc-pVDZ/B3LYP, both ways: spherical is 24 functions and -76.42034158487586 against -76.42034158487475, Cartesian is 25 and -76.42153632160655 against -76.42153632160569. 6-31G and STO-3G are unchanged either way, which is the other half of it — below d the two forms are the same functions.

The tests are on the plumbing rather than the integrals, because that is where this can fail silently: a flag that never arrives leaves a converged energy in the wrong space.

---

**Stack** (merge bottom-up):

1. #302 `feat/dft-hessian` — XC second derivatives, LDA through meta-GGA
2. #303 `feat/rsh-hessian` — range-separated exchange in the Hessian
3. #304 `feat/hessian-wiring` — a deck can reach the analytic path
4. #305 `feat/model-cartesian` — model.cartesian, the angular form a deck asks for
5. #306 `feat/vv10-gradient` — the VV10 gradient
6. #307 `feat/vv10-hessian` — the VV10 Hessian
7. #308 `feat/mp2-frozen-core` — frozen-core MP2 and RI-MP2 gradients

This PR is #4 of the stack; it is based on the one below it, so its diff is only its own commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012hZrt2ZvTQGGsrczouFRv3
