### PR TITLE
refactor scf config 

### DIFF
--- a/src/methods/mqc_cuest_iface.f90
+++ b/src/methods/mqc_cuest_iface.f90
@@ -12,11 +12,12 @@ module mqc_cuest_iface
    !! the method files carry no preprocessor conditionals at all.
    use pic_types, only: dp
    use mqc_config_types, only: guess_step_t
-   use mqc_method_config, only: pcm_config_t, mcscf_config_t
+   use mqc_method_config, only: pcm_config_t, mcscf_config_t, scf_options_t
    implicit none
    private
 
    public :: cuest_scf_settings_t
+   public :: apply_scf_settings
    public :: BACKEND_AUTO, BACKEND_CUEST, BACKEND_LIBCINT
    public :: parse_backend_name
    public :: method_runs_on_cuest
@@ -169,6 +170,49 @@ module mqc_cuest_iface
    end type cuest_scf_settings_t
 
 contains
+
+   subroutine apply_scf_settings(settings, options)
+      !! Hand a backend everything the SCF half of a method decided
+      !!
+      !! **The third and last copy of the shared settings.** A field reaching
+      !! a backend crossed three hand-maintained layers: the options type, the
+      !! `configure_*` that fills it, and this block. `scf_options_t` and
+      !! `configure_scf` removed the first two; without this one a field could
+      !! be declared on both methods and filled on both and still never arrive,
+      !! which is exactly what `allow_crap_scf` did on the Kohn-Sham path --
+      !! the deck said true, the options object said true, and the backend was
+      !! never told.
+      !!
+      !! `backend` is deliberately not here: parsing its name can fail, and a
+      !! routine that copies fields should not also be the one that reports an
+      !! error. The caller keeps that line.
+      type(cuest_scf_settings_t), intent(inout) :: settings
+      class(scf_options_t), intent(in) :: options
+
+      settings%basis_set = options%basis_set
+      settings%ecp_set = options%ecp_set
+      settings%aux_basis_set = options%aux_basis_set
+      settings%aux_basis_named = options%aux_basis_named
+      settings%cartesian = options%cartesian
+      settings%spherical = options%spherical
+      settings%density_fitting = options%density_fitting
+      settings%freeze_core = options%freeze_core
+      settings%n_frozen_core = options%n_frozen_core
+      settings%unrestricted = options%unrestricted
+      settings%guess = options%guess
+      if (allocated(options%guess_steps)) settings%guess_steps = options%guess_steps
+      settings%max_iter = options%max_iter
+      settings%allow_crap_scf = options%allow_crap_scf
+      settings%energy_tol = options%energy_tol
+      settings%density_tol = options%density_tol
+      settings%level_shift = options%level_shift
+      settings%linear_dependence = options%linear_dependence
+      settings%use_diis = options%use_diis
+      settings%diis_size = options%diis_size
+      settings%verbose = options%verbose
+      settings%device_rank = options%device_rank
+      settings%pcm = options%pcm
+   end subroutine apply_scf_settings
 
    subroutine parse_backend_name(name, kind, error)
       !! A deck's backend name to one of BACKEND_*

--- a/src/methods/mqc_cuest_iface.f90
+++ b/src/methods/mqc_cuest_iface.f90
@@ -12,12 +12,13 @@ module mqc_cuest_iface
    !! the method files carry no preprocessor conditionals at all.
    use pic_types, only: dp
    use mqc_config_types, only: guess_step_t
-   use mqc_method_config, only: pcm_config_t, mcscf_config_t, scf_options_t
+   use mqc_method_config, only: pcm_config_t, mcscf_config_t, scf_options_t, properties_config_t
    implicit none
    private
 
    public :: cuest_scf_settings_t
    public :: apply_scf_settings
+   public :: apply_properties_settings
    public :: BACKEND_AUTO, BACKEND_CUEST, BACKEND_LIBCINT
    public :: parse_backend_name
    public :: method_runs_on_cuest
@@ -170,6 +171,39 @@ module mqc_cuest_iface
    end type cuest_scf_settings_t
 
 contains
+
+   subroutine apply_properties_settings(settings, properties)
+      !! Hand a backend the post-SCF properties the deck asked for
+      !!
+      !! The sibling of `apply_scf_settings`, and it exists for the same
+      !! reason: this block was written out by hand in each method and the
+      !! three had already diverged. Kohn-Sham unpacked four of the eight and
+      !! MCSCF six, so `keywords.properties.bonding_energy` on a Kohn-Sham run
+      !! reached a backend that reads `settings%bonding_energy` -- the same
+      !! routine Hartree-Fock uses -- and found the default. That one is worse
+      !! than a dropped feature: the flag guards a *refusal*, because the
+      !! bonding energy decomposition rebuilds atom energies from gas-phase
+      !! operators and must not run under a continuum, so never setting it
+      !! disarmed a check that exists to stop a wrong answer.
+      !!
+      !! `fukui_population` and `charges_scheme` are allocatable and stay
+      !! guarded: an unset one must not overwrite what a backend already has.
+      type(cuest_scf_settings_t), intent(inout) :: settings
+      type(properties_config_t), intent(in) :: properties
+
+      settings%bonding_analysis = properties%bonding_analysis
+      settings%bonding_threshold = properties%bonding_threshold
+      settings%bonding_energy = properties%bonding_energy
+      settings%bonding_no_sharing = properties%bonding_no_sharing
+      settings%bonding_no_sharing_ci = properties%bonding_no_sharing_ci
+      settings%bonding_restrict_localization = properties%bonding_restrict_localization
+      if (allocated(properties%fukui_population)) then
+         settings%fukui_population = properties%fukui_population
+      end if
+      if (allocated(properties%charges_scheme)) then
+         settings%charges_scheme = properties%charges_scheme
+      end if
+   end subroutine apply_properties_settings
 
    subroutine apply_scf_settings(settings, options)
       !! Hand a backend everything the SCF half of a method decided

--- a/src/methods/mqc_method_config.f90
+++ b/src/methods/mqc_method_config.f90
@@ -295,6 +295,14 @@ module mqc_method_config
       !! field it does not own. Anything specific to one reference -- a
       !! functional, a grid, coupled-cluster settings -- belongs in the
       !! extending type, not here.
+      !!
+      !! **Adding a field here means adding it in two more places**:
+      !! `configure_scf` in `mqc_method_factory`, which fills it from the deck,
+      !! and `apply_scf_settings` in `mqc_cuest_iface`, which hands it to the
+      !! backend. `test/test_mqc_scf_options.f90` asserts the second of those
+      !! for every field, so add it there too -- a field nothing asserts is a
+      !! field that can go missing again, and the way it goes missing is
+      !! silently.
       character(len=32) :: basis_set = "sto-3g"
          !! Orbital basis set name
       character(len=32) :: ecp_set = ""

--- a/src/methods/mqc_method_config.f90
+++ b/src/methods/mqc_method_config.f90
@@ -15,6 +15,7 @@ module mqc_method_config
 
    public :: method_config_t
    public :: scf_config_t, xtb_config_t, dft_config_t, mcscf_config_t
+   public :: scf_options_t
    public :: correlation_config_t, cc_config_t, f12_config_t
    public :: efp_config_t
    public :: pcm_config_t
@@ -273,6 +274,88 @@ module mqc_method_config
       character(len=32) :: bonding_no_sharing_ci = "transform"
       real(dp) :: bonding_threshold = 1.0_dp
    end type properties_config_t
