### PR TITLE
linear dependency warning once in opt

### DIFF
--- a/src/methods/scf/mqc_scf_common.f90
+++ b/src/methods/scf/mqc_scf_common.f90
@@ -57,7 +57,14 @@ module mqc_scf_common
       real(dp) :: worst_kept = 0.0_dp     !! smallest surviving eigenvalue seen
    end type lindep_tally_t
 
-   logical, save :: collecting = .false.
+   integer, save :: collect_depth = 0
+      !! Nesting depth of open collect windows, not a flag: a fragmented
+      !! calculation opens one per `run_calculation`, and a geometry
+      !! optimization opens one around every step -- so optimizing a fragmented
+      !! system nests them. A plain logical let the inner `end` close the outer
+      !! window at the first step, after which every later SCF reported
+      !! individually and the outer tally came back empty. The outermost window
+      !! owns the tally; inner ones fold into it and report nothing of their own.
       !! Set while a caller is running many SCFs and wants one report, not
       !! many. Module state because the report is raised deep inside
       !! `run_czt_rhf`, which is reached from the fragment bridge, SAPT,
@@ -75,14 +82,28 @@ contains
 
    subroutine lindep_collect_begin()
       !! Start folding linear-dependence reports into a tally
-      collecting = .true.
-      tally = lindep_tally_t()
+      !!
+      !! Nests: only the outermost window resets the tally, so an inner one
+      !! cannot discard what an outer one has already gathered.
+      collect_depth = collect_depth + 1
+      if (collect_depth == 1) tally = lindep_tally_t()
    end subroutine lindep_collect_begin
 
    subroutine lindep_collect_end(result)
-      !! Stop collecting and hand back what was seen
+      !! Close one window and hand back what it saw
+      !!
+      !! An inner window hands back nothing -- `report_linear_dependence_tally`
+      !! says nothing for an empty tally -- and leaves the accumulation running
+      !! for the window outside it, which is the one that reports.
       type(lindep_tally_t), intent(out) :: result
-      collecting = .false.
+
+      if (collect_depth > 1) then
+         collect_depth = collect_depth - 1
+         result = lindep_tally_t()
+         return
+      end if
+
+      collect_depth = 0
       result = tally
       tally = lindep_tally_t()
    end subroutine lindep_collect_end
@@ -183,7 +204,7 @@ contains
       ! Collecting: fold this SCF into the tally and say nothing. One
       ! fragmented run is thousands of SCFs against eight to twelve lines
       ! apiece. See `report_linear_dependence_tally`.
-      if (collecting) then
+      if (collect_depth > 0) then
          if (n_dropped > 0) then
             tally%n_reports = tally%n_reports + 1
             tally%n_dropped_scf = tally%n_dropped_scf + 1

--- a/src/optimization/mqc_geometry_optimizer.f90
+++ b/src/optimization/mqc_geometry_optimizer.f90
@@ -35,6 +35,8 @@ module mqc_geometry_optimizer
    use mqc_optimization_output, only: optimization_record_t, write_optimization_json, &
                                       write_trajectory_xyz
    use mqc_frag_utils, only: generate_mbe_term_list
+   use mqc_scf_common, only: lindep_tally_t, lindep_collect_begin, lindep_collect_end, &
+                             report_linear_dependence_tally
    implicit none
 
    real(dp), parameter :: ZERO_FREQ_CM = 10.0_dp
@@ -122,6 +124,7 @@ contains
       logical :: converged
       integer :: probe_status
       real(dp) :: final_energy
+      type(lindep_tally_t) :: lindep
       real(dp), allocatable :: coords(:, :)
       real(dp), allocatable :: endpoint_geom(:, :)
       integer, allocatable :: atomic_numbers(:)
@@ -227,6 +230,16 @@ contains
          ! leaves `active` set for the rest of the process.
          if (error%has_error()) return
 
+         ! Fold every step's linear-dependence report into one, the way a
+         ! fragmented run folds its fragments'. An optimization is one SCF per
+         ! step against eight lines apiece, and the basis is the same basis at
+         ! every step -- so the per-SCF report says the same thing tens of
+         ! times and buries the step table it is printed into.
+         !
+         ! The window opens here rather than before the probe gradient above,
+         ! because the returns between the two would leave it open for the rest
+         ! of the process and silence every later SCF.
+         call lindep_collect_begin()
          if (algorithm_needs_hessian(config%optimization%algorithm) .and. &
              is_restricted_hf(config)) then
             call dlfind_optimize(config%optimization, n_atoms, atomic_numbers, residues, &
@@ -238,7 +251,13 @@ contains
                                  coords, evaluate_energy_gradient, record_step, &
                                  final_energy, error, endpoint=endpoint_geom)
          end if
