### PR TITLE
The VV10 gradient, so a -V functional can be optimized

### DIFF
--- a/backends/libcint/mqc_libcint_gradient.f90
+++ b/backends/libcint/mqc_libcint_gradient.f90
@@ -34,9 +34,11 @@ module mqc_libcint_gradient
                                     metric_inverse_sqrt, eri_shell_table_t, &
                                     eri_shell_table, eri_schwarz_collapse
    use mqc_libcint_ao, only: eval_ao_block, AO_POINT_BLOCK, AO_HESS_COMP, &
-                             shell_extents, block_significant_aos
+                             shell_extents, block_significant_aos, eval_rho
    use mqc_libcint_xc, only: xc_context_t, xc_grid_lda_quantities, &
-                             xc_grid_gga_quantities, xc_grid_kernel_quantities
+                             xc_grid_gga_quantities, xc_grid_kernel_quantities, &
+                             ensure_nlc_grid
+   use mqc_libcint_vv10, only: vv10_nlc
    use mqc_dft_partition, only: becke_partition_derivatives
    use pic_blas_interfaces, only: pic_gemm
    use libcint_fortran, only: libcint_1e_ipovlp_sph, libcint_1e_ipovlp_cart, &
@@ -396,26 +398,26 @@ contains
       integer :: n_sig, isig, jsig
       logical :: unrestricted
 
-      ! A VV10 gradient is not the semilocal gradient. The non-local term
-      ! depends on the nuclear positions twice over -- through |r - r'| in the
-      ! kernel and through rho and grad rho at both points -- and none of that
-      ! is computed here.
-      !
-      ! Refused rather than omitted, because omitting it survives every check
-      ! a user can make: the SCF converges, the energy is right, and the
-      ! forces are quietly wrong, so an optimisation walks confidently to the
-      ! wrong minimum.
+      unrestricted = present(density_beta)
+
+      ! The non-local term, where the functional carries one. Refused for an
+      ! open shell rather than omitted: omitting it survives every check a user
+      ! can make -- the SCF converges, the energy is right, and the forces are
+      ! quietly wrong, so an optimisation walks confidently to the wrong
+      ! minimum. It is worth 43 mHartree in the energy on water/STO-3G.
       if (ctx%nlc_b /= 0.0_dp .or. ctx%nlc_c /= 0.0_dp) then
-         call error%set(ERROR_VALIDATION, "this functional carries a non-local "// &
-                        "correlation term (VV10), whose contribution to the nuclear "// &
-                        "gradient is not implemented. Refused rather than returning a "// &
-                        "gradient missing it.")
-         return
+         if (unrestricted) then
+            call error%set(ERROR_VALIDATION, "this functional carries a non-local "// &
+                           "correlation term (VV10), whose nuclear gradient is "// &
+                           "implemented for a closed shell only. Refused rather than "// &
+                           "returning a gradient missing it.")
+            return
+         end if
+         call vv10_gradient(ctx, mol, density, gradient, error)
+         if (error%has_error()) return
       end if
 
       if (.not. ctx%active) return
-
-      unrestricted = present(density_beta)
       nao = mol%nao
       natm = mol%natm
       npts = ctx%grid%n_points
@@ -628,6 +630,200 @@ contains
          end do
       end do
    end subroutine xc_gradient