+
+   type :: scf_options_t
+      !! What every self-consistent-field method carries, defined once
+      !!
+      !! **This exists because the copies drifted and one of them cost a bug.**
+      !! `hf_options_t` and `dft_options_t` each held these fields by hand,
+      !! and each had to be updated in three places -- the type, its
+      !! `configure_*` in the factory, and the `settings%... = options%...`
+      !! block in the method. Miss the third and a keyword is read from the
+      !! deck, passes the schema, reaches the config and is silently dropped:
+      !! that is what happened to `allow_crap_scf` on the Kohn-Sham path,
+      !! which was honoured for Hartree-Fock and ignored for DFT. The two
+      !! copies had also drifted in spelling -- `conv_tol` against
+      !! `energy_tol`, `density_fitting` against `use_density_fitting` -- for
+      !! fields meant to mean the same thing.
+      !!
+      !! Method options **extend** this rather than holding it as a component,
+      !! so `options%max_iter` keeps working and a method cannot forget a
+      !! field it does not own. Anything specific to one reference -- a
+      !! functional, a grid, coupled-cluster settings -- belongs in the
+      !! extending type, not here.
+      character(len=32) :: basis_set = "sto-3g"
+         !! Orbital basis set name
+      character(len=32) :: ecp_set = ""
+         !! Effective core potential set, empty for an all-electron run
+      character(len=32) :: aux_basis_set = "def2-universal-jkfit"
+         !! Auxiliary (JKFIT) basis for the density-fitted J and K
+      logical :: aux_basis_named = .false.
+         !! Whether the deck asked for `aux_basis_set`. See `scf_config_t`.
+      logical :: cartesian = .false.
+         !! `model.cartesian`; see `mqc_config_t`.
+      logical :: spherical = .true.
+         !! Use spherical (true) or Cartesian (false) basis
+      integer :: max_iter = 100
+         !! Maximum SCF iterations
+      real(dp) :: energy_tol = 1.0e-8_dp
+         !! Energy convergence threshold
+      real(dp) :: density_tol = 1.0e-6_dp
+         !! Density matrix convergence threshold
+      real(dp) :: linear_dependence = 0.0_dp
+         !! Zero means the orthogonaliser's own cutoff. See `scf_config_t`.
+      real(dp) :: level_shift = 0.0_dp
+         !! Hartree added to the virtual block before each diagonalisation.
+         !! Zero is off. See `scf_config_t`.
+      logical :: use_diis = .true.
+         !! Use DIIS acceleration
+      integer :: diis_size = 8
+         !! Number of Fock matrices for DIIS
+      logical :: allow_crap_scf = .false.
+         !! Keep a non-converged SCF instead of failing
+      character(len=32) :: guess = "auto"
+         !! Initial guess: 'core', 'gwh', 'sac', 'sad', 'basis_set_projection',
+         !! or 'auto'. 'auto' means the backend picks, because the best
+         !! starting point is a property of the backend rather than of the
+         !! request: the CPU path resolves it to 'sad', and cuEST to 'gwh'.
+         !! An explicit spelling always wins over both.
+      type(guess_step_t), allocatable :: guess_steps(:)
+         !! The basis ladder for 'basis_set_projection', one entry per
+         !! preliminary SCF in order.
+      logical :: unrestricted = .false.
+         !! Force UHF/UKS even for a closed shell
+      logical :: density_fitting = .false.
+         !! Fit J and K rather than computing exact integrals
+      logical :: freeze_core = .false.
+         !! Exclude core orbitals from a post-SCF correlation treatment
+      integer :: n_frozen_core = -1
+         !! Core orbitals to freeze; -1 counts them from the elements
+      character(len=16) :: backend = "auto"
+         !! Which backend evaluates the integrals
+      integer :: device_rank = 0
+         !! Node-local MPI rank, for spreading ranks across a node's GPUs
+      logical :: verbose = .false.
+         !! Print SCF iterations
+      type(pcm_config_t) :: pcm
+         !! Continuum solvation. A property of the reference rather than of
+         !! the functional, which is why it sits here: Hartree-Fock, DFT, MP2
+         !! and coupled cluster all reach the backend through an extending
+         !! type, and leaving it off one of them meant `keywords.pcm` was read,
+         !! validated and then silently dropped for that path.
+      type(properties_config_t) :: properties
+         !! Population analysis and other post-SCF properties
+   end type scf_options_t
 
    type :: mcscf_config_t
       !! Configuration for MCSCF/CASSCF method

--- a/src/methods/mqc_method_dft.F90
+++ b/src/methods/mqc_method_dft.F90
@@ -22,7 +22,7 @@ module mqc_method_dft
    use mqc_physical_fragment, only: physical_fragment_t
    use mqc_error, only: error_t, ERROR_VALIDATION
    use mqc_semi_numerical_hessian, only: finite_difference_hessian
-   use mqc_cuest_iface, only: apply_scf_settings, cuest_scf_settings_t, parse_backend_name, &
+   use mqc_cuest_iface, only: apply_properties_settings, apply_scf_settings, cuest_scf_settings_t, parse_backend_name, &
                               BACKEND_CUEST, BACKEND_LIBCINT
    use mqc_cuest_bridge, only: run_cuest_scf
    use mqc_libcint_bridge, only: run_libcint_hf
@@ -127,14 +127,7 @@ contains
       ! Where the molecule reacts. Absent here until now, so a DFT deck asking
       ! for `properties.fukui` got a normal DFT run and no analysis, with no
       ! error to say why: the bridge gates on this being allocated.
-      if (allocated(this%options%properties%fukui_population)) then
-         settings%fukui_population = this%options%properties%fukui_population
-      end if
-      if (allocated(this%options%properties%charges_scheme)) then
-         settings%charges_scheme = this%options%properties%charges_scheme
-      end if
-      settings%bonding_analysis = this%options%properties%bonding_analysis
-      settings%bonding_threshold = this%options%properties%bonding_threshold
+      call apply_properties_settings(settings, this%options%properties)
       ! Set unconditionally, and deliberately not guarded on the backend. cuEST
       ! has no four-index path so it fits regardless and ignores this, per the
       ! note at the top of this module; on the libcint side it is a real choice.

--- a/src/methods/mqc_method_dft.F90
+++ b/src/methods/mqc_method_dft.F90
@@ -127,6 +127,26 @@ contains
       ! Where the molecule reacts. Absent here until now, so a DFT deck asking
       ! for `properties.fukui` got a normal DFT run and no analysis, with no
       ! error to say why: the bridge gates on this being allocated.
+      ! Refused rather than run. The QUAO bonding options are not meant for a
+      ! Kohn-Sham reference, and nothing in the backend stops them: the
+      ! dispatch is gated only on the deck naming an analysis, so handing these
+      ! over would run a decomposition on Kohn-Sham orbitals and report numbers
+      ! for it. Before this refactor a Kohn-Sham deck asking for them was
+      ! silently ignored, which is the failure this work exists to end -- but
+      ! the fix is to say no, not to start obeying a request the method was
+      ! never meant to serve. `bonding_analysis` itself stays copied: it selects
+      ! *which* analysis and its own dispatch handles "none".
+      if (this%options%properties%bonding_energy .or. &
+          this%options%properties%bonding_no_sharing .or. &
+          this%options%properties%bonding_restrict_localization) then
+         call result%error%set(ERROR_VALIDATION, "the QUAO bonding options are not "// &
+                               "available for a Kohn-Sham reference: the energy "// &
+                               "decomposition and its sharing controls are defined "// &
+                               "against a Hartree-Fock or MCSCF wavefunction. Request "// &
+                               "them on one of those instead.")
+         result%has_error = .true.
+         return
+      end if
       call apply_properties_settings(settings, this%options%properties)
       ! Set unconditionally, and deliberately not guarded on the backend. cuEST
       ! has no four-index path so it fits regardless and ignores this, per the

--- a/src/methods/mqc_method_dft.F90
+++ b/src/methods/mqc_method_dft.F90
@@ -22,7 +22,7 @@ module mqc_method_dft
    use mqc_physical_fragment, only: physical_fragment_t
    use mqc_error, only: error_t, ERROR_VALIDATION
    use mqc_semi_numerical_hessian, only: finite_difference_hessian
-   use mqc_cuest_iface, only: cuest_scf_settings_t, parse_backend_name, &
+   use mqc_cuest_iface, only: apply_scf_settings, cuest_scf_settings_t, parse_backend_name, &
                               BACKEND_CUEST, BACKEND_LIBCINT
    use mqc_cuest_bridge, only: run_cuest_scf
    use mqc_libcint_bridge, only: run_libcint_hf
@@ -108,15 +108,8 @@ contains
          return
       end if
 
-      settings%basis_set = this%options%basis_set
-      settings%cartesian = this%options%cartesian
-      settings%ecp_set = this%options%ecp_set
-      settings%aux_basis_set = this%options%aux_basis_set
-      settings%aux_basis_named = this%options%aux_basis_named
+      call apply_scf_settings(settings, this%options)
       settings%functional = this%options%functional
