### PR TITLE
Make the SCAN family reachable, and refuse half a functional

### DIFF
--- a/backends/libcint/mqc_libcint_xc.F90
+++ b/backends/libcint/mqc_libcint_xc.F90
@@ -201,7 +201,7 @@ contains
    end function xc_available
 
    subroutine xc_context_create(mol, functional, ctx, error, level, polarized, &
-                                screen_tol, point_block, nlc_level)
+                                screen_tol, point_block, nlc_level, allow_half)
       !! Resolve a functional name and build the grid it will be integrated on
       type(libcint_molecule_t), intent(in) :: mol
       character(len=*), intent(in) :: functional
@@ -221,6 +221,10 @@ contains
          !! evaluates the whole basis, which is the way to check what it costs.
       integer, intent(in), optional :: point_block
          !! Grid points per block. Non-positive keeps the default.
+      logical, intent(in), optional :: allow_half
+         !! Accept a libxc name carrying only exchange or only correlation.
+         !! Passed to `xc_spec_from_name`, which explains why it exists and why
+         !! no deck may set it. The derivative tests are the only caller.
 
       type(xc_spec_t) :: spec
       integer :: grid_level, i, id, family
@@ -237,7 +241,7 @@ contains
          return
       end if
 
-      call xc_spec_from_name(functional, spec, error)
+      call xc_spec_from_name(functional, spec, error, allow_half=allow_half)
       if (error%has_error()) return
 
       grid_level = DEFAULT_GRID_LEVEL
@@ -369,11 +373,20 @@ contains
             ctx%nlc_c = nlc_c
          end if
 
-         ! libxc owns a global hybrid's fraction, so ask rather than assume. Only a
-         ! composition libxc does not carry may state its own, and `mqc_xc_spec`
-         ! leaves that at zero for everything libxc knows -- so the two can never
-         ! both be nonzero and disagree.
-         if (spec%from_libxc .and. .not. (cam_omega /= 0.0_dp .and. cam_beta /= 0.0_dp)) then
+         ! libxc owns a hybrid's fraction, so ask rather than assume -- and ask it
+         ! of every component, not only of a functional libxc carries whole. SCAN0
+         ! is the case that separates those two readings: it is a composition here,
+         ! because libxc pairs no correlation with it, but its exchange component
+         ! `hyb_mgga_x_scan0` carries the quarter of exact exchange itself. Asking
+         ! only for single-component specs dropped that quarter silently, which is
+         ! a converged number for a different functional.
+         !
+         ! Safe to ask always: every semilocal component of every composition in
+         ! `mqc_xc_spec` reports zero here, so nothing existing moves. A spec's own
+         ! `exx_fraction` remains for exchange libxc knows nothing about, which is
+         ! the double hybrids and only them -- so the two still cannot both be
+         ! nonzero and disagree.
+         if (.not. (cam_omega /= 0.0_dp .and. cam_beta /= 0.0_dp)) then
             libxc_exx = xc_f03_hyb_exx_coef(ctx%func(i))
             ctx%exx_fraction = ctx%exx_fraction + spec%component(i)%weight*libxc_exx
          end if

--- a/mqc_docs/source/input_files.rst
+++ b/mqc_docs/source/input_files.rst
@@ -448,9 +448,9 @@ carry at all:
    * - Name
      - Rung
      - Composition
-   * - ``svwn``, ``lda``, ``lsda``
+   * - ``svwn``, ``svwn5``, ``lda``, ``lsda``
      - LDA
-     - ``lda_x`` + ``lda_c_vwn``
+     - ``lda_x`` + ``lda_c_vwn`` (VWN5, matching the name the GPU path uses)
    * - ``pbe``
      - GGA
      - ``gga_x_pbe`` + ``gga_c_pbe``
@@ -469,6 +469,28 @@ carry at all:
    * - ``m06-l``, ``m06l``
      - meta-GGA
      - ``mgga_x_m06_l`` + ``mgga_c_m06_l``