+
+   subroutine vv10_gradient(ctx, mol, density, gradient, error)
+      !! VV10's contribution to dE/dR, accumulated in place
+      !!
+      !! **The non-locality is already inside `vrho` and `vsigma`.** VV10's
+      !! energy is a double integral, which makes it sound as though its
+      !! derivative needs machinery a semilocal functional does not have. It
+      !! does not. `E_nl` is a functional of rho and sigma, so
+      !!
+      !!     dE/dR = int dr [ dE/drho(r) drho(r)/dR + dE/dsigma(r) dsigma(r)/dR ]
+      !!
+      !! and the pair sum over the second grid is spent entirely on producing
+      !! those two arrays -- the same two the Fock build already consumes. What
+      !! is left is the ordinary GGA contraction, term for term, which is why
+      !! this reads like `xc_gradient`'s GGA path with the quantities swapped.
+      !! PySCF reaches the same conclusion by the same route: `get_nlc_vxc`
+      !! calls `_vv10nlc` for the potential and then hands it to the shared
+      !! `_gga_grad_sum_`.
+      !!
+      !! **The grid response is kept, unlike PySCF's.** `get_nlc_vxc` stops at
+      !! the basis-function term; this carries the moving points and the moving
+      !! partition weights too, because the semilocal gradient next door does
+      !! and a total made of one of each would be neither. It also makes the
+      !! term checkable: against a difference of the energy the three-term
+      !! version agrees to the step error, where a basis-function-only version
+      !! sits about 1e-4 away -- small enough to read as a loose tolerance and
+      !! large enough to hide a sign error.
+      !!
+      !! Restricted only. The caller refuses an open shell before this is
+      !! reached.
+      type(xc_context_t), intent(inout) :: ctx
+      type(libcint_molecule_t), intent(in) :: mol
+      real(dp), intent(in) :: density(:, :)
+      real(dp), intent(inout) :: gradient(:, :)
+      type(error_t), intent(inout) :: error
+
+      real(dp), allocatable :: rho(:), sigma(:), rho_grad(:, :)
+      real(dp), allocatable :: exc(:), vrho(:), vsigma(:), gcoef(:, :)
+      real(dp), allocatable :: dedw(:), fexp(:, :)
+      real(dp), allocatable :: rho_blk(:), rho_grad_blk(:, :)
+      real(dp), allocatable :: ao(:, :), ao_grad(:, :, :), ao_hess(:, :, :)
+      real(dp), allocatable :: dchi(:, :), dgchi(:, :, :)
+      real(dp), allocatable :: dpart(:, :, :)
+      real(dp), allocatable :: extents(:), d_sig(:, :)
+      logical, allocatable :: shell_mask(:)
+      integer, allocatable :: ao_list(:), ao_offset(:)
+      integer, allocatable :: c_offsets(:), c_counts(:)
+      real(dp) :: contrib, wv, scale
+      integer :: npts, nao, natm, g0, g1, nb, ig, id, gg, comp, ia, own
+      integer :: n_sig, isig, jsig
+
+      if (ctx%nlc_b == 0.0_dp .and. ctx%nlc_c == 0.0_dp) return
+
+      call ensure_nlc_grid(ctx, mol, error)
+      if (error%has_error()) return
+      npts = ctx%nlc_grid%n_points
+      if (npts == 0) return
+
+      nao = mol%nao
+      natm = mol%natm
+      scale = 2.0_dp
+
+      ! Sweep one: rho and its gradient over the whole grid at once. The pair
+      ! sum needs every point before it can produce any potential, so unlike
+      ! the semilocal path this cannot be done a block at a time.
+      allocate (rho(npts), sigma(npts), rho_grad(npts, 3))
+      rho = 0.0_dp
+      sigma = 0.0_dp
+      rho_grad = 0.0_dp
+      do g0 = 1, npts, ctx%point_block
+         g1 = min(g0 + ctx%point_block - 1, npts)
+         nb = g1 - g0 + 1
+         if (allocated(rho_blk)) deallocate (rho_blk, rho_grad_blk)
+         allocate (rho_blk(nb), rho_grad_blk(nb, 3))
+         call eval_ao_block(mol, ctx%nlc_grid%coords(:, g0:g1), ao, error, grad=ao_grad)
+         if (error%has_error()) return
+         call eval_rho(ao, density, rho_blk, ao_grad=ao_grad, rho_grad=rho_grad_blk)
+         do ig = 1, nb
+            rho(g0 + ig - 1) = rho_blk(ig)
+            do id = 1, 3
+               rho_grad(g0 + ig - 1, id) = rho_grad_blk(ig, id)
+            end do
+            sigma(g0 + ig - 1) = rho_grad_blk(ig, 1)**2 + rho_grad_blk(ig, 2)**2 &
+                                 + rho_grad_blk(ig, 3)**2
+         end do
+      end do
+
+      allocate (exc(npts), vrho(npts), vsigma(npts), dedw(npts), fexp(3, npts))
+      call vv10_nlc(ctx%nlc_b, ctx%nlc_c, ctx%nlc_grid%coords, rho, sigma, &
+                    ctx%nlc_grid%coords, rho, sigma, ctx%nlc_grid%weights, &
+                    exc, vrho, vsigma, dedw=dedw, fexp=fexp)
+
+      ! dE/d(grad rho) = 2 vsigma grad rho, the chain rule the semilocal path
+      ! applies to its own sigma, written the same way so the two cannot
+      ! disagree about it.
+      allocate (gcoef(npts, 3))
+      do id = 1, 3
+         do ig = 1, npts
+            gcoef(ig, id) = 2.0_dp*vsigma(ig)*rho_grad(ig, id)
+         end do
+      end do
+
+      allocate (c_offsets(natm), c_counts(natm))
+      allocate (shell_mask(mol%nbas), ao_offset(mol%nbas), ao_list(nao))
+      allocate (d_sig(nao, nao))
+      call shell_extents(mol, ctx%screen_tol, extents)
+
+      ! Sweep two: the three terms, on the grid the potential was built on.
+      do g0 = 1, npts, ctx%point_block
+         g1 = min(g0 + ctx%point_block - 1, npts)
+         nb = g1 - g0 + 1
+
+         call block_significant_aos(mol, ctx%nlc_grid%coords(:, g0:g1), extents, &
+                                    shell_mask, ao_list, ao_offset, n_sig, &
+                                    atom_offsets=c_offsets, atom_counts=c_counts)
+
+         if (n_sig > 0) then
+            do jsig = 1, n_sig
+               do isig = 1, n_sig
+                  d_sig(isig, jsig) = density(ao_list(isig), ao_list(jsig))
+               end do
+            end do
+
+            ! Second derivatives, because the sigma channel pairs a basis
+            ! function's gradient with another derivative of it.
+            call eval_ao_block(mol, ctx%nlc_grid%coords(:, g0:g1), ao, error, &
+                               grad=ao_grad, hess=ao_hess, shell_mask=shell_mask, &
+                               ao_offset=ao_offset, n_ao_out=n_sig)
+            if (error%has_error()) return
+
+            if (allocated(dchi)) deallocate (dchi)
+            allocate (dchi(nb, n_sig))
+            call density_times_ao(ao, d_sig(1:n_sig, 1:n_sig), nb, n_sig, dchi)
+
+            if (allocated(dgchi)) deallocate (dgchi)
+            allocate (dgchi(nb, n_sig, 3))
+            call density_times_ao_grad(ao_grad, d_sig(1:n_sig, 1:n_sig), nb, n_sig, dgchi)
+
+            do ig = 1, nb
+               gg = g0 + ig - 1
+               own = ctx%nlc_grid%atom(gg)
+               wv = ctx%nlc_grid%weights(gg)*vrho(gg)
+               call accumulate_channel(ao_grad, dchi, ig, n_sig, wv, scale, &
+                                       c_offsets, c_counts, natm, own, gradient)
+               call accumulate_gga_channel(ao_grad, ao_hess, dchi, dgchi, ig, n_sig, &
+                                           ctx%nlc_grid%weights(gg)*gcoef(gg, :), scale, &
+                                           c_offsets, c_counts, natm, own, gradient)
+            end do
+         end if
+
+         ! The partition-weight term, and the point-motion term that cancels
+         ! most of it, written as `xc_gradient` writes them -- see there for
+         ! why the second is not optional.
+         !
+         ! **Two things differ from the semilocal version and neither is
+         ! optional.** The coefficient is `dE/dw` and not `rho*exc`, because a
+         ! point's weight multiplies it twice over; and the points carry an
+         ! explicit force of their own, because the kernel is a function of
+         ! where they are. Together they are worth 4.5e-4 on water, which is
+         ! not a tolerance question: it does not shrink when the grid is
+         ! refined, because it is not a quadrature error.
+         if (allocated(dpart)) deallocate (dpart)
+         allocate (dpart(3, natm, nb))
+         call becke_partition_derivatives(ctx%nlc_grid%coords(:, g0:g1), mol%coords, &
+                                          ctx%nlc_grid%numbers, ctx%nlc_grid%atom(g0:g1), &
+                                          ctx%nlc_grid%scheme, ctx%nlc_grid%adjust, &
+                                          dpart, error)
+         if (error%has_error()) return
+
+         do ig = 1, nb
+            gg = g0 + ig - 1
+            own = ctx%nlc_grid%atom(gg)
+
+            ! The point's own coordinate derivative, onto the atom it rides.
+            do comp = 1, 3
+               gradient(comp, own) = gradient(comp, own) &
+                                     + ctx%nlc_grid%weights(gg)*fexp(comp, gg)
+            end do
+
+            contrib = ctx%nlc_grid%quad_weights(gg)*dedw(gg)
+            do ia = 1, natm
+               do comp = 1, 3
+                  gradient(comp, ia) = gradient(comp, ia) + contrib*dpart(comp, ia, ig)
+               end do
+            end do
+            do ia = 1, natm
+               do comp = 1, 3
+                  gradient(comp, own) = gradient(comp, own) &
+                                        - contrib*dpart(comp, ia, ig)
+               end do
+            end do
+         end do
+      end do
+   end subroutine vv10_gradient
 
    subroutine xc_potential_gradient(ctx, mol, density, pmat, gradient, error)
       !! `d/dR Tr(P V_xc[D])`, with both densities held fixed, accumulated in place