-      settings%spherical = this%options%spherical
-      settings%verbose = this%options%verbose
-      settings%device_rank = this%options%device_rank
       ! Resolved here rather than carried as a string, so an unknown name fails
       ! once, before any integrals, instead of at each dispatch.
       call parse_backend_name(this%options%backend, settings%backend, backend_error)
@@ -125,23 +118,12 @@ contains
          result%has_error = .true.
          return
       end if
-      settings%unrestricted = this%options%unrestricted
-      settings%guess = this%options%guess
-      if (allocated(this%options%guess_steps)) settings%guess_steps = this%options%guess_steps
-      settings%max_iter = this%options%max_iter
-      settings%energy_tol = this%options%energy_tol
-      settings%density_tol = this%options%density_tol
-      settings%level_shift = this%options%level_shift
-      settings%linear_dependence = this%options%linear_dependence
-      settings%use_diis = this%options%use_diis
-      settings%diis_size = this%options%diis_size
       settings%radial_points = this%options%radial_points
       settings%angular_points = this%options%angular_points
       settings%grid_level = this%options%grid_level
       settings%nlc_grid_level = this%options%nlc_grid_level
       settings%screening_tolerance = this%options%screening_tolerance
       settings%block_size = this%options%block_size
-      settings%pcm = this%options%pcm
       ! Where the molecule reacts. Absent here until now, so a DFT deck asking
       ! for `properties.fukui` got a normal DFT run and no analysis, with no
       ! error to say why: the bridge gates on this being allocated.
@@ -163,9 +145,6 @@ contains
       ! Until this line existed a Kohn-Sham deck could not turn fitting on
       ! however it asked. That made the fitted path unreachable rather than
       ! wrong, which is the better of the two failures but still a gap.
-      settings%density_fitting = this%options%density_fitting
-      settings%freeze_core = this%options%freeze_core
-      settings%n_frozen_core = this%options%n_frozen_core
 
       ! The same choice Hartree-Fock makes, and made the same way rather than a
       ! second time: cuEST when this build has it, because that is the production

--- a/src/methods/mqc_method_dft.F90
+++ b/src/methods/mqc_method_dft.F90
@@ -16,7 +16,7 @@ module mqc_method_dft
    !! cannot end up with mismatched Coulomb and XC definitions.
    use pic_types, only: dp
    use mqc_config_types, only: guess_step_t
-   use mqc_method_config, only: pcm_config_t, properties_config_t
+   use mqc_method_config, only: scf_options_t, pcm_config_t, properties_config_t
    use mqc_method_base, only: qc_method_t
    use mqc_result_types, only: calculation_result_t
    use mqc_physical_fragment, only: physical_fragment_t
@@ -31,46 +31,10 @@ module mqc_method_dft
 
    public :: dft_method_t, dft_options_t
 
-   type :: dft_options_t
+   type, extends(scf_options_t) :: dft_options_t
       !! DFT calculation options
-      character(len=32) :: basis_set = "sto-3g"
-      character(len=32) :: ecp_set = ""
-         !! Effective core potential set, empty for an all-electron run
-         !! Basis set name
       character(len=32) :: functional = "b3lyp"
          !! Exchange-correlation functional
-      integer :: max_iter = 100
-         !! Maximum SCF iterations
-      real(dp) :: energy_tol = 1.0e-8_dp
-         !! Energy convergence threshold
-      real(dp) :: density_tol = 1.0e-6_dp
-      real(dp) :: linear_dependence = 0.0_dp
-         !! Zero means the orthogonaliser's own cutoff. See `scf_config_t`.
-         !! Density matrix convergence threshold
-      real(dp) :: level_shift = 0.0_dp
-         !! Hartree added to the virtual block before each diagonalisation.
-         !! Zero is off. See `scf_config_t`.
-      logical :: spherical = .true.
-         !! Use spherical (true) or Cartesian (false) basis
-      logical :: verbose = .false.
-         !! Print SCF iterations
-      integer :: device_rank = 0
-         !! Node-local MPI rank, for spreading ranks across a node's GPUs
-      logical :: unrestricted = .false.
-         !! Force UHF/UKS even for a closed shell
-      character(len=32) :: guess = "auto"
-         !! Initial guess: 'core', 'gwh', 'sac', 'sad', 'basis_set_projection',
-         !! or 'auto'
-      type(guess_step_t), allocatable :: guess_steps(:)
-         !! The basis ladder for 'basis_set_projection', one entry per
-         !! preliminary SCF in order.
-         !!
-         !! 'auto' means the backend picks, because the best starting point
-         !! is a property of the backend rather than of the request: the CPU
-         !! path resolves it to 'sad', and cuEST to 'gwh', each having
-         !! measured its own. An explicit spelling always wins over both.
-
-      ! Grid settings
       character(len=16) :: grid_type = "medium"
          !! Integration grid quality
       integer :: radial_points = 75
@@ -88,41 +52,12 @@ module mqc_method_dft
          !! Number of angular grid points (Lebedev)
 
       ! Density fitting
-      logical :: use_density_fitting = .false.
-         !! Use RI-J approximation
-      logical :: cartesian = .false.
-         !! `model.cartesian`; see `mqc_config_t`.
-      character(len=32) :: aux_basis_set = "def2-universal-jkfit"
-         !! Auxiliary (JKFIT) basis. Required by the cuEST backend.
-      logical :: aux_basis_named = .false.
-         !! Whether the deck asked for it. See `scf_config_t`.
-
-      ! Correlation, for the double hybrids. Nothing else on this path has a
-      ! correlated term, but `b2plyp` and its relatives carry an MP2 and read
-      ! `keywords.correlation` like any other method that does. Absent these,
-      ! a deck asking to freeze the core got an all-electron answer with
-      ! nothing in the output to say the request had been dropped.
-      logical :: freeze_core = .false.
-      integer :: n_frozen_core = -1
-         !! -1 counts the core from the elements
-
-      ! Dispersion correction
       logical :: use_dispersion = .false.
          !! Add empirical dispersion correction
       character(len=8) :: dispersion_type = "d3bj"
          !! Dispersion type: "d3", "d3bj", "d4"
 
       ! DIIS acceleration
-      logical :: use_diis = .true.
-         !! Use DIIS for SCF convergence
-      integer :: diis_size = 8
-         !! Number of Fock matrices in DIIS
-      type(properties_config_t) :: properties
-      type(pcm_config_t) :: pcm
-         !! Continuum solvation. Only the cuEST path implements it; the CPU
-         !! backend ignores it, which `run_cuest_scf`'s stub makes visible.
-      character(len=16) :: backend = "auto"
-         !! Integral backend request: "auto", "cuest"/"gpu", "libcint"/"cpu".
    end type dft_options_t
 
    type, extends(qc_method_t) :: dft_method_t
@@ -228,7 +163,7 @@ contains
       ! Until this line existed a Kohn-Sham deck could not turn fitting on
       ! however it asked. That made the fitted path unreachable rather than
       ! wrong, which is the better of the two failures but still a gap.
-      settings%density_fitting = this%options%use_density_fitting
+      settings%density_fitting = this%options%density_fitting
       settings%freeze_core = this%options%freeze_core
       settings%n_frozen_core = this%options%n_frozen_core
 

--- a/src/methods/mqc_method_dft.F90
+++ b/src/methods/mqc_method_dft.F90
@@ -127,23 +127,30 @@ contains
       ! Where the molecule reacts. Absent here until now, so a DFT deck asking
       ! for `properties.fukui` got a normal DFT run and no analysis, with no
       ! error to say why: the bridge gates on this being allocated.
