### PR TITLE
Build against libfint main, ahead of its next tag

### DIFF
--- a/cmake/MqcOptions.cmake
+++ b/cmake/MqcOptions.cmake
@@ -115,7 +115,7 @@ set(MQC_LIBFINT_REPOSITORY
     "https://github.com/JorgeG94/libfint.git"
     CACHE STRING "Where to fetch libfint from")
 set(MQC_LIBFINT_TAG
-    "v0.3.0"
+    "v0.3.1"
     CACHE STRING "libfint revision to build against")
 
 set(MQC_CREST_REPOSITORY


### PR DESCRIPTION
Pins f8f260f, libfint's main after PR #14: the SP env-extent fix in the Fortran and C ABI, a grids env under-count, an L-shell check pass on the wrappers and a bounds-checked CI lane. Nothing the release build reads changed; this is so CI runs the whole suite against it before the tag is cut. A full commit hash rather than a branch name, so the build is the same tomorrow, and so a shallow fetch resolves it.