--- a/backends/libcint/mqc_libcint_vv10.f90
+++ b/backends/libcint/mqc_libcint_vv10.f90
@@ -44,7 +44,7 @@ contains
 
    subroutine vv10_nlc(b, c, coords, rho, sigma, &
                        inner_coords, inner_rho, inner_sigma, inner_weights, &
-                       exc, vrho, vsigma)
+                       exc, vrho, vsigma, dedw, fexp)
       !! VV10's energy density and potential at each outer grid point
       !!
       !! `exc` is the energy *per electron*, so the caller forms the energy the
@@ -67,10 +67,35 @@ contains
       real(dp), intent(out) :: exc(:)         !! (n_out)
       real(dp), intent(out) :: vrho(:)        !! (n_out), dE/drho
       real(dp), intent(out) :: vsigma(:)      !! (n_out), dE/dsigma
+      real(dp), intent(out), optional :: dedw(:)
+         !! (n_out), dE/dw_i -- the derivative with respect to the *weight* of
+         !! a point, which a nuclear gradient needs because the Becke partition
+         !! moves with the nuclei.
+         !!
+         !! **It is not `rho*exc`.** For a semilocal functional it would be:
+         !! the energy is a sum of independent per-point terms and the weight
+         !! of one multiplies one of them. Here point `k` appears twice, once
+         !! as the outer point and once inside every other point's inner sum,
+         !! and the kernel's symmetry makes those two contributions equal. So
+         !! this carries `beta + f` where `exc` carries `beta + f/2` -- the
+         !! same doubling that distinguishes `vrho` from `exc` just above.
+      real(dp), intent(out), optional :: fexp(:, :)
+         !! (3, n_out), dE/dr_i at fixed density and weights, per unit weight
+         !!
+         !! The energy depends on *where the points are* and not only on what
+         !! the density is there: `r^2` sits inside the kernel. Nothing in a
+         !! semilocal functional does this, which is why a gradient assembled
+         !! from the usual three terms is incomplete here by about 4e-4 on
+         !! water and does not converge away with the grid.
+         !!
+         !! Per unit weight, so the caller multiplies by `w_i` exactly as it
+         !! does for `exc`, and sums onto the atom that owns the point.
 
       real(dp) :: pi43, kvv, beta
       real(dp) :: w0, k_out, dw0_drho, dw0_dsigma, dk_drho, w0tmp