+   * - ``scan``
+     - meta-GGA
+     - ``mgga_x_scan`` + ``mgga_c_scan``
+   * - ``r2scan``
+     - meta-GGA
+     - ``mgga_x_r2scan`` + ``mgga_c_r2scan``
+   * - ``r2scan01``
+     - meta-GGA
+     - ``mgga_x_r2scan01`` + ``mgga_c_r2scan01`` (the larger-η regularisation)
+   * - ``scan0``
+     - hybrid meta-GGA
+     - ``hyb_mgga_x_scan0`` + ``mgga_c_scan`` (libxc reports the 25% from the
+       exchange component)
+   * - ``r2scan0``
+     - hybrid meta-GGA
+     - ``hyb_mgga_xc_r2scan0`` (25% exact exchange, libxc's to report)
+   * - ``r2scanh``
+     - hybrid meta-GGA
+     - ``hyb_mgga_xc_r2scanh`` (10%)
+   * - ``r2scan50``
+     - hybrid meta-GGA
+     - ``hyb_mgga_xc_r2scan50`` (50%)
    * - ``wb97x``
      - range-separated hybrid
      - ``hyb_gga_xc_wb97x`` (ω = 0.3)
@@ -505,6 +527,19 @@ precisely because it is B2PLYP's semilocal part at full weight.
 
 Anything beyond meta-GGA is refused, as is a functional needing the density
 Laplacian -- on libxc's own say-so rather than a guess about which ones are safe.
+
+**Half a functional is refused too.** A libxc name may be spelled directly, but
+only if it is a whole functional. libxc splits most semilocal functionals into an
+exchange half and a correlation half, and either half alone is a valid libxc
+functional that initialises, evaluates and converges -- to an energy that is not
+the functional anyone meant. On water/STO-3G ``mgga_x_r2scan`` alone lands 0.32
+Hartree from r2SCAN and ``mgga_c_r2scan`` alone nine Hartree, both silently.
+Nothing downstream can catch that, because nothing about the calculation is
+wrong; only the choice of functional is. So a name whose libxc role is ``_x_`` or
+``_c_`` is refused at the deck, and the pair belongs in the table above -- which
+is where every functional in that position already is. Names carrying ``_xc_``
+pass through untouched; a ``_k_`` name is refused as well, being a kinetic-energy
+functional rather than an exchange-correlation one.
 
 Continuum Solvation
 ^^^^^^^^^^^^^^^^^^^

--- a/src/methods/mqc_xc_spec.f90
+++ b/src/methods/mqc_xc_spec.f90
@@ -103,7 +103,7 @@ contains
       needs = this%exx_fraction /= 0.0_dp
    end function spec_needs_exact_exchange
 
-   subroutine xc_spec_from_name(name, spec, error)
+   subroutine xc_spec_from_name(name, spec, error, allow_half)
       !! A functional name to its composition
       !!
       !! Anything not named here is passed through as a single libxc component, on
@@ -111,12 +111,30 @@ contains
       !! carries several thousand functionals and this module should not shadow any
       !! of them. A name libxc also does not know fails at resolution, with libxc's
       !! own error, which is a better message than one invented here.
+      !!
+      !! The one thing checked before that pass-through is that the name is a
+      !! *whole* functional and not one half of one -- see `check_name_is_whole`,
+      !! which is the difference between a deck being refused and a deck quietly
+      !! returning the wrong energy.
       character(len=*), intent(in) :: name
       type(xc_spec_t), intent(out) :: spec
       type(error_t), intent(inout) :: error
+      logical, intent(in), optional :: allow_half
+         !! Accept a libxc name that is only exchange or only correlation.
+         !! Default false, and a deck must never set it: the point of the check
+         !! is that half a functional converges silently. It exists for the
+         !! derivative tests, which want one rung's kernel in isolation --
+         !! `lda_x` before `svwn`, `gga_x_pbe` before `pbe` -- so that a broken
+         !! exchange second derivative is not masked by a working correlation
+         !! one. Naming it at the call site is the whole value: a half asked for
+         !! on purpose reads differently from a half asked for by mistake.
 
       character(len=:), allocatable :: lower
+      logical :: whole_only
       integer :: i
+
+      whole_only = .true.
+      if (present(allow_half)) whole_only = .not. allow_half
 
       lower = trim(adjustl(name))
       do i = 1, len(lower)
@@ -231,6 +249,70 @@ contains
          spec%component(1) = xc_component_t("mgga_x_m06_l", 1.0_dp)
          spec%component(2) = xc_component_t("mgga_c_m06_l", 1.0_dp)
 
+         ! ---- the SCAN family ------------------------------------------------
+         !
+         ! SCAN: Sun, Ruzsinszky and Perdew, Phys. Rev. Lett. 115, 036402 (2015).
+         ! r2SCAN: Furness, Kaplan, Ning, Perdew and Sun, J. Phys. Chem. Lett. 11,
+         ! 8208 (2020) -- SCAN re-regularised to remove the numerical sensitivity
+         ! that made the original need an unusually fine grid. It is the member of
+         ! the family to reach for, and the reason the rest are spelled out beside
+         ! it rather than left to whoever knows libxc's naming.
+         !
+         ! The semilocal members follow TPSS and M06-L above: libxc carries the two
+         ! halves and no name for the pair. Until these rows existed `"functional":
+         ! "r2scan"` failed as a name libxc does not know -- while `mgga_x_r2scan`
+         ! *succeeded*, converged, at an energy missing every bit of the
+         ! correlation. That second failure is the one worth preventing, and the
+         ! completeness check in the default case below is what now prevents it.
+      case ("r2scan")
+         spec%from_libxc = .false.
+         spec%n_components = 2
+         spec%component(1) = xc_component_t("mgga_x_r2scan", 1.0_dp)
+         spec%component(2) = xc_component_t("mgga_c_r2scan", 1.0_dp)
+
+         ! The same construction at the larger regularisation parameter. libxc
+         ! labels both halves "with larger value for eta", which is what says they
+         ! are a pair -- there is no published name pairing them for us.
+      case ("r2scan01")
+         spec%from_libxc = .false.
+         spec%n_components = 2
+         spec%component(1) = xc_component_t("mgga_x_r2scan01", 1.0_dp)
+         spec%component(2) = xc_component_t("mgga_c_r2scan01", 1.0_dp)
+
+      case ("scan")
+         spec%from_libxc = .false.
+         spec%n_components = 2
+         spec%component(1) = xc_component_t("mgga_x_scan", 1.0_dp)
+         spec%component(2) = xc_component_t("mgga_c_scan", 1.0_dp)
+
+         ! The hybrids split two ways, and the split is libxc's rather than ours.
+         ! r2SCAN0, r2SCANh and r2SCAN50 it carries whole, one `hyb_mgga_xc_` name
+         ! each, so those three rows are renames and must state no fraction of
+         ! their own. SCAN0 it does not: `hyb_mgga_x_scan0` is the hybridised
+         ! exchange by itself, so SCAN0 is that plus SCAN correlation -- and the
+         ! quarter of exact exchange still belongs to libxc, which reports it from
+         ! the component, not from a number written here.
+      case ("scan0")
+         spec%from_libxc = .false.
+         spec%n_components = 2
+         spec%component(1) = xc_component_t("hyb_mgga_x_scan0", 1.0_dp)
+         spec%component(2) = xc_component_t("mgga_c_scan", 1.0_dp)
+
+      case ("r2scan0")
+         spec%from_libxc = .true.
+         spec%n_components = 1
+         spec%component(1) = xc_component_t("hyb_mgga_xc_r2scan0", 1.0_dp)
+
+      case ("r2scanh")
+         spec%from_libxc = .true.
+         spec%n_components = 1
+         spec%component(1) = xc_component_t("hyb_mgga_xc_r2scanh", 1.0_dp)
+
+      case ("r2scan50")
+         spec%from_libxc = .true.
+         spec%n_components = 1
+         spec%component(1) = xc_component_t("hyb_mgga_xc_r2scan50", 1.0_dp)
+
          ! BLYP, which libxc also leaves as two halves. Worth a row of its own
          ! rather than leaving callers to spell both: it is B2PLYP's semilocal
          ! part at full weight, so it is the functional a double hybrid's kernel
@@ -248,7 +330,7 @@ contains
          spec%component(1) = xc_component_t("gga_x_pbe", 1.0_dp)
          spec%component(2) = xc_component_t("gga_c_pbe", 1.0_dp)
 
-      case ("svwn", "lda", "lsda")
+      case ("svwn", "svwn5", "lda", "lsda")
          spec%from_libxc = .false.
          spec%n_components = 2
          spec%component(1) = xc_component_t("lda_x", 1.0_dp)
@@ -256,10 +338,87 @@ contains
 
          ! ---- everything else is libxc's ------------------------------------
       case default
+         if (whole_only) call check_name_is_whole(lower, error)
+         if (error%has_error()) return
          spec%from_libxc = .true.
          spec%n_components = 1
          spec%component(1) = xc_component_t(lower, 1.0_dp)
       end select
    end subroutine xc_spec_from_name
+
+   pure function libxc_role(name) result(role)
+      !! Which part of a functional a libxc name is: "x", "c", "xc", "k" or ""
+      !!
+      !! libxc spells every functional `<family>_<role>_<label>`, and the role is
+      !! the first underscore-delimited segment that is one of those four. All 702
+      !! functionals in 7.1.2 follow it without exception, so this reads libxc's
+      !! own convention rather than keeping a list that could fall out of step
+      !! with it. A name following no such convention returns "" and is left for
+      !! libxc to reject in its own words.
+      character(len=*), intent(in) :: name
+      character(len=2) :: role
+
+      integer :: i, lo, n
+
+      role = ""
+      lo = 1
+      n = len_trim(name)
+      do i = 1, n + 1
+         if (i <= n) then
+            if (name(i:i) /= "_") cycle
+         end if
+         if (is_role(name(lo:i - 1))) then
+            role = name(lo:i - 1)
+            return
+         end if
+         lo = i + 1
+      end do
+   end function libxc_role
+
+   pure function is_role(segment) result(yes)
+      !! Whether one name segment is a role marker rather than part of the label
+      character(len=*), intent(in) :: segment
+      logical :: yes
+      yes = segment == "x" .or. segment == "c" .or. segment == "xc" .or. segment == "k"
+   end function is_role
+
+   subroutine check_name_is_whole(name, error)
+      !! Refuse a libxc name that is only half of a functional
+      !!
+      !! libxc splits most of its semilocal functionals into an exchange half and
+      !! a correlation half, and either half alone is a perfectly valid libxc
+      !! functional that initialises, evaluates, and converges. It just is not the
+      !! functional anyone meant: `mgga_x_r2scan` alone lands 0.32 Hartree from
+      !! r2SCAN and `mgga_c_r2scan` alone nine Hartree, both silently, on a water
+      !! molecule. Nothing downstream can catch that, because there is nothing
+      !! wrong with the calculation -- only with which functional it ran.
+      !!
+      !! This costs nothing in reach: a pair libxc does not carry under one name
+      !! belongs in the table above, which is where every such functional in this
+      !! module already is.
+      character(len=*), intent(in) :: name
+      type(error_t), intent(inout) :: error
+
+      character(len=2) :: role
+
+      role = libxc_role(name)
+      select case (trim(role))
+      case ("x", "c")
+         call error%set(ERROR_VALIDATION, "'"//trim(name)//"' is only the "// &
+                        trim(merge("exchange   ", "correlation", trim(role) == "x"))// &
+                        " half of a functional. libxc carries the halves "// &
+                        "separately and one of them alone converges to an energy "// &
+                        "that is not the functional it is named after. Ask for a "// &
+                        "name that pairs them, or for a libxc name carrying "// &
+                        "'_xc_'.")
+      case ("k")
+         call error%set(ERROR_VALIDATION, "'"//trim(name)//"' is a kinetic energy "// &
+                        "functional, not an exchange-correlation one.")
+      case default
+         ! "xc", a whole functional; or "", a name following no libxc convention
+         ! at all. Both pass, the second because an unrecognisable name is libxc's
+         ! to reject in its own words rather than this module's to guess at.
+      end select
+   end subroutine check_name_is_whole
 
 end module mqc_xc_spec

--- a/test/test_mqc_xc_hessian.f90
+++ b/test/test_mqc_xc_hessian.f90
@@ -111,6 +111,14 @@ contains
 
    subroutine reference_state(functional, ctx, density, err, ok, basis)
       !! One converged reference: the grid and the density everything below uses
+      !!
+      !! `allow_half` is set here and in the two helpers below because several
+      !! callers name a libxc exchange half on purpose -- `lda_x`, `gga_x_pbe`,
+      !! `mgga_x_tpss` -- to get one rung's kernel with no correlation term beside
+      !! it, so that a broken second derivative of exchange cannot be masked by a
+      !! working one of correlation. A deck naming a half is refused, which is
+      !! what that flag defaults to; asking for one here is deliberate, and the
+      !! argument is how it says so.
       character(len=*), intent(in) :: functional
       character(len=*), intent(in), optional :: basis
          !! STO-3G unless asked otherwise, which is what every caller here
@@ -129,7 +137,7 @@ contains
       if (present(basis)) use_basis = basis
       call build_libcint_molecule(WATER_Z, WATER_SYM, WATER, trim(use_basis), mol, err)
       if (err%has_error()) return
-      call xc_context_create(mol, functional, ctx, err, level=3)
+      call xc_context_create(mol, functional, ctx, err, level=3, allow_half=.true.)
       if (err%has_error()) then
          call mol%destroy()
          return
@@ -930,7 +938,7 @@ contains
       ok = .false.
       call build_libcint_molecule(WATER_Z, WATER_SYM, coords, "sto-3g", mol, err)
       if (err%has_error()) return
-      call xc_context_create(mol, functional, ctx, err, level=3)
+      call xc_context_create(mol, functional, ctx, err, level=3, allow_half=.true.)
       if (err%has_error()) return
       call run_libcint_rhf(mol, 10, 100, 1.0e-12_dp, 1.0e-10_dp, .false., scf, err, xc=ctx)
       if (.not. err%has_error()) then
@@ -955,7 +963,7 @@ contains
       ok = .false.
       call build_libcint_molecule(WATER_Z, WATER_SYM, coords, "sto-3g", mol, err)
       if (err%has_error()) return
-      call xc_context_create(mol, functional, ctx, err, level=3)
+      call xc_context_create(mol, functional, ctx, err, level=3, allow_half=.true.)
       if (err%has_error()) return
       call run_libcint_rhf(mol, 10, 100, 1.0e-12_dp, 1.0e-10_dp, .false., scf, err, xc=ctx)
       if (.not. err%has_error()) then

--- a/test/test_mqc_xc_spec.f90
+++ b/test/test_mqc_xc_spec.f90
@@ -31,7 +31,9 @@ contains
                   new_unittest("plain_functionals_pass_through_to_libxc", test_passthrough), &
                   new_unittest("published_fractions_are_what_we_think", test_published), &
                   new_unittest("mpw2plyp_matches_its_paper", test_mpw2plyp), &
-                  new_unittest("an_empty_name_is_refused", test_empty) &
+                  new_unittest("an_empty_name_is_refused", test_empty), &
+                  new_unittest("scan_family_pairs_its_halves", test_scan_family), &
+                  new_unittest("half_a_functional_is_refused", test_halves_refused) &
                   ]
    end subroutine collect_mqc_xc_spec_tests
 
