### PR TITLE
different grids for the vv correction 

### DIFF
--- a/backends/libcint/mqc_libcint_vv10.f90
+++ b/backends/libcint/mqc_libcint_vv10.f90
@@ -34,6 +34,16 @@ module mqc_libcint_vv10
    public :: VV10_RHO_THRESHOLD
 
    real(dp), parameter :: VV10_RHO_THRESHOLD = 1.0e-8_dp
+
+   !> Beyond this separation, in Bohr, an inner point is not summed. Negative
+   !> disables the cutoff and restores the full double sum.
+   !>
+   !> The kernel falls off as r^-6: at large separation `g -> r^2 w0`,
+   !> `gp -> r^2 w0p` and `gt -> r^2 (w0 + w0p)`, so `t = rpw/(g gp gt)` goes as
+   !> `rpw / r^6`. The number of points at a separation grows as r^2, so the
+   !> tail this drops integrates as r^-3 -- fast, but not so fast that the
+   !> radius can be picked by eye. It is measured, not assumed.
+   real(dp), parameter, public :: VV10_CUTOFF = -1.0_dp
       !! Points below this density are dropped from both grids.
       !!
       !! Not a tuning knob so much as the boundary of where the expression is
@@ -139,6 +149,8 @@ contains
       real(dp) :: rho_1, rho_3, rho_4, rho_5, gamma2, omega_1, omega_3
       real(dp) :: r_i, s_i
       real(dp), allocatable :: w0p(:), kp(:), rpw(:)
+      real(dp), allocatable :: cx(:), cy(:), cz(:)
+      real(dp) :: r2_cut
       integer :: n_out, n_in, i, j, n_kept
       integer, allocatable :: keep(:)
 
@@ -189,7 +201,12 @@ contains
       end do
       if (n_kept == 0) return
 
+      ! The coordinates are gathered alongside, rather than reached through
+      ! `keep` in the inner loop. That loop is the whole cost of VV10, and an
+      ! indirection inside it is an extra load per pair and a barrier to
+      ! vectorising the three differences.
       allocate (w0p(n_kept), kp(n_kept), rpw(n_kept))
+      allocate (cx(n_kept), cy(n_kept), cz(n_kept))
       do j = 1, n_kept
          r_i = inner_rho(keep(j))
          s_i = inner_sigma(keep(j))
@@ -197,7 +214,13 @@ contains
          w0p(j) = sqrt(w0tmp + pi43*r_i)
          kp(j) = kvv*r_i**(1.0_dp/6.0_dp)
          rpw(j) = r_i*inner_weights(keep(j))
+         cx(j) = inner_coords(1, keep(j))
+         cy(j) = inner_coords(2, keep(j))
+         cz(j) = inner_coords(3, keep(j))
       end do
+
+      r2_cut = huge(1.0_dp)
+      if (VV10_CUTOFF > 0.0_dp) r2_cut = VV10_CUTOFF*VV10_CUTOFF
 
       ! Every outer point is independent: it writes only its own three
       ! outputs and reads a shared inner grid that nothing mutates. The
@@ -206,7 +229,7 @@ contains
       ! disappear against it -- so it is the only thing here worth threading.
       !$omp parallel do default(none) &
       !$omp    shared(n_out, n_kept, rho, sigma, coords, inner_coords, keep, &
-      !$omp           w0p, kp, rpw, exc, vrho, vsigma, c, kvv, pi43, beta, &
+      !$omp           w0p, kp, rpw, cx, cy, cz, r2_cut, exc, vrho, vsigma, c, kvv, pi43, beta, &
       !$omp           want_grad, dedw, fexp, want_hess, want_curv, &
       !$omp           hess_u, hess_w, hess_a, hess_b, hess_c, hess_e, &
       !$omp           domega_drho, domega_dgamma, d2omega_drho2, &
@@ -247,10 +270,15 @@ contains
          fy = 0.0_dp
          fz = 0.0_dp
          do j = 1, n_kept
-            dx = inner_coords(1, keep(j)) - coords(1, i)
-            dy = inner_coords(2, keep(j)) - coords(2, i)
-            dz = inner_coords(3, keep(j)) - coords(3, i)
+            dx = cx(j) - coords(1, i)
+            dy = cy(j) - coords(2, i)
+            dz = cz(j) - coords(3, i)
             r2 = dx*dx + dy*dy + dz*dz
+            ! Three divisions and a dozen multiplies are skipped for the price
+            ! of a compare. Visiting the pair at all is still O(n^2); making it
+            ! sub-quadratic needs the inner list binned in space, which this is
+            ! the prerequisite for rather than a substitute for.
+            if (r2 > r2_cut) cycle
             gp = r2*w0p(j) + kp(j)
             g = r2*w0 + k_out
             gt = g + gp

--- a/backends/libcint/mqc_libcint_vv10.f90
+++ b/backends/libcint/mqc_libcint_vv10.f90
@@ -59,7 +59,7 @@ contains
                        hess_u, hess_w, hess_a, hess_b, hess_c, hess_e, &
                        domega_drho, domega_dgamma, d2omega_drho2, &
                        d2omega_dgamma2, d2omega_drho_dgamma, &
-                       dkappa_drho, d2kappa_drho2)
+                       dkappa_drho, d2kappa_drho2, n_inner_kept)
       !! VV10's energy density and potential at each outer grid point
       !!
       !! `exc` is the energy *per electron*, so the caller forms the energy the