-      real(dp) :: dx, dy, dz, r2, g, gp, gt, t, tt
+      real(dp) :: dx, dy, dz, r2, g, gp, gt, t, tt, q
+      real(dp) :: fx, fy, fz
+      logical :: want_grad
       real(dp) :: f_sum, u_sum, w_sum
       real(dp) :: r_i, s_i
       real(dp), allocatable :: w0p(:), kp(:), rpw(:)
@@ -82,6 +107,9 @@ contains
       exc = 0.0_dp
       vrho = 0.0_dp
       vsigma = 0.0_dp
+      want_grad = present(dedw) .or. present(fexp)
+      if (present(dedw)) dedw = 0.0_dp
+      if (present(fexp)) fexp = 0.0_dp
 
       pi43 = 4.0_dp*PI/3.0_dp
       kvv = b*1.5_dp*PI*(9.0_dp*PI)**(-1.0_dp/6.0_dp)
@@ -117,9 +145,11 @@ contains
       ! disappear against it -- so it is the only thing here worth threading.
       !$omp parallel do default(none) &
       !$omp    shared(n_out, n_kept, rho, sigma, coords, inner_coords, keep, &
-      !$omp           w0p, kp, rpw, exc, vrho, vsigma, c, kvv, pi43, beta) &
+      !$omp           w0p, kp, rpw, exc, vrho, vsigma, c, kvv, pi43, beta, &
+      !$omp           want_grad, dedw, fexp) &
       !$omp    private(i, j, r_i, s_i, w0, w0tmp, dw0_drho, dw0_dsigma, k_out, &
-      !$omp            dk_drho, f_sum, u_sum, w_sum, dx, dy, dz, r2, g, gp, gt, t, tt) &
+      !$omp            dk_drho, f_sum, u_sum, w_sum, dx, dy, dz, r2, g, gp, gt, t, tt, &
+      !$omp            q, fx, fy, fz) &
       !$omp    schedule(dynamic, 64)
       do i = 1, n_out
          if (rho(i) < VV10_RHO_THRESHOLD) cycle