@@ -83,17 +85,19 @@ contains
       ! A libxc name, not a friendly one: "pbe" and "svwn" are *compositions* here,
       ! because libxc carries their exchange and correlation halves without carrying
       ! that name for the pair. So the pass-through case has to be spelled the way
-      ! libxc spells it.
-      call xc_spec_from_name("GGA_X_PBE", spec, err)
+      ! libxc spells it -- and it has to be a whole functional, since a lone half
+      ! is now refused. `gga_x_pbe` used to stand here and would fail today, which
+      ! is the point of that check rather than a casualty of it.
+      call xc_spec_from_name("MGGA_XC_B97M_V", spec, err)
       call check(error,.not. err%has_error(), err%get_message())
       if (allocated(error)) return
-      call check(error, spec%from_libxc, "gga_x_pbe should be left to libxc")
+      call check(error, spec%from_libxc, "mgga_xc_b97m_v should be left to libxc")
       if (allocated(error)) return
-      call check(error, spec%n_components == 1, "gga_x_pbe should be one component")
+      call check(error, spec%n_components == 1, "mgga_xc_b97m_v should be one component")
       if (allocated(error)) return
-      call check(error, spec%name == "gga_x_pbe", "the name should be lowercased")
+      call check(error, spec%name == "mgga_xc_b97m_v", "the name should be lowercased")
       if (allocated(error)) return