-      ! Refused rather than run. The QUAO bonding options are not meant for a
-      ! Kohn-Sham reference, and nothing in the backend stops them: the
-      ! dispatch is gated only on the deck naming an analysis, so handing these
-      ! over would run a decomposition on Kohn-Sham orbitals and report numbers
-      ! for it. Before this refactor a Kohn-Sham deck asking for them was
-      ! silently ignored, which is the failure this work exists to end -- but
-      ! the fix is to say no, not to start obeying a request the method was
-      ! never meant to serve. `bonding_analysis` itself stays copied: it selects
-      ! *which* analysis and its own dispatch handles "none".
-      if (this%options%properties%bonding_energy .or. &
-          this%options%properties%bonding_no_sharing .or. &
-          this%options%properties%bonding_restrict_localization) then
-         call result%error%set(ERROR_VALIDATION, "the QUAO bonding options are not "// &
-                               "available for a Kohn-Sham reference: the energy "// &
-                               "decomposition and its sharing controls are defined "// &
-                               "against a Hartree-Fock or MCSCF wavefunction. Request "// &
-                               "them on one of those instead.")
+      ! Refused rather than run. The quasi-atomic bonding analysis is not
+      ! defined against a Kohn-Sham reference, and nothing in the backend stops
+      ! it: `run_libcint_hf` serves both references and its dispatch is gated
+      ! only on the deck naming an analysis, so handing this over would run a
+      ! decomposition on Kohn-Sham orbitals and report numbers for it. Before
+      ! this refactor such a deck was silently ignored, which is the failure
+      ! this work exists to end -- but the fix is to say no, not to start
+      ! obeying a request the method was never meant to serve.
+      !
+      ! The analysis itself is refused, not merely its sub-options. Naming
+      ! `quao` with none of them set still runs it, so a check on
+      ! `bonding_energy` and friends alone would leave the plainest spelling of
+      ! the request working.
+      ! Tested on the name rather than through `bonding_analysis_kind`, which
+      ! lives in `mqc_libcint_bonding` -- a backend module this one must not
+      ! depend on, or the build without libcint stops compiling. "none" and
+      ! empty are that function's own spellings for off; any other name selects
+      ! an analysis, and QUAO is the only one there is.
+      if (len_trim(this%options%properties%bonding_analysis) > 0 .and. &
+          trim(adjustl(this%options%properties%bonding_analysis)) /= "none") then
+         call result%error%set(ERROR_VALIDATION, "the quasi-atomic bonding analysis is "// &
+                               "not available for a Kohn-Sham reference: it is defined "// &
+                               "against a Hartree-Fock or MCSCF wavefunction. Request it "// &
+                               "on one of those instead.")
          result%has_error = .true.
          return
       end if

--- a/src/methods/mqc_method_factory.F90
+++ b/src/methods/mqc_method_factory.F90
@@ -8,7 +8,7 @@ module mqc_method_factory
                                METHOD_TYPE_DFT, METHOD_TYPE_MCSCF, METHOD_TYPE_MP2, &
                                METHOD_TYPE_CCSD, METHOD_TYPE_CCSD_T, &
                                method_type_to_string
-   use mqc_method_config, only: method_config_t
+   use mqc_method_config, only: scf_options_t, method_config_t
    use mqc_method_base, only: qc_method_t
    use mqc_method_hf, only: hf_method_t
    use mqc_method_dft, only: dft_method_t
@@ -176,6 +176,47 @@ contains
    end subroutine configure_xtb
 #endif
 
+   subroutine configure_scf(options, config)
+      !! Fill everything a self-consistent-field method shares, from the deck
+      !!
+      !! **The shared type was not enough on its own.** Making `hf_options_t`
+      !! and `dft_options_t` extend `scf_options_t` collapses the *declaration*
+      !! of a shared field, but each `configure_*` still had to assign it by
+      !! hand -- so a field could exist on both types and still be filled for
+      !! only one. That is precisely how `allow_crap_scf` reached the Kohn-Sham
+      !! options and stayed `.false.` whatever the deck said. Assigning them
+      !! here, once, is what removes the second copy; the caller then adds only
+      !! what is specific to its own reference.
+      class(scf_options_t), intent(inout) :: options
+      type(method_config_t), intent(in) :: config
+
+      options%basis_set = config%basis_set
+      options%ecp_set = config%ecp_set
+      options%spherical = config%use_spherical
+      options%verbose = config%verbose
+      options%device_rank = config%device_rank
+      options%backend = config%backend
+      options%freeze_core = config%corr%freeze_core
+      options%n_frozen_core = config%corr%n_frozen_core
+      options%cartesian = config%scf%cartesian
+      options%aux_basis_set = config%scf%aux_basis_set
+      options%aux_basis_named = config%scf%aux_basis_named
+      options%density_fitting = config%scf%density_fitting
+      options%unrestricted = config%scf%unrestricted
+      options%guess = config%scf%guess
+      if (allocated(config%scf%guess_steps)) options%guess_steps = config%scf%guess_steps
+      options%max_iter = config%scf%max_iter
+      options%allow_crap_scf = config%scf%allow_crap_scf
+      options%energy_tol = config%scf%energy_convergence
+      options%density_tol = config%scf%density_convergence
+      options%level_shift = config%scf%level_shift
+      options%linear_dependence = config%scf%linear_dependence
+      options%use_diis = config%scf%use_diis
+      options%diis_size = config%scf%diis_size
+      options%pcm = config%pcm
+      options%properties = config%properties
+   end subroutine configure_scf
+
    subroutine configure_hf(m, config, with_mp2, with_cc)
       !! Configure a Hartree-Fock method instance from config%scf (shared SCF settings)
       type(hf_method_t), intent(inout) :: m
@@ -191,14 +232,9 @@ contains
          !! reach the same code.
 
       ! Common settings
-      m%options%basis_set = config%basis_set
-      m%options%ecp_set = config%ecp_set
-      m%options%spherical = config%use_spherical
-      m%options%verbose = config%verbose
-      m%options%device_rank = config%device_rank
 
-      m%options%backend = config%backend
       ! SCF settings from shared config%scf
+      call configure_scf(m%options, config)
       if (present(with_mp2)) m%options%run_mp2 = with_mp2
       if (present(with_cc)) m%options%run_cc = with_cc
       m%options%cc_triples = config%cc%include_triples
@@ -210,8 +246,6 @@ contains
       if (.not. config%cc%use_diis) m%options%cc_diis_size = 0
       ! From config%corr, not config%scf: the reference and the correlation
       ! treatment are configured separately and may disagree.
-      m%options%freeze_core = config%corr%freeze_core
-      m%options%n_frozen_core = config%corr%n_frozen_core
       m%options%corr_density_fitting = config%corr%use_df
       ! One and one unless scaling was asked for, so an unscaled run cannot
       ! pick up factors that happen to be sitting in the config.
@@ -220,27 +254,10 @@ contains
          m%options%scs_os = config%corr%scs_os
       end if
 
-      m%options%cartesian = config%scf%cartesian
-      m%options%aux_basis_set = config%scf%aux_basis_set
-      m%options%aux_basis_named = config%scf%aux_basis_named
-      m%options%density_fitting = config%scf%density_fitting
-      m%options%unrestricted = config%scf%unrestricted
-      m%options%guess = config%scf%guess
-      if (allocated(config%scf%guess_steps)) m%options%guess_steps = config%scf%guess_steps
-      m%options%max_iter = config%scf%max_iter
-      m%options%allow_crap_scf = config%scf%allow_crap_scf
-      m%options%conv_tol = config%scf%energy_convergence
-      m%options%density_tol = config%scf%density_convergence
-      m%options%level_shift = config%scf%level_shift
-      m%options%linear_dependence = config%scf%linear_dependence
-      m%options%use_diis = config%scf%use_diis
-      m%options%diis_size = config%scf%diis_size
       ! Not from `config%dft`, and so easy to leave out: the continuum sits on
       ! the shared config beside the SCF settings precisely because it applies
       ! to any reference. `configure_dft` copied it and this did not, which made
       ! `keywords.pcm` a no-op for Hartree-Fock, MP2 and coupled cluster.
-      m%options%pcm = config%pcm
-      m%options%properties = config%properties
    end subroutine configure_hf
 
    subroutine configure_dft(m, config)
@@ -249,63 +266,40 @@ contains
       type(method_config_t), intent(in) :: config
 
       ! Common settings
-      m%options%basis_set = config%basis_set
-      m%options%ecp_set = config%ecp_set
-      m%options%spherical = config%use_spherical
-      m%options%verbose = config%verbose
-      m%options%device_rank = config%device_rank
 
       ! SCF settings from shared config%scf