@@ -144,6 +174,9 @@ contains
          f_sum = 0.0_dp
          u_sum = 0.0_dp
          w_sum = 0.0_dp
+         fx = 0.0_dp
+         fy = 0.0_dp
+         fz = 0.0_dp
          do j = 1, n_kept
             dx = inner_coords(1, keep(j)) - coords(1, i)
             dy = inner_coords(2, keep(j)) - coords(2, i)
@@ -157,12 +190,29 @@ contains
             tt = t*(1.0_dp/g + 1.0_dp/gt)
             u_sum = u_sum + tt
             w_sum = w_sum + tt*r2
+            ! The kernel's own dependence on the separation. `g` and `gp` each
+            ! carry `r^2`, weighted by that end's `w0`, and `gt` carries both.
+            if (want_grad) then
+               q = t*(w0/g + w0p(j)/gp + (w0 + w0p(j))/gt)
+               fx = fx + q*dx
+               fy = fy + q*dy
+               fz = fz + q*dz
+            end if
          end do
          f_sum = -1.5_dp*f_sum
 
          exc(i) = beta + 0.5_dp*f_sum
          vrho(i) = beta + f_sum + 1.5_dp*(u_sum*dk_drho + w_sum*dw0_drho)
          vsigma(i) = 1.5_dp*w_sum*dw0_dsigma
+         if (present(dedw)) dedw(i) = r_i*(beta + f_sum)
+         if (present(fexp)) then
+            ! d/dr_i of the pair sum: two from differentiating a squared
+            ! separation, and another from the outer point appearing in both
+            ! roles, against `dx` which is measured inner minus outer.
+            fexp(1, i) = -3.0_dp*r_i*fx
+            fexp(2, i) = -3.0_dp*r_i*fy
+            fexp(3, i) = -3.0_dp*r_i*fz
+         end if
       end do
       !$omp end parallel do
    end subroutine vv10_nlc

--- a/backends/libcint/mqc_libcint_xc.F90
+++ b/backends/libcint/mqc_libcint_xc.F90
@@ -83,6 +83,7 @@ module mqc_libcint_xc
    public :: xc_grid_gga_quantities
    public :: xc_kernel_apply
    public :: xc_grid_kernel_quantities
+   public :: ensure_nlc_grid
 
    real(dp), parameter :: KERNEL_RHO_FLOOR = 1.0e-10_dp
       !! Grid points below this density contribute no *second* derivative.
@@ -1926,23 +1927,12 @@ contains
       real(dp), allocatable :: exc(:), vrho(:), vsigma(:)
       real(dp), allocatable :: ao(:, :), ao_grad(:, :, :), grad_coeff(:, :)
       real(dp), allocatable :: rho_blk(:), rho_grad_blk(:, :), vtau_none(:)
-      integer, allocatable :: numbers(:)
       integer :: npts, g0, g1, nb, ig, id
 
       e_nl = 0.0_dp
 