+         call lindep_collect_end(lindep)
          call logger%info("  "//repeat("-", 69))
+         ! After the table's closing rule, so the summary sits under the steps
+         ! it describes rather than interrupting them. The final single point
+         ! below is outside the window on purpose: it is one SCF on the
+         ! geometry actually kept, and worth its own full report.
+         call report_linear_dependence_tally(lindep, "optimization steps")
 
          ! Stop the workers whether or not that succeeded: a rank 0 that
          ! returned an error without sending this would leave N-1 ranks blocked

--- a/test/test_mqc_scf_common.f90
+++ b/test/test_mqc_scf_common.f90
@@ -25,6 +25,7 @@ contains
       type(unittest_type), allocatable, intent(out) :: testsuite(:)
 
       testsuite = [ &
+                  new_unittest("scf_lindep_tally_nests", test_tally_nests), &
                   new_unittest("scf_orthogonalizer_diagonalizes_the_overlap", test_orth_identity), &
                   new_unittest("scf_orthogonalizer_keeps_every_mode_when_well_conditioned", test_orth_full_rank), &
                   new_unittest("scf_orthogonalizer_drops_a_null_mode", test_orth_drops_null), &
@@ -44,6 +45,54 @@ contains
                   new_unittest("scf_lindep_tally_resets_between_windows", test_tally_resets) &
                   ]
    end subroutine collect_mqc_scf_common
+
+   subroutine test_tally_nests(error)
+      !! An inner window folds into the outer one instead of closing it
+      !!
+      !! Optimizing a fragmented system opens both: the optimizer wraps every
+      !! step, and each step's `run_calculation` wraps its fragments. When the
+      !! gate was a plain logical the inner `end` closed the outer window at
+      !! the first step, so every later SCF reported individually and the
+      !! optimizer's tally came back empty -- the summary silently covered one
+      !! step out of fifty.
+      !!
+      !! The outermost window owns the tally. An inner one reports nothing of
+      !! its own, which is what keeps a fragmented step from printing a
+      !! per-step summary inside an optimization that is about to print one.
+      type(error_type), allocatable, intent(out) :: error
+      type(lindep_tally_t) :: inner, outer
+
+      call lindep_collect_begin()                                  ! optimizer
+      call report_linear_dependence(10, 10, 1.0e-6_dp, 1.0e-6_dp, .false.)
+
+      call lindep_collect_begin()                                  ! one step's fragments
+      call report_linear_dependence(10, 10, 3.0e-7_dp, 3.0e-7_dp, .false.)
+      call lindep_collect_end(inner)
+
+      ! The inner window reports nothing: an empty tally, which
+      ! `report_linear_dependence_tally` prints nothing for.
+      call check(error, inner%n_reports, 0)
+      if (allocated(error)) return
+
+      ! Still collecting, so this is folded in rather than printed.
+      call report_linear_dependence(10, 10, 2.0e-6_dp, 2.0e-6_dp, .false.)
+      call lindep_collect_end(outer)
+
+      ! All three SCFs, including the one inside the inner window.
+      call check(error, outer%n_reports, 3)
+      if (allocated(error)) return
+      call check(error, outer%n_near_scf, 3)
+      if (allocated(error)) return
+      ! The worst is the inner window's, which a closed outer window would
+      ! have lost along with everything after it.
+      call check(error, outer%worst_kept, 3.0e-7_dp, thr=1.0e-20_dp)
+      if (allocated(error)) return
+
+      ! And the window is properly shut: a report now goes straight out.
+      call lindep_collect_begin()
+      call lindep_collect_end(inner)
+      call check(error, inner%n_reports, 0)
+   end subroutine test_tally_nests
 
    subroutine test_tally_drops(error)
       !! Many SCFs that each lose functions become one tally, not many reports


### PR DESCRIPTION
The linera depdennyc warning was pringint once per SCF even in logger info which made the printout very ugly