-      m%options%unrestricted = config%scf%unrestricted
-      m%options%guess = config%scf%guess
-      if (allocated(config%scf%guess_steps)) m%options%guess_steps = config%scf%guess_steps
-      m%options%max_iter = config%scf%max_iter
-      m%options%energy_tol = config%scf%energy_convergence
-      m%options%density_tol = config%scf%density_convergence
-      m%options%level_shift = config%scf%level_shift
-      m%options%linear_dependence = config%scf%linear_dependence
-      m%options%use_diis = config%scf%use_diis
-      m%options%diis_size = config%scf%diis_size
 
       ! DFT-specific from config%dft
+      call configure_scf(m%options, config)
       m%options%functional = config%dft%functional
       m%options%grid_type = config%dft%grid_type
       m%options%grid_level = config%dft%grid_level
       m%options%nlc_grid_level = config%dft%nlc_grid_level
       m%options%screening_tolerance = config%dft%screening_tolerance
       m%options%block_size = config%dft%block_size
-      m%options%pcm = config%pcm
-      m%options%properties = config%properties
-      m%options%backend = config%backend
       m%options%radial_points = config%dft%radial_points
       m%options%angular_points = config%dft%angular_points
 
       ! Density fitting. The auxiliary basis normally comes from the shared
       ! SCF settings, which is what the %model `aux_basis` keyword fills; a
       ! DFT-specific override wins only when it was actually set.
-      ! From the *shared* SCF settings, which is what `keywords.scf.density_fitting`
-      ! fills and what Hartree-Fock reads a few lines above. `config%dft%use_density_fitting`
-      ! is never written by the reader or the adapter, so taking it here meant a
-      ! Kohn-Sham deck could not turn fitting on however it asked -- the flag was
-      ! read from a field nothing set. The DFT-specific auxiliary override below
-      ! still wins where it is given, because that one *is* filled.
-      m%options%use_density_fitting = config%scf%density_fitting .or. &
-                                      config%dft%use_density_fitting
+      ! `density_fitting` itself comes from the shared settings via
+      ! `configure_scf`. It used to be OR-ed here with
+      ! `config%dft%use_density_fitting`, which the reader and the adapter never
+      ! write -- its only assignment anywhere is to `.false.` in the defaults --
+      ! so that term was always false and the OR was reading a field nothing
+      ! set. The DFT-specific *auxiliary basis* override below is different: it
+      ! is filled, and it still wins where it is given.
       if (len_trim(config%dft%aux_basis_set) > 0) then
          m%options%aux_basis_set = config%dft%aux_basis_set
          m%options%aux_basis_named = .true.
       else
-         m%options%cartesian = config%scf%cartesian
-         m%options%aux_basis_set = config%scf%aux_basis_set
-         m%options%aux_basis_named = config%scf%aux_basis_named
       end if
 
       ! Correlation, which on this path means a double hybrid's perturbative
       ! term and nothing else. From `config%corr`, the same place Hartree-Fock
       ! reads it, so one deck keyword means one thing whichever method carries
       ! the MP2.
-      m%options%freeze_core = config%corr%freeze_core
-      m%options%n_frozen_core = config%corr%n_frozen_core
 
       ! Dispersion
       m%options%use_dispersion = config%dft%use_dispersion
@@ -357,7 +351,7 @@ contains
       ! reference-based method reads. A CASSCF starts from a closed-shell SCF,
       ! and a deck that tightened `keywords.scf` meant that one too.
       m%options%max_iter = config%scf%max_iter
-      m%options%conv_tol = config%scf%energy_convergence
+      m%options%energy_tol = config%scf%energy_convergence
       m%options%density_tol = config%scf%density_convergence
       m%options%level_shift = config%scf%level_shift
       m%options%linear_dependence = config%scf%linear_dependence

--- a/src/methods/mqc_method_hf.F90
+++ b/src/methods/mqc_method_hf.F90
@@ -18,7 +18,7 @@ module mqc_method_hf
    use mqc_physical_fragment, only: physical_fragment_t
    use mqc_error, only: error_t, ERROR_VALIDATION
    use mqc_semi_numerical_hessian, only: finite_difference_hessian
-   use mqc_cuest_iface, only: cuest_scf_settings_t, parse_backend_name, &
+   use mqc_cuest_iface, only: apply_scf_settings, cuest_scf_settings_t, parse_backend_name, &
                               BACKEND_CUEST, BACKEND_LIBCINT
    use mqc_cuest_bridge, only: run_cuest_scf
    use mqc_libcint_bridge, only: run_libcint_hf
@@ -82,7 +82,7 @@ contains
       type(cuest_scf_settings_t) :: settings
       type(error_t) :: backend_error
 
-      settings%pcm = this%options%pcm
+      call apply_scf_settings(settings, this%options)
       settings%bonding_analysis = this%options%properties%bonding_analysis
       settings%bonding_threshold = this%options%properties%bonding_threshold
       settings%bonding_energy = this%options%properties%bonding_energy
@@ -96,15 +96,7 @@ contains
       settings%bonding_restrict_localization = &
          this%options%properties%bonding_restrict_localization
       settings%bonding_no_sharing_ci = this%options%properties%bonding_no_sharing_ci
-      settings%basis_set = this%options%basis_set
-      settings%cartesian = this%options%cartesian
-      settings%ecp_set = this%options%ecp_set
-      settings%aux_basis_set = this%options%aux_basis_set
-      settings%aux_basis_named = this%options%aux_basis_named
-      settings%density_fitting = this%options%density_fitting
       settings%run_mp2 = this%options%run_mp2
-      settings%freeze_core = this%options%freeze_core
-      settings%n_frozen_core = this%options%n_frozen_core
       settings%corr_density_fitting = this%options%corr_density_fitting
       settings%run_cc = this%options%run_cc
       settings%cc_triples = this%options%cc_triples
@@ -115,9 +107,6 @@ contains
       settings%scs_ss = this%options%scs_ss
       settings%scs_os = this%options%scs_os
       settings%functional = ""        ! empty selects pure Hartree-Fock
-      settings%spherical = this%options%spherical
-      settings%verbose = this%options%verbose
-      settings%device_rank = this%options%device_rank
       ! Resolved here rather than carried as a string, so an unknown name fails
       ! once, before any integrals, instead of at each dispatch.
       call parse_backend_name(this%options%backend, settings%backend, backend_error)
@@ -126,17 +115,6 @@ contains
          result%has_error = .true.
          return
       end if
-      settings%unrestricted = this%options%unrestricted
-      settings%guess = this%options%guess
-      if (allocated(this%options%guess_steps)) settings%guess_steps = this%options%guess_steps
-      settings%max_iter = this%options%max_iter
-      settings%allow_crap_scf = this%options%allow_crap_scf
-      settings%energy_tol = this%options%energy_tol
-      settings%density_tol = this%options%density_tol
-      settings%level_shift = this%options%level_shift
-      settings%linear_dependence = this%options%linear_dependence
-      settings%use_diis = this%options%use_diis
-      settings%diis_size = this%options%diis_size
 
       ! cuEST when this build has it, because that is the production path and
       ! the only one with gradients. The CPU backend takes over when it does

--- a/src/methods/mqc_method_hf.F90
+++ b/src/methods/mqc_method_hf.F90
@@ -13,7 +13,7 @@ module mqc_method_hf
    use pic_types, only: dp
    use mqc_config_types, only: guess_step_t
    use mqc_method_base, only: qc_method_t
-   use mqc_method_config, only: pcm_config_t, properties_config_t
+   use mqc_method_config, only: scf_options_t, pcm_config_t, properties_config_t
    use mqc_result_types, only: calculation_result_t
    use mqc_physical_fragment, only: physical_fragment_t
    use mqc_error, only: error_t, ERROR_VALIDATION
@@ -27,32 +27,12 @@ module mqc_method_hf
 
    public :: hf_method_t, hf_options_t
 
-   type :: hf_options_t
+   type, extends(scf_options_t) :: hf_options_t
       !! Hartree-Fock calculation options