-      ! Built on first use rather than beside the exchange grid, because
-      ! whether it is needed at all is only known once the functional's
-      ! components have been read, which happens after that grid is made.
-      ! Nothing that is not a `-V` functional ever pays for it.
-      if (ctx%nlc_grid%n_points == 0) then
-         allocate (numbers(mol%natm))
-         numbers = nint(mol%charges)
-         call build_dft_grid(mol%coords, numbers, ctx%nlc_grid, error, &
-                             level=ctx%nlc_grid_level)
-         deallocate (numbers)
-         if (error%has_error()) return
-      end if
+      call ensure_nlc_grid(ctx, mol, error)
+      if (error%has_error()) return
 
       npts = ctx%nlc_grid%n_points
       if (npts == 0) return
@@ -1999,6 +1989,31 @@ contains
                                    vtau=vtau_none, any_gga=.true., any_mgga=.false.)
       end do
    end subroutine vv10_add_potential
+
+   subroutine ensure_nlc_grid(ctx, mol, error)
+      !! Build the non-local correlation grid, once, on first use
+      !!
+      !! Built on first use rather than beside the exchange grid, because
+      !! whether it is needed at all is only known once the functional's
+      !! components have been read, which happens after that grid is made.
+      !! Nothing that is not a `-V` functional ever pays for it.
+      !!
+      !! Shared by the potential and the gradient so that the two integrate and
+      !! differentiate the same quadrature. They would otherwise each build one
+      !! and agree only as long as the level and the partition defaults did.
+      type(xc_context_t), intent(inout) :: ctx
+      type(libcint_molecule_t), intent(in) :: mol
+      type(error_t), intent(inout) :: error
+
+      integer, allocatable :: numbers(:)
+
+      if (ctx%nlc_grid%n_points > 0) return
+      allocate (numbers(mol%natm))
+      numbers = nint(mol%charges)
+      call build_dft_grid(mol%coords, numbers, ctx%nlc_grid, error, &
+                          level=ctx%nlc_grid_level)
+      deallocate (numbers)
+   end subroutine ensure_nlc_grid
 
    subroutine accumulate_xc_matrix(weights, ao, vrho, v, ao_grad, grad_coeff, vtau, &
                                    any_gga, any_mgga)

--- a/mqc_docs/source/analytic_hessians.rst
+++ b/mqc_docs/source/analytic_hessians.rst
@@ -159,9 +159,11 @@ Each of these is refused rather than approximated. A Hessian that silently
 drops a term is worse than one you cannot have: the frequencies come out
 plausible.
 
-**VV10 non-local correlation** (``b97m-v``, ``wb97m-v``). Not implemented, and
-not a small job: VV10 is a double integral over the density, so its second
-derivative is a double-grid object. PySCF implements it in three parts behind
+**VV10 non-local correlation** (``b97m-v``, ``wb97m-v``). Not implemented. The
+*gradient* is -- and it turned out not to need new machinery, because the pair
+sum is spent producing ``vrho`` and ``vsigma`` and what follows is the ordinary
+GGA contraction. The second derivative is not the same story: it is a
+double-grid object. PySCF implements it in three parts behind
 dedicated kernels. On water the missing term is worth about 1.4e-3 in the
 Hessian -- small, but the functional exists for dispersion-bound systems and
 nothing says it stays small there.

--- a/mqc_docs/source/capabilities.rst
+++ b/mqc_docs/source/capabilities.rst
@@ -767,8 +767,9 @@ Current Limitations
    methods carry their own through tblite; a Kohn-Sham number from a functional
    that does not include dispersion itself does not get it from anywhere here.
    VV10 is the exception: the ``-V`` functionals carry their own non-local
-   correlation and it is evaluated, for the energy. Its nuclear gradient is not
-   implemented and is refused, so a ``-V`` functional cannot be optimized
+   correlation, and it is evaluated for both the energy and the nuclear
+   gradient, so a ``-V`` functional can be optimized. Its second derivative is
+   not implemented -- see :doc:`analytic_hessians`
 4. **Multireference dynamic correlation**: CASSCF and ORMAS-SCF give the
    reference, and there is no NEVPT2, CASPT2 or MRCI on top of it
 5. **Local correlation**: no DLPNO or equivalent, so coupled cluster is