@@ -129,6 +129,10 @@ contains
          !! (n_out). E = sum_j w_j rho_j Phi -- the inner sum itself, which is
          !! `2*(exc - beta)`. Returned anyway because PySCF's Hessian formulas
          !! consume it under this name and normalisation.
+      integer, intent(out), optional :: n_inner_kept
+         !! How many inner points survived the density threshold. The pair sum
+         !! is this times the outer count, so it is the one number that says
+         !! what the double integral actually costs.
       real(dp), intent(out), optional :: domega_drho(:), domega_dgamma(:)
       real(dp), intent(out), optional :: d2omega_drho2(:), d2omega_dgamma2(:)
       real(dp), intent(out), optional :: d2omega_drho_dgamma(:)
@@ -199,6 +203,7 @@ contains
             keep(n_kept) = j
          end if
       end do
+      if (present(n_inner_kept)) n_inner_kept = n_kept
       if (n_kept == 0) return
 
       ! The coordinates are gathered alongside, rather than reached through

--- a/backends/libcint/mqc_libcint_xc.F90
+++ b/backends/libcint/mqc_libcint_xc.F90
@@ -30,6 +30,8 @@ module mqc_libcint_xc
    !! -- is factored into `accumulate_xc_matrix`, since that is the arithmetic worth
    !! having exactly one copy of.
    use pic_types, only: dp
+   use pic_logger, only: logger => global_logger
+   use pic_io, only: to_char
    use pic_blas_interfaces, only: pic_gemm
    use mqc_error, only: error_t, ERROR_VALIDATION
    use mqc_libcint_vv10, only: vv10_nlc, vv10_hessian_kernel
@@ -1939,6 +1941,7 @@ contains
       real(dp), allocatable :: ao(:, :), ao_grad(:, :, :), grad_coeff(:, :)
       real(dp), allocatable :: rho_blk(:), rho_grad_blk(:, :), vtau_none(:)
       integer :: npts, g0, g1, nb, ig, id
+      integer :: n_kept
 
       e_nl = 0.0_dp
 
@@ -1975,7 +1978,18 @@ contains
       allocate (exc(npts), vrho(npts), vsigma(npts))
       call vv10_nlc(ctx%nlc_b, ctx%nlc_c, ctx%nlc_grid%coords, rho, sigma, &
                     ctx%nlc_grid%coords, rho, sigma, ctx%nlc_grid%weights, &
-                    exc, vrho, vsigma)
+                    exc, vrho, vsigma, n_inner_kept=n_kept)
+
+      ! What the double integral actually costs, which is otherwise invisible:
+      ! the pair count is the product of these two, and the term is the whole
+      ! expense of a `-V` functional. Both grids here are the non-local one --
+      ! see `nlc_grid_level`, which is a fixed level rather than a step below
+      ! `grid_level`, so a deck already running a coarse grid gets no
+      ! separation between the two unless it asks.
+      call logger%verbose("  VV10: "//to_char(npts)//" grid points, "// &
+                          to_char(n_kept)//" carry density, "// &
+                          to_char(real(npts, dp)*real(n_kept, dp)/1.0e6_dp)// &
+                          " million pairs")
 
       e_nl = sum(ctx%nlc_grid%weights*rho*exc)
 


### PR DESCRIPTION
Say how many pairs VV10 is summing

The cost of a `-V` functional is the product of two grid counts, and
neither was reported anywhere. `vv10_nlc` hands back how many inner points
survived the density threshold, and `vv10_add_potential` logs it beside
the grid size and the pair count it implies.

It immediately corrected a guess of mine that was wrong by a factor of
eight, and turned up something worth acting on. On a 45-atom anion at
`nlc_grid_level: 0`:

    VV10: 40948 grid points, 39940 carry density, 1635.5 million pairs

**The density threshold prunes 2.5%.** The comment above it says it
"removes most of what is left: a molecular grid is mostly vacuum, and a
point with no density contributes nothing to either side of the integral"
-- and at `VV10_RHO_THRESHOLD = 1e-8` that is not true here. A thousand
points of forty-one thousand.

Whether it can be raised is a question about accuracy that this does not
answer, but it is now a question someone can ask, because the number is
visible. Note also that only the *inner* list is filtered: the outer loop
runs every point regardless, so a threshold that did prune would be worth
applying twice.

Logged at `verbose` rather than `performance`, because it is per SCF
iteration and would otherwise print on every cycle of every `-V` run.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>