-      type(properties_config_t) :: properties
-      type(pcm_config_t) :: pcm
-         !! Continuum solvation. Carried here as well as on the Kohn-Sham
-         !! options because a continuum is a property of the reference, not of
-         !! the functional: Hartree-Fock, MP2 and coupled cluster all reach the
-         !! backend through this type, and leaving it off meant `keywords.pcm`
-         !! was read, validated, and then silently dropped for every one of them.
-      character(len=32) :: basis_set = "sto-3g"
-      character(len=32) :: ecp_set = ""
-         !! Effective core potential set, empty for an all-electron run
-         !! Orbital basis set name
-      logical :: cartesian = .false.
-         !! `model.cartesian`; see `mqc_config_t`.
-      character(len=32) :: aux_basis_set = "def2-universal-jkfit"
-         !! Auxiliary (JKFIT) basis for the density-fitted J and K
-      logical :: aux_basis_named = .false.
-         !! Whether the deck asked for `aux_basis_set`. See `scf_config_t`.
-      logical :: density_fitting = .false.
       logical :: run_mp2 = .false.
          !! Follow the reference with an MP2 correction. Set by the factory
          !! from the method name rather than by a keyword: "mp2" is a method,
          !! not an option on Hartree-Fock.
-      logical :: freeze_core = .false.
-      integer :: n_frozen_core = -1
       logical :: corr_density_fitting = .false.
       real(dp) :: scs_ss = 1.0_dp
       real(dp) :: scs_os = 1.0_dp
@@ -66,46 +46,6 @@ module mqc_method_hf
       integer :: cc_diis_size = 8
       logical :: cc_spin_adapted = .true.
          !! Spatial-orbital coupled cluster rather than spin orbitals
-         !! Fit J and K rather than computing exact integrals (CPU backend)
-      logical :: spherical = .true.
-         !! Use spherical (true) or Cartesian (false) basis
-      logical :: verbose = .false.
-         !! Print SCF iterations
-      integer :: device_rank = 0
-         !! Node-local MPI rank, for spreading ranks across a node's GPUs
-      logical :: unrestricted = .false.
-         !! Force UHF/UKS even for a closed shell
-      character(len=32) :: guess = "auto"
-         !! Initial guess: 'core', 'gwh', 'sac', 'sad', 'basis_set_projection',
-         !! or 'auto'
-      type(guess_step_t), allocatable :: guess_steps(:)
-         !! The basis ladder for 'basis_set_projection', one entry per
-         !! preliminary SCF in order.
-         !!
-         !! 'auto' means the backend picks, because the best starting point
-         !! is a property of the backend rather than of the request: the CPU
-         !! path resolves it to 'sad', and cuEST to 'gwh', each having
-         !! measured its own. An explicit spelling always wins over both.
-
-      ! SCF settings (from shared scf_config_t)
-      logical :: allow_crap_scf = .false.  !! Keep a non-converged SCF instead of failing
-      integer :: max_iter = 100
-         !! Maximum SCF iterations
-      real(dp) :: conv_tol = 1.0e-8_dp
-         !! Energy convergence threshold
-      real(dp) :: density_tol = 1.0e-6_dp
-      real(dp) :: linear_dependence = 0.0_dp
-         !! Zero means the orthogonaliser's own cutoff. See `scf_config_t`.
-         !! Density matrix convergence threshold
-      real(dp) :: level_shift = 0.0_dp
-         !! Hartree added to the virtual block before each diagonalisation.
-         !! Zero is off. See `scf_config_t`.
-      logical :: use_diis = .true.
-         !! Use DIIS acceleration
-      integer :: diis_size = 8
-         !! Number of Fock matrices for DIIS
-      character(len=16) :: backend = "auto"
-         !! Integral backend request: "auto", "cuest"/"gpu", "libcint"/"cpu".
    end type hf_options_t
 
    type, extends(qc_method_t) :: hf_method_t
@@ -191,7 +131,7 @@ contains
       if (allocated(this%options%guess_steps)) settings%guess_steps = this%options%guess_steps
       settings%max_iter = this%options%max_iter
       settings%allow_crap_scf = this%options%allow_crap_scf
-      settings%energy_tol = this%options%conv_tol
+      settings%energy_tol = this%options%energy_tol
       settings%density_tol = this%options%density_tol
       settings%level_shift = this%options%level_shift
       settings%linear_dependence = this%options%linear_dependence

--- a/src/methods/mqc_method_hf.F90
+++ b/src/methods/mqc_method_hf.F90
@@ -18,7 +18,7 @@ module mqc_method_hf
    use mqc_physical_fragment, only: physical_fragment_t
    use mqc_error, only: error_t, ERROR_VALIDATION
    use mqc_semi_numerical_hessian, only: finite_difference_hessian
-   use mqc_cuest_iface, only: apply_scf_settings, cuest_scf_settings_t, parse_backend_name, &
+   use mqc_cuest_iface, only: apply_properties_settings, apply_scf_settings, cuest_scf_settings_t, parse_backend_name, &
                               BACKEND_CUEST, BACKEND_LIBCINT
    use mqc_cuest_bridge, only: run_cuest_scf
    use mqc_libcint_bridge, only: run_libcint_hf
@@ -83,19 +83,7 @@ contains
       type(error_t) :: backend_error
 
       call apply_scf_settings(settings, this%options)
-      settings%bonding_analysis = this%options%properties%bonding_analysis
-      settings%bonding_threshold = this%options%properties%bonding_threshold
-      settings%bonding_energy = this%options%properties%bonding_energy
-      if (allocated(this%options%properties%fukui_population)) then
-         settings%fukui_population = this%options%properties%fukui_population
-      end if
-      if (allocated(this%options%properties%charges_scheme)) then
-         settings%charges_scheme = this%options%properties%charges_scheme
-      end if
-      settings%bonding_no_sharing = this%options%properties%bonding_no_sharing
-      settings%bonding_restrict_localization = &
-         this%options%properties%bonding_restrict_localization
-      settings%bonding_no_sharing_ci = this%options%properties%bonding_no_sharing_ci
+      call apply_properties_settings(settings, this%options%properties)
       settings%run_mp2 = this%options%run_mp2
       settings%corr_density_fitting = this%options%corr_density_fitting
       settings%run_cc = this%options%run_cc

--- a/src/methods/mqc_method_mcscf.f90
+++ b/src/methods/mqc_method_mcscf.f90
@@ -171,7 +171,7 @@ contains
       settings%verbose = this%options%verbose
       settings%functional = ""        ! empty selects pure Hartree-Fock
       settings%max_iter = this%options%max_iter
-      settings%energy_tol = this%options%conv_tol
+      settings%energy_tol = this%options%energy_tol
       settings%density_tol = this%options%density_tol
       settings%level_shift = this%options%level_shift
       settings%linear_dependence = this%options%linear_dependence

--- a/src/methods/mqc_method_mcscf.f90
+++ b/src/methods/mqc_method_mcscf.f90
@@ -26,7 +26,7 @@ module mqc_method_mcscf
    use mqc_result_types, only: calculation_result_t
    use mqc_physical_fragment, only: physical_fragment_t
    use mqc_error, only: ERROR_VALIDATION
-   use mqc_cuest_iface, only: cuest_scf_settings_t
+   use mqc_cuest_iface, only: apply_properties_settings, cuest_scf_settings_t
    use mqc_libcint_bridge, only: run_libcint_mcscf
    implicit none
    private
@@ -159,13 +159,23 @@ contains
       ! begins with a closed-shell SCF and the backend takes the same settings
       ! object for it that Hartree-Fock does.
       settings%pcm = this%options%pcm
-      settings%bonding_analysis = this%options%properties%bonding_analysis
-      settings%bonding_threshold = this%options%properties%bonding_threshold
-      settings%bonding_energy = this%options%properties%bonding_energy
-      settings%bonding_no_sharing = this%options%properties%bonding_no_sharing
-      settings%bonding_restrict_localization = &
-         this%options%properties%bonding_restrict_localization
-      settings%bonding_no_sharing_ci = this%options%properties%bonding_no_sharing_ci
+
+      ! Refused rather than dropped. `run_libcint_mcscf` never reads
+      ! `settings%fukui_population` -- unlike `run_libcint_hf`, which does --
+      ! so a deck asking for Fukui indices on a CASSCF would otherwise be
+      ! obeyed everywhere except where it matters and report a result that
+      ! ignored it. That is the failure this whole shared-settings work exists
+      ! to end, and handing the field over unread would recreate it one layer
+      ! further down.
+      if (allocated(this%options%properties%fukui_population)) then
+         call result%error%set(ERROR_VALIDATION, "Fukui indices are not available for "// &
+                               "an MCSCF reference: they need a response the CASSCF path "// &
+                               "does not build. Request them on a Hartree-Fock or "// &
+                               "Kohn-Sham calculation instead.")
+         result%has_error = .true.
+         return
+      end if
+      call apply_properties_settings(settings, this%options%properties)
       settings%basis_set = this%options%basis_set
       settings%spherical = this%options%spherical
       settings%verbose = this%options%verbose

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -109,6 +109,10 @@ if(MQC_ENABLE_LIBCINT)
   # Fukui indices by difference in the electron count.
   addtest(mqc_fukui)
   target_link_libraries(test_mqc_fukui PRIVATE cint_fortran cint)