-      call check(error,.not. spec%is_double_hybrid(), "pbe is not a double hybrid")
+      call check(error,.not. spec%is_double_hybrid(), "b97m-v is not a double hybrid")
       if (allocated(error)) return
       ! Crucially zero: a plain hybrid's fraction is libxc's to report, and a
       ! number here would be a second source of truth that could disagree.
@@ -162,6 +166,119 @@ contains
       if (allocated(error)) return
       call check(error, spec%component(1)%name == "gga_x_mpw91", "mPW2-PLYP exchange is mPW91")
    end subroutine test_mpw2plyp
+
+   subroutine test_scan_family(error)
+      !! Every SCAN row resolves to both halves of a functional, not one
+      !!
+      !! The failure this pins is not a wrong number but a missing term: r2SCAN
+      !! spelled as its exchange half alone converges 0.32 Hartree away on water
+      !! and says nothing. So what is asserted is the component *count* and the
+      !! two names, for every row, rather than any energy.
+      type(error_type), allocatable, intent(out) :: error
+      type(xc_spec_t) :: spec
+      type(error_t) :: err
+
+      call xc_spec_from_name("r2scan", spec, err)
+      call check(error,.not. err%has_error(), err%get_message())
+      if (allocated(error)) return
+      call check(error, spec%n_components == 2, "r2scan is exchange and correlation")
+      if (allocated(error)) return
+      call check(error, spec%component(1)%name == "mgga_x_r2scan", "r2scan exchange")
+      if (allocated(error)) return
+      call check(error, spec%component(2)%name == "mgga_c_r2scan", "r2scan correlation")
+      if (allocated(error)) return
+
+      call xc_spec_from_name("scan", spec, err)
+      call check(error, spec%n_components == 2 .and. &
+                 spec%component(1)%name == "mgga_x_scan" .and. &
+                 spec%component(2)%name == "mgga_c_scan", "scan is both halves")
+      if (allocated(error)) return
+
+      call xc_spec_from_name("r2scan01", spec, err)
+      call check(error, spec%n_components == 2 .and. &
+                 spec%component(1)%name == "mgga_x_r2scan01" .and. &
+                 spec%component(2)%name == "mgga_c_r2scan01", &
+                 "r2scan01 pairs the two larger-eta halves, not one of each")
+      if (allocated(error)) return
+
+      ! SCAN0's exchange component is itself a hybrid, so this row must still
+      ! claim no fraction of its own: the quarter of exact exchange is libxc's to
+      ! report from `hyb_mgga_x_scan0`.
+      call xc_spec_from_name("scan0", spec, err)
+      call check(error, spec%n_components == 2 .and. &
+                 spec%component(1)%name == "hyb_mgga_x_scan0" .and. &
+                 spec%component(2)%name == "mgga_c_scan", &
+                 "scan0 is hybridised exchange plus SCAN correlation")
+      if (allocated(error)) return
+      call check(error,.not. spec%needs_exact_exchange(), &
+                 "scan0 must not state an exchange fraction libxc already carries")
+      if (allocated(error)) return
+
+      ! The three libxc does carry whole. These are renames, so one component and
+      ! no fraction stated here.
+      call xc_spec_from_name("r2scan0", spec, err)
+      call check(error, spec%from_libxc .and. spec%n_components == 1 .and. &
+                 spec%component(1)%name == "hyb_mgga_xc_r2scan0", "r2scan0 is a rename")
+      if (allocated(error)) return
+      call xc_spec_from_name("r2scanh", spec, err)
+      call check(error, spec%component(1)%name == "hyb_mgga_xc_r2scanh", "r2scanh is a rename")
+      if (allocated(error)) return
+      call xc_spec_from_name("r2scan50", spec, err)
+      call check(error, spec%component(1)%name == "hyb_mgga_xc_r2scan50", "r2scan50 is a rename")
+      if (allocated(error)) return
+      call check(error,.not. spec%needs_exact_exchange(), &
+                 "a rename must leave its fraction to libxc")
+   end subroutine test_scan_family
+
+   subroutine test_halves_refused(error)
+      !! A libxc name carrying only exchange or only correlation is refused
+      !!
+      !! Both halves initialise and evaluate perfectly well in libxc, so nothing
+      !! downstream can catch this -- the calculation is correct, it is just not
+      !! the functional anyone asked for. Refusing at the name is the only place
+      !! it can be caught.
+      type(error_type), allocatable, intent(out) :: error
+      type(xc_spec_t) :: spec
+      type(error_t) :: err
+
+      call xc_spec_from_name("mgga_x_r2scan", spec, err)
+      call check(error, err%has_error(), "exchange alone must be refused")
+      if (allocated(error)) return
+
+      call err%clear()
+      call xc_spec_from_name("mgga_c_r2scan", spec, err)
+      call check(error, err%has_error(), "correlation alone must be refused")
+      if (allocated(error)) return
+
+      call err%clear()
+      call xc_spec_from_name("gga_x_pbe", spec, err)
+      call check(error, err%has_error(), "a GGA exchange half must be refused too")
+      if (allocated(error)) return
+
+      call err%clear()
+      call xc_spec_from_name("lda_x", spec, err)
+      call check(error, err%has_error(), "the role can be the last segment")
+      if (allocated(error)) return
+
+      ! Kinetic energy functionals are not exchange-correlation ones at all.
+      call err%clear()
+      call xc_spec_from_name("gga_k_tfvw", spec, err)
+      call check(error, err%has_error(), "a kinetic functional is not an xc one")
+      if (allocated(error)) return
+
+      ! And the complement, so this cannot pass by refusing everything: a whole
+      ! functional still goes through, and so does a name following no libxc
+      ! convention, which stays libxc's to reject in its own words.
+      call err%clear()
+      call xc_spec_from_name("hyb_mgga_xc_r2scan0", spec, err)
+      call check(error,.not. err%has_error(), "a combined name must pass through")
+      if (allocated(error)) return
+
+      call err%clear()
+      call xc_spec_from_name("not_a_functional", spec, err)
+      call check(error,.not. err%has_error(), &
+                 "an unrecognisable name is libxc's to reject, not this module's")
+   end subroutine test_halves_refused
 
    subroutine test_empty(error)
       !! No functional named is an error, not a default

