### PR TITLE
mcscf can run with cart only

### DIFF
--- a/src/methods/mqc_method_factory.F90
+++ b/src/methods/mqc_method_factory.F90
@@ -321,6 +321,7 @@ contains
       m%options%properties = config%properties
       m%options%basis_set = config%basis_set
       m%options%spherical = config%use_spherical
+      m%options%cartesian = config%scf%cartesian
       m%options%verbose = config%verbose
 
       ! Active space from config%mcscf

--- a/src/methods/mqc_method_mcscf.f90
+++ b/src/methods/mqc_method_mcscf.f90
@@ -41,6 +41,11 @@ module mqc_method_mcscf
          !! request arrives; the CPU path has no cavity.
       character(len=32) :: basis_set = "sto-3g"
          !! Basis set name
+      logical :: cartesian = .false.
+         !! `model.cartesian`; see `mqc_config_t`. The backend already reads
+         !! `settings%cartesian` (`run_libcint_mcscf`); until this field
+         !! existed there was nothing to give it, so a Cartesian deck ran
+         !! spherical without saying so.
       logical :: spherical = .true.
          !! Use spherical (true) or Cartesian (false) basis
       logical :: verbose = .false.
@@ -168,6 +173,7 @@ contains
       settings%bonding_no_sharing_ci = this%options%properties%bonding_no_sharing_ci
       settings%basis_set = this%options%basis_set
       settings%spherical = this%options%spherical
+      settings%cartesian = this%options%cartesian
       settings%verbose = this%options%verbose
       settings%functional = ""        ! empty selects pure Hartree-Fock
       settings%max_iter = this%options%max_iter


### PR DESCRIPTION
Tell MCSCF the angular form the deck asked for

`model.cartesian` was silently ignored by every MCSCF run. The backend
already honoured it -- `run_libcint_mcscf` passes
`force_cartesian=settings%cartesian` -- but nothing ever set that field:
`mcscf_options_t` had no `cartesian`, `configure_mcscf` never assigned
one, and the method never copied it into `settings`. So a CASCI or CASSCF
deck asking for a Cartesian basis got a spherical one, with no warning and
no error: a different number of basis functions and a different energy,
reported as though it were what was asked for.

Same three-layer shape as `allow_crap_scf` on the Kohn-Sham path, and the
same cause -- one concept maintained as N hand-copied instances, where
missing one fails silently. Three lines, one per layer.

Checked rather than assumed, because the backend honouring a flag is not
the same as the method being right to send it. CASCI(4,4) on water in
cc-pVDZ, against PySCF fed this repository's own basis JSON:

    spherical   ours -76.027333538855   pyscf -76.027333538870
    Cartesian   ours -76.027675087729   pyscf -76.027675087689

nao goes 24 to 25 as the oxygen d shell turns 5d into 6d, and both
angular forms agree at the SCF convergence floor.

One trap worth recording for anyone testing this. 6-31G* cannot show the
bug: its d shell is declared `gto_cartesian` in the basis data, so it is
already Cartesian and the flag changes nothing -- the first run of this
test gave identical energies to 1e-13 and looked like the fix had not
worked. cc-pVDZ declares `gto_spherical`, so the flag bites there. CASCI
with `optimize_orbitals: false` rather than CASSCF, so the comparison
rests on fixed reference orbitals and cannot be confused by the
symmetry-trapped stationary point CASSCF finds on small water cases.

No existing validation reference moves: no deck under
validation/inputs/cpu/mqc/mcscf/ sets `model.cartesian`, so this changes
nothing that was previously measured. 121/121 unit tests.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>