+  # Every field on the shared SCF options type reaches the backend's settings.
+  # The refactor removed three hand-copied blocks; this is what keeps them gone.
+  addtest(mqc_scf_options)
+
   # Unrestricted MP2, whose closed-shell limit is the restricted one.
   addtest(mqc_ump2)
   target_link_libraries(test_mqc_ump2 PRIVATE cint_fortran cint)

--- a/test/test_mqc_method_placeholders.f90
+++ b/test/test_mqc_method_placeholders.f90
@@ -159,7 +159,7 @@ contains
       call create_test_fragment(fragment)
 
       method%options%verbose = .true.
-      method%options%use_density_fitting = .true.
+      method%options%density_fitting = .true.
 
       call method%calc_energy(fragment, result)
 

--- a/test/test_mqc_scf_options.f90
+++ b/test/test_mqc_scf_options.f90
@@ -22,8 +22,9 @@ module test_mqc_scf_options
    !! look identical from the backend's side.
    use testdrive, only: new_unittest, unittest_type, error_type, check
    use pic_types, only: dp
-   use mqc_method_config, only: scf_options_t
-   use mqc_cuest_iface, only: cuest_scf_settings_t, apply_scf_settings
+   use mqc_method_config, only: scf_options_t, properties_config_t
+   use mqc_cuest_iface, only: cuest_scf_settings_t, apply_scf_settings, &
+                              apply_properties_settings
    use mqc_config_types, only: guess_step_t
    implicit none
    private
@@ -37,7 +38,9 @@ contains
 
       testsuite = [ &
                   new_unittest("every_shared_field_reaches_the_settings", every_field_arrives), &
-                  new_unittest("an_unallocated_guess_ladder_is_not_copied", ladder_optional) &
+                  new_unittest("an_unallocated_guess_ladder_is_not_copied", ladder_optional), &
+                  new_unittest("every_property_reaches_the_settings", every_property_arrives), &
+                  new_unittest("unset_allocatable_properties_are_not_copied", properties_optional) &
                   ]
    end subroutine collect_mqc_scf_options_tests
 
@@ -161,6 +164,76 @@ contains
       call check(error,.not. allocated(settings%guess_steps), &
                  "a ladder appeared from nowhere")
    end subroutine ladder_optional
+
+   !> The properties block had diverged three ways before it was shared: HF
+   !> unpacked all eight, Kohn-Sham four and MCSCF six. Same populate-and-assert
+   !> as the SCF fields, for the same reason.
+   subroutine every_property_arrives(error)
+      type(error_type), allocatable, intent(out) :: error
+
+      type(properties_config_t) :: properties
+      type(cuest_scf_settings_t) :: settings
+
+      properties%bonding_analysis = "quao"
+      properties%bonding_threshold = 0.125_dp
+      properties%bonding_energy = .true.
+      properties%bonding_no_sharing = .true.
+      properties%bonding_no_sharing_ci = "project"
+      properties%bonding_restrict_localization = .true.
+      properties%fukui_population = "mulliken"
+      properties%charges_scheme = "chelpg"
+
+      call apply_properties_settings(settings, properties)
+
+      call check(error, settings%bonding_analysis == properties%bonding_analysis, &
+                 "bonding_analysis")
+      if (allocated(error)) return
+      call check(error, settings%bonding_threshold == properties%bonding_threshold, &
+                 "bonding_threshold")
+      if (allocated(error)) return
+      ! The one that guards a refusal rather than a feature: Kohn-Sham never
+      ! set it, so the check that stops a bonding-energy decomposition running
+      ! under a continuum could not fire.
+      call check(error, settings%bonding_energy .eqv. properties%bonding_energy, &
+                 "bonding_energy")
+      if (allocated(error)) return
+      call check(error, settings%bonding_no_sharing .eqv. properties%bonding_no_sharing, &
+                 "bonding_no_sharing")
+      if (allocated(error)) return
+      call check(error, settings%bonding_no_sharing_ci == properties%bonding_no_sharing_ci, &
+                 "bonding_no_sharing_ci")
+      if (allocated(error)) return
+      call check(error, settings%bonding_restrict_localization .eqv. &
+                 properties%bonding_restrict_localization, "bonding_restrict_localization")
+      if (allocated(error)) return
+      call check(error, allocated(settings%fukui_population), "fukui_population unset")
+      if (allocated(error)) return
+      call check(error, settings%fukui_population == "mulliken", "fukui_population")
+      if (allocated(error)) return
+      call check(error, allocated(settings%charges_scheme), "charges_scheme unset")
+      if (allocated(error)) return
+      call check(error, settings%charges_scheme == "chelpg", "charges_scheme")
+   end subroutine every_property_arrives
+
+   !> Two of the eight are allocatable, and an unset one must not overwrite
+   !> whatever the backend already holds.
+   subroutine properties_optional(error)
+      type(error_type), allocatable, intent(out) :: error
+
+      type(properties_config_t) :: properties
+      type(cuest_scf_settings_t) :: settings
+
+      properties%bonding_analysis = "quao"
+      call apply_properties_settings(settings, properties)
+      call check(error, settings%bonding_analysis == "quao", &
+                 "an unset allocatable stopped the copy")
+      if (allocated(error)) return
+      call check(error,.not. allocated(settings%fukui_population), &
+                 "fukui_population appeared from nowhere")
+      if (allocated(error)) return
+      call check(error,.not. allocated(settings%charges_scheme), &
+                 "charges_scheme appeared from nowhere")
+   end subroutine properties_optional
 
 end module test_mqc_scf_options
 