--- a/tools/cpu_validation/gen_cpu_validation.py
+++ b/tools/cpu_validation/gen_cpu_validation.py
@@ -450,6 +450,16 @@ DFT_CASES = [
     ("water", "cc-pvdz", "pbe0", 3),
     ("water", "cc-pvdz", "tpss", 3),
     ("water", "cc-pvdz", "m06-l", 3),
+    # The SCAN family, for the two things in it nothing above reaches. r2SCAN is
+    # a semilocal pair like TPSS, but was unreachable by name until libxc's two
+    # halves were paired here -- and asking for one half alone still converges,
+    # so a case that runs the pair is what says the pairing survived. SCAN0 is
+    # the rarer shape: a composition whose *exchange component* carries the
+    # hybrid fraction, which nothing else in this table does. Reading that
+    # fraction only for functionals libxc carries whole left it 2.27 Hartree low,
+    # converged and unflagged.
+    ("water", "cc-pvdz", "r2scan", 3),
+    ("water", "cc-pvdz", "scan0", 3),
     ("ch4", "cc-pvdz", "pbe", 3),
     # Range-separated hybrids, which reach their exchange by a path nothing else
     # uses: a second, erf-attenuated quartet loop. Losing it is not a small

--- a/validation/check_dft.f90
+++ b/validation/check_dft.f90
@@ -223,7 +223,11 @@ contains
          return
       end if
 
-      call xc_context_create(mol, functional, xc, err, level=level)
+      ! `allow_half` because the ladder above starts at `lda_x` and `gga_x_pbe`
+      ! on purpose: one rung's kernel with no correlation beside it, so a broken
+      ! exchange term cannot be masked by a working correlation one. A deck asking
+      ! for half a functional is refused; asking here is deliberate.
+      call xc_context_create(mol, functional, xc, err, level=level, allow_half=.true.)
       if (err%has_error()) then
          write (*, "(A,A,A,A)") "[dft] ", functional, " context failed: ", err%get_message()
          failures = failures + 1

--- a/validation/inputs/cpu/mqc/dft/cpu_water_cc-pvdz_r2scan.json
+++ b/validation/inputs/cpu/mqc/dft/cpu_water_cc-pvdz_r2scan.json
@@ -1,0 +1,33 @@
+{
+    "schema": {
+        "name": "mqc-frag",
+        "version": "1.0"
+    },
+    "molecules": [
+        {
+            "xyz": "../../../sample_inputs/w1.xyz",
+            "molecular_charge": 0,
+            "molecular_multiplicity": 1
+        }
+    ],
+    "model": {
+        "method": "dft",
+        "basis": "cc-pvdz",
+        "functional": "r2scan"
+    },
+    "keywords": {
+        "scf": {
+            "maxiter": 100,
+            "tolerance": 1e-12
+        },
+        "dft": {
+            "grid_level": 3
+        }
+    },
+    "system": {
+        "logger": {
+            "level": "Verbose"
+        }
+    },
+    "driver": "Energy"
+}

--- a/validation/inputs/cpu/mqc/dft/cpu_water_cc-pvdz_scan0.json
+++ b/validation/inputs/cpu/mqc/dft/cpu_water_cc-pvdz_scan0.json
@@ -1,0 +1,33 @@
+{
+    "schema": {
+        "name": "mqc-frag",
+        "version": "1.0"
+    },
+    "molecules": [
+        {
+            "xyz": "../../../sample_inputs/w1.xyz",
+            "molecular_charge": 0,
+            "molecular_multiplicity": 1
+        }
+    ],
+    "model": {
+        "method": "dft",
+        "basis": "cc-pvdz",
+        "functional": "scan0"
+    },
+    "keywords": {
+        "scf": {
+            "maxiter": 100,
+            "tolerance": 1e-12
+        },
+        "dft": {
+            "grid_level": 3
+        }
+    },
+    "system": {
+        "logger": {
+            "level": "Verbose"
+        }
+    },
+    "driver": "Energy"
+}

--- a/validation/validation_tests_cpu.json
+++ b/validation/validation_tests_cpu.json
@@ -281,7 +281,7 @@
         {
             "name": "RHF SiH4 6-31g (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_sih4_6-31g.json",
-            "expected_energy": -291.173723638595,
+            "expected_energy": -291.173723638596,
             "type": "unfragmented"
         },
         {
@@ -383,13 +383,13 @@
         {
             "name": "RHF SiH4 cc-pvdz (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_sih4_cc-pvdz.json",
-            "expected_energy": -291.242848599776,
+            "expected_energy": -291.242848599779,
             "type": "unfragmented"
         },
         {
             "name": "RHF PH3 cc-pvdz (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_ph3_cc-pvdz.json",
-            "expected_energy": -342.470428497942,
+            "expected_energy": -342.470428497941,
             "type": "unfragmented"
         },
         {
@@ -503,7 +503,7 @@
         {
             "name": "RHF H2S aug-cc-pvdz (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_h2s_aug-cc-pvdz.json",
-            "expected_energy": -398.698035963355,
+            "expected_energy": -398.698035963354,
             "type": "unfragmented"
         },
         {
@@ -551,7 +551,7 @@
         {
             "name": "RHF SiH4 def2-svp (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_sih4_def2-svp.json",
-            "expected_energy": -291.15392386055,
+            "expected_energy": -291.153923860553,
             "type": "unfragmented"
         },
         {
@@ -647,25 +647,25 @@
         {
             "name": "RHF AlH3 def2-tzvp (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_alh3_def2-tzvp.json",
-            "expected_energy": -243.641284905954,
+            "expected_energy": -243.641284905955,
             "type": "unfragmented"
         },
         {
             "name": "RHF SiH4 def2-tzvp (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_sih4_def2-tzvp.json",
-            "expected_energy": -291.257893577061,
+            "expected_energy": -291.25789357706,
             "type": "unfragmented"
         },
         {
             "name": "RHF PH3 def2-tzvp (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_ph3_def2-tzvp.json",
-            "expected_energy": -342.483090810071,
+            "expected_energy": -342.48309081007,
             "type": "unfragmented"
         },
         {
             "name": "RHF H2S def2-tzvp (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_h2s_def2-tzvp.json",
-            "expected_energy": -398.706600110124,
+            "expected_energy": -398.706600110123,
             "type": "unfragmented"
         },
         {
@@ -857,7 +857,7 @@
         {
             "name": "RHF SiH4 6-31g** (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_sih4_6-31g_st__st_.json",
-            "expected_energy": -291.230819820062,
+            "expected_energy": -291.230819820065,
             "type": "unfragmented"
         },
         {
@@ -869,7 +869,7 @@
         {
             "name": "RHF H2S 6-31g** (CPU)",
             "input": "inputs/cpu/mqc/rhf/cpu_h2s_6-31g_st__st_.json",
-            "expected_energy": -398.674799073107,
+            "expected_energy": -398.674799073108,
             "type": "unfragmented"
         },
         {
@@ -894,7 +894,7 @@
         {
             "name": "RHF HI def2-svp with def2-ecp (CPU)",
             "input": "inputs/cpu/mqc/ecp/cpu_hi_def2-svp_ecp.json",
-            "expected_energy": -297.231531663359,
+            "expected_energy": -297.23153166336,
             "type": "unfragmented",
             "requires": "ecp"
         },
@@ -908,7 +908,7 @@
         {
             "name": "RHF I2 def2-svp with def2-ecp (CPU)",
             "input": "inputs/cpu/mqc/ecp/cpu_i2_def2-svp_ecp.json",
-            "expected_energy": -593.316185118824,
+            "expected_energy": -593.316185118822,
             "type": "unfragmented",
             "requires": "ecp"
         },
@@ -957,7 +957,7 @@
         {
             "name": "RHF HgCl2 def2-svp with def2-ecp (CPU)",
             "input": "inputs/cpu/mqc/ecp/cpu_hgcl2_def2-svp_ecp.json",
-            "expected_energy": -1071.288919266049,
+            "expected_energy": -1071.288919266051,
             "type": "unfragmented",
             "requires": "ecp"
         },
@@ -1290,12 +1290,12 @@
             "expected_energy": -76.027511701606,
             "expected_gradient": [
                 [
-                    -0.0,
+                    0.0,
                     2.31e-10,
                     0.01008181498
                 ],
                 [
-                    -0.0,
+                    0.0,
                     0.015838424428,
                     -0.005040907405
                 ],
@@ -1559,12 +1559,12 @@
                     -0.013156164002
                 ],
                 [
-                    -0.0,
+                    0.0,
                     0.001753795523,
                     0.006578082092
                 ],
                 [
-                    -0.0,
+                    0.0,
                     -0.001753795752,
                     0.006578081922
                 ]
@@ -1586,7 +1586,7 @@
                     -0.01580269768
                 ],
                 [
-                    -0.0,
+                    0.0,
                     -0.000836411319,
                     0.007901348925
                 ],
@@ -3635,18 +3635,18 @@
             "expected_gradient": [
                 [
                     0.0,
-                    2.91e-10,
-                    -0.100057160628
+                    3.11e-10,
+                    -0.100057160622
                 ],
                 [
                     0.0,
-                    -0.031606308594,
-                    0.05002858043
+                    -0.031606308603,
+                    0.050028580432
                 ],
                 [
                     0.0,
-                    0.031606308283,
-                    0.050028580193
+                    0.031606308295,
+                    0.050028580186
                 ]
             ],
             "gradient_tolerance": 1e-07,
@@ -3659,24 +3659,24 @@
             "expected_energy": -56.3395970169,
             "expected_gradient": [
                 [
-                    -6.3e-10,
-                    -2.44e-10,
-                    0.008288657366
+                    -4e-11,
+                    -2.9e-11,
+                    0.008288657367
                 ],
                 [
-                    -0.002408829873,
-                    1e-12,
-                    -0.002762885865
+                    -0.002408829768,
+                    -2.38e-10,
+                    -0.002762885685
                 ],
                 [
-                    0.001204414996,
-                    -0.002086107922,
-                    -0.002762885857
+                    0.001204414513,
+                    -0.00208610766,
+                    -0.002762886289
                 ],
                 [
-                    0.001204415083,
-                    0.002086108082,
-                    -0.002762885822
+                    0.001204414784,
+                    0.00208610774,
+                    -0.002762885861
                 ]
             ],
             "gradient_tolerance": 1e-07,
@@ -3690,18 +3690,18 @@
             "expected_gradient": [
                 [
                     0.0,
-                    2.95e-10,
-                    -0.100058570613
+                    3.15e-10,
+                    -0.100058570607
                 ],
                 [
                     0.0,
-                    -0.03160630009,
-                    0.050029285427
+                    -0.031606300099,
+                    0.050029285425
                 ],
                 [
                     0.0,
-                    0.031606299774,
-                    0.050029285185
+                    0.031606299786,
+                    0.050029285179
                 ]
             ],
             "gradient_tolerance": 1e-07,
@@ -3714,19 +3714,19 @@
             "expected_energy": -75.21055452719,
             "expected_gradient": [
                 [
-                    -5e-12,
-                    3e-10,
-                    -0.103869051924
+                    1.9e-10,
+                    2.96e-10,
+                    -0.103869051904
                 ],
                 [
-                    1e-11,
-                    -0.03625317651,
-                    0.051934526089
+                    -4e-12,
+                    -0.036253176502,
+                    0.051934526081
                 ],
                 [
-                    7e-12,
-                    0.036253176194,
-                    0.051934525843
+                    -1.94e-10,
+                    0.03625317621,
+                    0.051934525859
                 ]
             ],
             "gradient_tolerance": 1e-07,
@@ -3751,7 +3751,7 @@
                 ],
                 [
                     5e-12,
-                    0.036278085923,
+                    0.036278085926,
                     0.051930795066
                 ]
             ],
@@ -3778,7 +3778,7 @@
                 [
                     1.1e-11,
                     -0.00316726912,
-                    0.006368342484
+                    0.006368342371
                 ]
             ],
             "gradient_tolerance": 1e-07,
@@ -3808,7 +3808,7 @@
                 ],
                 [
                     0.014303650105,
-                    0.024773605382,
+                    0.02477360538,
                     -0.016217303266
                 ]
             ],
@@ -3981,13 +3981,13 @@
         {
             "name": "CCSD H2O cc-pvdz frozen 1 (CPU)",
             "input": "inputs/cpu/mqc/ccsd/cpu_water_cc-pvdz_ccsd_f1.json",
-            "expected_energy": -76.237533859112,
+            "expected_energy": -76.237533859115,
             "type": "unfragmented"
         },
         {
             "name": "CCSD(T) H2O cc-pvdz frozen 1 (CPU)",
             "input": "inputs/cpu/mqc/ccsd-t/cpu_water_cc-pvdz_ccsdt_f1.json",
-            "expected_energy": -76.240549582968,
+            "expected_energy": -76.24054958297,
             "type": "unfragmented"
         },
         {
@@ -4059,6 +4059,20 @@
             "name": "KS M06-L H2O cc-pvdz grid 3 (CPU)",
             "input": "inputs/cpu/mqc/dft/cpu_water_cc-pvdz_m06l.json",
             "expected_energy": -76.413432743074,
+            "type": "unfragmented",
+            "requires": "libxc"
+        },
+        {
+            "name": "KS R2SCAN H2O cc-pvdz grid 3 (CPU)",
+            "input": "inputs/cpu/mqc/dft/cpu_water_cc-pvdz_r2scan.json",
+            "expected_energy": -76.380943873818,
+            "type": "unfragmented",
+            "requires": "libxc"
+        },
+        {
+            "name": "KS SCAN0 H2O cc-pvdz grid 3 (CPU)",
+            "input": "inputs/cpu/mqc/dft/cpu_water_cc-pvdz_scan0.json",
+            "expected_energy": -76.377749449546,
             "type": "unfragmented",
             "requires": "libxc"
         },


### PR DESCRIPTION
make r2scan accessible from the top level functional keyword