--- a/mqc_docs/source/input_files.rst
+++ b/mqc_docs/source/input_files.rst
@@ -547,6 +547,18 @@ dependence anywhere in the kernel, so an unrestricted calculation evaluates it
 once on :math:`\rho_\alpha + \rho_\beta` and adds the identical contribution
 to each spin's matrix.
 
+The **nuclear gradient** is available for a closed shell, so a ``-V`` functional
+can be optimized. It needs no new integrals: the pair sum is spent producing
+:math:`\delta E/\delta\rho` and :math:`\delta E/\delta\sigma`, the same two
+quantities the Fock build consumes, after which the contraction is the one a GGA
+uses. Two terms have no semilocal counterpart and are included -- the kernel
+depends on *where* the grid points are, through :math:`|\mathbf{r}-\mathbf{r}'|`,
+and a point's weight enters the energy twice rather than once. Leaving either
+out costs 4.5e-4 on water and does not shrink when the grid is refined, since
+neither is a quadrature error. The open shell is refused rather than
+approximated, and the second derivative is not implemented; see
+:doc:`analytic_hessians`.
+
 Why it needs its own grid
 """""""""""""""""""""""""
 

--- a/test/test_mqc_rsh_gradient.f90
+++ b/test/test_mqc_rsh_gradient.f90
@@ -1,5 +1,8 @@
-!! The range-separated gradient, against a difference of its own energy
+!! Range-separated and non-local gradients, against a difference of the energy
 module test_mqc_rsh_gradient
+   !! Two families of functional need more than the standard gradient, and
+   !! both are checked here the same way.
+   !!
    !! A range-separated functional splits its exchange over an error-function
    !! kernel, so its gradient needs two exchange derivatives rather than one:
    !! the full-range pass every hybrid takes, and a second at the screened
@@ -7,7 +10,15 @@ module test_mqc_rsh_gradient
    !! the exact-ERI path refused outright rather than return a gradient
    !! missing wB97X's dominant exchange term.
    !!
-   !! Differencing the total energy is the right check for that second pass.
+   !! A functional carrying VV10 has a non-local correlation term whose energy
+   !! is a double integral over the grid. Its gradient turns out not to need
+   !! new machinery -- the pair sum is spent producing `vrho` and `vsigma`, and
+   !! what follows is the ordinary GGA contraction -- but it does need two
+   !! terms no semilocal functional has: the kernel depends on where the grid
+   !! points are, and a point's weight enters the energy twice rather than
+   !! once.
+   !!
+   !! Differencing the total energy is the right check for both.
    !! It needs no reference implementation, it is sensitive to the coefficient
    !! and the sign as well as to the algebra, and -- unlike the Hessian tests
    !! next door -- nothing here is held fixed, so the comparison is exact up
@@ -42,7 +53,8 @@ contains
                   new_unittest("wb97x-gradient", test_wb97x), &
                   new_unittest("cam-b3lyp-gradient", test_cam_b3lyp), &
                   new_unittest("global-hybrid-unchanged", test_b3lyp_unchanged), &
-                  new_unittest("rsh-hessian", test_rsh_hessian) &
+                  new_unittest("rsh-hessian", test_rsh_hessian), &
+                  new_unittest("vv10-gradient", test_vv10) &
                   ]
    end subroutine collect_mqc_rsh_gradient
 
@@ -192,6 +204,21 @@ contains
       ok = .not. err%has_error()
    end subroutine hess_at
 
+   subroutine test_vv10(error)
+      !! The non-local term's gradient, alone and on top of everything else
+      !!
+      !! `b97m-v` is VV10 over a meta-GGA and nothing else; `wb97x-v` adds
+      !! range separation; `wb97m-v` has all three at once. All three land on
+      !! the same 1.47e-7 as a plain hybrid, which is the point -- the
+      !! non-local term is not approximated here, it is differentiated.
+      type(error_type), allocatable, intent(out) :: error
+      call gradient_against_energy("b97m-v", error)
+      if (allocated(error)) return
+      call gradient_against_energy("wb97x-v", error)
+      if (allocated(error)) return
+      call gradient_against_energy("wb97m-v", error)
+   end subroutine test_vv10
+
    subroutine gradient_against_energy(functional, error)
       character(len=*), intent(in) :: functional
       type(error_type), allocatable, intent(out) :: error