--- a/test/test_mqc_scf_options.f90
+++ b/test/test_mqc_scf_options.f90
@@ -1,0 +1,186 @@
+!! The shared SCF options reach the backend's settings
+module test_mqc_scf_options
+   !! One concept used to be maintained as three hand-copied instances -- the
+   !! options type, the `configure_*` that filled it, and the
+   !! `settings%x = options%x` block in each method. Missing any one of them
+   !! failed silently: `keywords.scf.allow_crap_scf` was read from the deck,
+   !! passed the schema, reached the config, and was dropped before the
+   !! backend, so a Kohn-Sham run hard-stopped while the deck said to keep
+   !! going. `scf_options_t`, `configure_scf` and `apply_scf_settings` removed
+   !! the three copies; this is what keeps them removed.
+   !!
+   !! **It tests the class, not the symptom.** A deck that fails to converge
+   !! would exercise `allow_crap_scf` and nothing else, needs an SCF to run,
+   !! and has no stable energy to compare. `apply_scf_settings` is a pure
+   !! function of its inputs, so every shared field can be checked at once in
+   !! milliseconds with no molecule: give each a value nothing defaults to,
+   !! hand it over, and require it to arrive.
+   !!
+   !! **Adding a field to `scf_options_t` means adding it here.** A field that
+   !! nothing asserts is a field that can go missing again -- this catches a
+   !! copy that was dropped, not a copy that was never written, and the two
+   !! look identical from the backend's side.
+   use testdrive, only: new_unittest, unittest_type, error_type, check
+   use pic_types, only: dp
+   use mqc_method_config, only: scf_options_t
+   use mqc_cuest_iface, only: cuest_scf_settings_t, apply_scf_settings
+   use mqc_config_types, only: guess_step_t
+   implicit none
+   private
+
+   public :: collect_mqc_scf_options_tests
+
+contains
+
+   subroutine collect_mqc_scf_options_tests(testsuite)
+      type(unittest_type), allocatable, intent(out) :: testsuite(:)
+
+      testsuite = [ &
+                  new_unittest("every_shared_field_reaches_the_settings", every_field_arrives), &
+                  new_unittest("an_unallocated_guess_ladder_is_not_copied", ladder_optional) &
+                  ]
+   end subroutine collect_mqc_scf_options_tests
+
+   !> An options object with nothing left at its default, so a field that fails
+   !> to arrive shows up as the default it should no longer hold.
+   subroutine populate(options)
+      type(scf_options_t), intent(out) :: options
+
+      options%basis_set = "cc-pvdz"
+      options%ecp_set = "def2-ecp"
+      options%aux_basis_set = "cc-pvdz-jkfit"
+      options%aux_basis_named = .true.
+      options%cartesian = .true.
+      options%spherical = .false.
+      options%density_fitting = .true.
+      options%freeze_core = .true.
+      options%n_frozen_core = 3
+      options%unrestricted = .true.
+      options%guess = "gwh"
+      options%max_iter = 217
+      options%allow_crap_scf = .true.
+      options%energy_tol = 1.5e-9_dp
+      options%density_tol = 2.5e-7_dp
+      options%level_shift = 0.35_dp
+      options%linear_dependence = 1.0e-5_dp
+      options%use_diis = .false.
+      options%diis_size = 11
+      options%verbose = .true.
+      options%device_rank = 2
+      options%pcm%enabled = .true.
+      options%pcm%dielectric = 32.7_dp
+      allocate (options%guess_steps(2))
+      options%guess_steps(1)%basis = "sto-3g"
+      options%guess_steps(1)%maxiter = 7
+      options%guess_steps(2)%basis = "6-31g"
+      options%guess_steps(2)%tolerance = 1.0e-4_dp
+   end subroutine populate
+
+   subroutine every_field_arrives(error)
+      type(error_type), allocatable, intent(out) :: error
+
+      type(scf_options_t) :: options
+      type(cuest_scf_settings_t) :: settings
+
+      call populate(options)
+      call apply_scf_settings(settings, options)
+
+      call check(error, settings%basis_set == options%basis_set, "basis_set")
+      if (allocated(error)) return
+      call check(error, settings%ecp_set == options%ecp_set, "ecp_set")
+      if (allocated(error)) return
+      call check(error, settings%aux_basis_set == options%aux_basis_set, "aux_basis_set")
+      if (allocated(error)) return
+      call check(error, settings%aux_basis_named .eqv. options%aux_basis_named, "aux_basis_named")
+      if (allocated(error)) return
+      call check(error, settings%cartesian .eqv. options%cartesian, "cartesian")
+      if (allocated(error)) return
+      call check(error, settings%spherical .eqv. options%spherical, "spherical")
+      if (allocated(error)) return
+      call check(error, settings%density_fitting .eqv. options%density_fitting, "density_fitting")
+      if (allocated(error)) return
+      call check(error, settings%freeze_core .eqv. options%freeze_core, "freeze_core")
+      if (allocated(error)) return
+      call check(error, settings%n_frozen_core == options%n_frozen_core, "n_frozen_core")
+      if (allocated(error)) return
+      call check(error, settings%unrestricted .eqv. options%unrestricted, "unrestricted")
+      if (allocated(error)) return
+      call check(error, settings%guess == options%guess, "guess")
+      if (allocated(error)) return
+      call check(error, settings%max_iter == options%max_iter, "max_iter")
+      if (allocated(error)) return
+      ! The field the whole refactor exists for: honoured on one reference and
+      ! silently dropped on the other, for as long as this block was written
+      ! out by hand in each method.
+      call check(error, settings%allow_crap_scf .eqv. options%allow_crap_scf, "allow_crap_scf")
+      if (allocated(error)) return
+      call check(error, settings%energy_tol == options%energy_tol, "energy_tol")
+      if (allocated(error)) return
+      call check(error, settings%density_tol == options%density_tol, "density_tol")
+      if (allocated(error)) return
+      call check(error, settings%level_shift == options%level_shift, "level_shift")
+      if (allocated(error)) return
+      call check(error, settings%linear_dependence == options%linear_dependence, "linear_dependence")
+      if (allocated(error)) return
+      call check(error, settings%use_diis .eqv. options%use_diis, "use_diis")
+      if (allocated(error)) return
+      call check(error, settings%diis_size == options%diis_size, "diis_size")
+      if (allocated(error)) return
+      call check(error, settings%verbose .eqv. options%verbose, "verbose")
+      if (allocated(error)) return
+      call check(error, settings%device_rank == options%device_rank, "device_rank")
+      if (allocated(error)) return
+      call check(error, settings%pcm%enabled .eqv. options%pcm%enabled, "pcm%enabled")
+      if (allocated(error)) return
+      call check(error, settings%pcm%dielectric == options%pcm%dielectric, "pcm%dielectric")
+      if (allocated(error)) return
+
+      call check(error, allocated(settings%guess_steps), "guess_steps not allocated")
+      if (allocated(error)) return
+      call check(error, size(settings%guess_steps) == 2, "guess_steps size")
+      if (allocated(error)) return
+      call check(error, settings%guess_steps(1)%basis == "sto-3g", "guess_steps(1)%basis")
+      if (allocated(error)) return
+      call check(error, settings%guess_steps(2)%maxiter == options%guess_steps(2)%maxiter, &
+                 "guess_steps(2)%maxiter")
+   end subroutine every_field_arrives
+
+   !> The ladder is optional, and copying an unallocated one would be a crash
+   !> rather than a wrong answer -- worth pinning separately because it is the
+   !> one field in the block guarded by a condition.
+   subroutine ladder_optional(error)
+      type(error_type), allocatable, intent(out) :: error
+
+      type(scf_options_t) :: options
+      type(cuest_scf_settings_t) :: settings
+
+      options%max_iter = 42
+      call apply_scf_settings(settings, options)
+      call check(error, settings%max_iter == 42, "an unallocated ladder stopped the copy")
+      if (allocated(error)) return
+      call check(error,.not. allocated(settings%guess_steps), &
+                 "a ladder appeared from nowhere")
+   end subroutine ladder_optional
+
+end module test_mqc_scf_options
+
+program tester
+   use, intrinsic :: iso_fortran_env, only: error_unit
+   use testdrive, only: run_testsuite, new_testsuite, testsuite_type
+   use test_mqc_scf_options, only: collect_mqc_scf_options_tests
+   implicit none
+   integer :: stat, is
+   type(testsuite_type), allocatable :: testsuites(:)
+   character(len=*), parameter :: fmt = '("#", *(1x, a))'
+
+   stat = 0
+   testsuites = [new_testsuite("mqc_scf_options", collect_mqc_scf_options_tests)]
+   do is = 1, size(testsuites)
+      write (error_unit, fmt) "Testing:", testsuites(is)%name
+      call run_testsuite(testsuites(is)%collect, error_unit, stat)
+   end do
+   if (stat > 0) then
+      write (error_unit, "(i0, 1x, a)") stat, "test(s) failed!"
+      error stop
+   end if
+end program tester


### PR DESCRIPTION
Assert every shared SCF field arrives, not just the one that broke

The refactor removed three hand-copied blocks; this is what keeps them
removed. `apply_scf_settings` is a pure function of its inputs, so give an
`scf_options_t` a value nothing defaults to in every field, hand it over,
and require each to arrive -- twenty-three fields in milliseconds, with no
molecule and no SCF.

Testing the class rather than the symptom, which is the point. A deck that
fails to converge would exercise `allow_crap_scf` and nothing else, needs a
calculation to run, and has no stable energy for a validation reference to
compare -- so it could never be more than one flag's regression test. This
covers every field the helper copies, including the next one someone adds
and forgets, provided they add it here too. The type now says so at the
point of temptation.

Verified by breaking it rather than by reading it: deleting the
`allow_crap_scf` line from `apply_scf_settings` makes this exit 1 with
`Message: allow_crap_scf`, naming the field, and restoring it passes
again. A test that has never failed is a test that has not been shown to
work, and this whole class of bug is one where the check and the defect
share an assumption.

The guess ladder gets its own case: it is the one field in the block
behind a condition, and copying an unallocated one would crash rather
than answer wrongly.

122/122 unit tests.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>