@@ -241,13 +268,18 @@ contains
          end do
       end do
 
-      ! Bounded by the difference, not by the gradient. All three land
-      ! 1.47e-7 from it, to three figures -- that sameness is the point: it is
-      ! the h^2 step error, so the range-separated gradients are as good as the
-      ! global hybrid's rather than merely close enough. Dropping the
-      ! long-range pass entirely misses by 1e-1 on wB97X and a coefficient
-      ! confused between alpha and alpha+beta by 1e-2, so the tolerance
-      ! separates right from wrong by several decades either way.
+      ! Bounded by the difference, not by the gradient. Every functional here
+      ! lands between 1.46e-7 and 1.48e-7 -- that sameness is the point: it is
+      ! the h^2 step error, so the range-separated and non-local gradients are
+      ! as good as the global hybrid's rather than merely close enough.
+      !
+      ! Dropping the long-range exchange pass misses by 1e-1 on wB97X and a
+      ! coefficient confused between alpha and alpha+beta by 1e-2. Omitting
+      ! VV10's explicit coordinate derivative, or taking its weight derivative
+      ! as `rho*exc` instead of `dE/dw`, misses by 4.5e-4 -- and that one does
+      ! not shrink when the grid is refined, because it is not a quadrature
+      ! error. The tolerance separates right from wrong by decades in each
+      ! case.
       !
       ! Against PySCF rather than against itself, at grid level 6: cam-B3LYP
       ! agrees to 4.1e-8 and B3LYP to 6.3e-8. wB97X is 3.9e-6, and that is the


### PR DESCRIPTION
Refused until now, and the refusal was right: omitting a non-local term worth 43 mHartree leaves an SCF that converges, an energy that is correct, and forces that are quietly wrong.

**It needs no new machinery.** `E_nl` is a functional of rho and sigma, so the pair sum is spent entirely on producing `vrho` and `vsigma` — the same two arrays the Fock build already consumes — and what follows is the ordinary GGA contraction. PySCF reaches this the same way: `get_nlc_vxc` calls `_vv10nlc` and hands the result to the shared `_gga_grad_sum_`. The double-grid object is the *second* derivative, not this one.

**Two terms have no semilocal counterpart**, and a first version written by copying `xc_gradient`'s three terms was wrong by 4.5e-4 without them:

* the kernel depends on *where the points are*, through `r^2`, which no functional of the density at a point does. This contributes a force between the atoms owning the two ends of each pair.
* a point's weight enters the energy twice, once as the outer point and once inside every other point's inner sum, and the kernel's symmetry makes the two equal. So the weight derivative carries `beta + f` where `exc` carries `beta + f/2` — the same doubling that already distinguishes `vrho` from `exc`. Using `rho*exc` there, correct for every semilocal functional, is a factor of two on half the term.

Both come back from `vv10_nlc` as optional outputs, computed in the pair loop that was already running and guarded so the potential path does not pay for them.

What made the difference findable was that it did not shrink with the grid: 4.4647e-4 at `nlc_grid_level` 1 and 4.4636e-4 at 3. A quadrature error would have moved. Against a difference of the energy, `b97m-v` now lands at 1.47e-7 — the h^2 step error, the same figure `b3lyp`, `cam-b3lyp` and `wb97x` land on. `wb97x-v` and `wb97m-v`, which stack VV10 on range separation and on both range separation and a meta-GGA, give 1.46e-7 and 1.48e-7.

The open shell is refused rather than approximated: neither this nor the semilocal path is written for two spins here.

---

**Stack** (merge bottom-up):

1. #302 `feat/dft-hessian` — XC second derivatives, LDA through meta-GGA
2. #303 `feat/rsh-hessian` — range-separated exchange in the Hessian
3. #304 `feat/hessian-wiring` — a deck can reach the analytic path
4. #305 `feat/model-cartesian` — model.cartesian, the angular form a deck asks for
5. #306 `feat/vv10-gradient` — the VV10 gradient
6. #307 `feat/vv10-hessian` — the VV10 Hessian
7. #308 `feat/mp2-frozen-core` — frozen-core MP2 and RI-MP2 gradients

This PR is #5 of the stack; it is based on the one below it, so its diff is only its own commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012hZrt2ZvTQGGsrczouFRv3
